### PR TITLE
feat(UI): plugin will automatically send getSetting to update UI

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/socketHandlers.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/socketHandlers.js
@@ -26,6 +26,8 @@ import {
 } from "./graph.js";
 import { updateCardPlayVisibility } from "./hud.js";
 import { scheduleRecompute } from "./scheduler.js";
+import { getCounterPathForCommand } from "./settings.js";
+
 
 function getModData(data) {
     return getModDataFromPayload(data, {
@@ -239,6 +241,8 @@ export function setupSocketListener() {
         const key = `${nextBeatmapIdentity}|${nextModSignature}`;
         resetPauseRuntime(true);
         state.lastBeatmapKey = key;
+
+        socket.sendCommand("getSettings", getCounterPathForCommand());
 
         scheduleRecompute("beatmap/mod changed", true);
     });


### PR DESCRIPTION
Related to #17 

Settings and UI shown in-game

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5c4299d5-868f-4770-9cfe-30fe645af76d" />

<img width="1429" height="894" alt="image" src="https://github.com/user-attachments/assets/1168d3b8-639b-418a-9892-eb94c79fff3e" />

Update the setting:

<img width="1413" height="905" alt="image" src="https://github.com/user-attachments/assets/c5fedde1-8f06-4641-b4bf-144b92cd9ac9" />

in-game:

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/04169036-1055-4b3e-ada6-191c2118a3e6" />

after switched select beatmap it will automatiaclly get the new setting to update UI

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a375c9e1-57a6-4b48-9bc9-1379f14b861a" />
