### PR TITLE
feat(HUD): added HUD will hide on main menu

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/hud.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/hud.js
@@ -230,7 +230,8 @@ export function updateCardPlayVisibility() {
         return;
     }
 
-    const shouldHide = state.hideCardDuringPlay && state.clientStateName === "play";
+    const shouldHide = (state.hideCardDuringPlay && state.clientStateName === "play") 
+                       || (state.clientStateName === "menu");
     mainCardEl.classList.toggle("card-hidden-by-play", shouldHide);
     mainCardEl.setAttribute("aria-hidden", shouldHide ? "true" : "false");
 }


### PR DESCRIPTION
Added analyzer's hud will hide on the main menu

Test on osu!stable:

https://github.com/user-attachments/assets/3b67b3f7-1977-4189-8b52-3cc1c37cf641

Test on osu!lazer

https://github.com/user-attachments/assets/8bb14a14-0918-4939-ba5e-451fee97d15d

do I need to add an option to make it optional like hideCardDuringPlay?
