### PR TITLE
feat(LN Rework): aggressive LN Rework with time window algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /backup
 AGENTS.md
 .omo/
+.opencode

--- a/ManiaMapAnalyser by Leo_Black/config.js
+++ b/ManiaMapAnalyser by Leo_Black/config.js
@@ -6,7 +6,7 @@ export const APP_CONFIG = {
         contentBar: ["None", "Auto", "Pattern", "Etterna", "Graph", "Full"],
         srText: ["Auto", "ReworkSR", "MSD", "Pattern", "InterludeSR"],
         diffText: ["None", "Graph", "Difficulty", "MSD", "Pattern", "ReworkSR", "InterludeSR"],
-        estimatorAlgorithm: ["Azusa", "Roxy", "Mixed", "Sunny", "Daniel", "Companella", "SunnyWindow"],
+        estimatorAlgorithm: ["Azusa", "Roxy", "Mixed", "Sunny", "Daniel", "Companella", "Sunnywindow"],
         etternaVersion: ["0.68.0-Unofficial", "0.70.0", "0.72.0", "0.72.3", "0.74.0"],
         companellaEtternaVersion: ["0.68.0-Unofficial", "0.70.0", "0.72.0", "0.72.3", "0.74.0"],
         cardOpacity: ["100%", "95%", "90%", "80%", "70%"],

--- a/ManiaMapAnalyser by Leo_Black/config.js
+++ b/ManiaMapAnalyser by Leo_Black/config.js
@@ -6,7 +6,7 @@ export const APP_CONFIG = {
         contentBar: ["None", "Auto", "Pattern", "Etterna", "Graph", "Full"],
         srText: ["Auto", "ReworkSR", "MSD", "Pattern", "InterludeSR"],
         diffText: ["None", "Graph", "Difficulty", "MSD", "Pattern", "ReworkSR", "InterludeSR"],
-        estimatorAlgorithm: ["Azusa", "Roxy", "Mixed", "Sunny", "Daniel", "Companella"],
+        estimatorAlgorithm: ["Azusa", "Roxy", "Mixed", "Sunny", "Daniel", "Companella", "SunnyWindow"],
         etternaVersion: ["0.68.0-Unofficial", "0.70.0", "0.72.0", "0.72.3", "0.74.0"],
         companellaEtternaVersion: ["0.68.0-Unofficial", "0.70.0", "0.72.0", "0.72.3", "0.74.0"],
         cardOpacity: ["100%", "95%", "90%", "80%", "70%"],

--- a/ManiaMapAnalyser by Leo_Black/config.js
+++ b/ManiaMapAnalyser by Leo_Black/config.js
@@ -6,7 +6,7 @@ export const APP_CONFIG = {
         contentBar: ["None", "Auto", "Pattern", "Etterna", "Graph", "Full"],
         srText: ["Auto", "ReworkSR", "MSD", "Pattern", "InterludeSR"],
         diffText: ["None", "Graph", "Difficulty", "MSD", "Pattern", "ReworkSR", "InterludeSR"],
-        estimatorAlgorithm: ["Azusa", "Roxy", "Mixed", "Sunny", "Daniel", "Companella", "Sunnywindow"],
+        estimatorAlgorithm: ["Azusa", "Roxy", "Mixed", "Sunny", "Daniel", "Companella"],
         etternaVersion: ["0.68.0-Unofficial", "0.70.0", "0.72.0", "0.72.3", "0.74.0"],
         companellaEtternaVersion: ["0.68.0-Unofficial", "0.70.0", "0.72.0", "0.72.3", "0.74.0"],
         cardOpacity: ["100%", "95%", "90%", "80%", "70%"],
@@ -105,6 +105,7 @@ export const APP_CONFIG = {
         srText: "ReworkSR",
         diffText: "Difficulty",
         debugUseAmount: false,
+        enableLNRework: false,
     },
 
     mods: {

--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -1,4 +1,5 @@
 import { runSunnyEstimatorFromText } from "../estimator/sunnyEstimator.js";
+//import { runSunnyWindowEstimatorFromText } from "../estimator/sunnyWindowEstimator.js"
 import { runDanielEstimatorFromText } from "../estimator/danielEstimator.js";
 import { runAzusaEstimatorFromText } from "../estimator/azusaEstimator.js";
 import { runRoxyEstimatorFromText } from "../estimator/roxyEstimator.js";
@@ -6,7 +7,6 @@ import {
     applyCompanellaToMixedResult,
     runMixedEstimatorFromText,
 } from "../estimator/mixedEstimator.js";
-import { runSunnyWindowEstimatorFromText } from "../estimator/sunnyWindowEstimator.js"
 import { classifyCompanellaDifficulty } from "../estimator/companellaEstimator.js";
 import { calculateInterludeStar } from "../interlude/index.js";
 import { analyzePatternFromText } from "../patterns/service.js";
@@ -243,7 +243,6 @@ export function resetReworkDisplay() {
 }
 
 export async function fetchBeatmapFile(reason) {
-    console.warn("11111")
     const requestSeq = (state.analysisRequestSeq || 0) + 1;
     state.analysisRequestSeq = requestSeq;
     const isStaleRequest = () => requestSeq !== state.analysisRequestSeq;
@@ -429,7 +428,7 @@ export async function fetchBeatmapFile(reason) {
                 nextNumericDifficulty = selectedRework.numericDifficulty;
                 nextNumericDifficultyHint = selectedRework.numericDifficultyHint;
                 pendingMixedCompanellaContext = selectedRework.mixedCompanellaPlan || null;
-            } else if (estimatorAlgorithm === "SunnyWindow") {
+            } else if (estimatorAlgorithm === "Sunnywindow") {
                 selectedRework = runSunnyWindowEstimatorFromText(rawText, estimatorOptions);
                 nextEstDiff = selectedRework.estDiff;
                 nextNumericDifficulty = selectedRework.numericDifficulty;

--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -6,6 +6,7 @@ import {
     applyCompanellaToMixedResult,
     runMixedEstimatorFromText,
 } from "../estimator/mixedEstimator.js";
+import { runSunnyWindowEstimatorFromText } from "../estimator/sunnyWindowEstimator.js"
 import { classifyCompanellaDifficulty } from "../estimator/companellaEstimator.js";
 import { calculateInterludeStar } from "../interlude/index.js";
 import { analyzePatternFromText } from "../patterns/service.js";
@@ -242,6 +243,7 @@ export function resetReworkDisplay() {
 }
 
 export async function fetchBeatmapFile(reason) {
+    console.warn("11111")
     const requestSeq = (state.analysisRequestSeq || 0) + 1;
     state.analysisRequestSeq = requestSeq;
     const isStaleRequest = () => requestSeq !== state.analysisRequestSeq;
@@ -427,6 +429,11 @@ export async function fetchBeatmapFile(reason) {
                 nextNumericDifficulty = selectedRework.numericDifficulty;
                 nextNumericDifficultyHint = selectedRework.numericDifficultyHint;
                 pendingMixedCompanellaContext = selectedRework.mixedCompanellaPlan || null;
+            } else if (estimatorAlgorithm === "SunnyWindow") {
+                selectedRework = runSunnyWindowEstimatorFromText(rawText, estimatorOptions);
+                nextEstDiff = selectedRework.estDiff;
+                nextNumericDifficulty = selectedRework.numericDifficulty;
+                nextNumericDifficultyHint = selectedRework.numericDifficultyHint;
             } else {
                 const wp = runInWorker(rawText, { ...estimatorOptions, estimatorAlgorithm: "Sunny" });
                 selectedRework = wp ? await wp : runSunnyEstimatorFromText(rawText, estimatorOptions);

--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -1,5 +1,5 @@
 import { runSunnyEstimatorFromText } from "../estimator/sunnyEstimator.js";
-//import { runSunnyWindowEstimatorFromText } from "../estimator/sunnyWindowEstimator.js"
+import { runSunnyWindowEstimatorFromText } from "../estimator/sunnyWindowEstimator.js"
 import { runDanielEstimatorFromText } from "../estimator/danielEstimator.js";
 import { runAzusaEstimatorFromText } from "../estimator/azusaEstimator.js";
 import { runRoxyEstimatorFromText } from "../estimator/roxyEstimator.js";

--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -1,5 +1,4 @@
 import { runSunnyEstimatorFromText } from "../estimator/sunnyEstimator.js";
-import { runSunnyWindowEstimatorFromText } from "../estimator/sunnyWindowEstimator.js"
 import { runDanielEstimatorFromText } from "../estimator/danielEstimator.js";
 import { runAzusaEstimatorFromText } from "../estimator/azusaEstimator.js";
 import { runRoxyEstimatorFromText } from "../estimator/roxyEstimator.js";
@@ -370,6 +369,7 @@ export async function fetchBeatmapFile(reason) {
                 odFlag: state.odFlag,
                 cvtFlag: state.cvtFlag,
                 withGraph: state.diffText === "Graph" || showsGraph,
+                enableLNRework: state.enableLNRework,
             };
 
             const azusaOptions = {

--- a/ManiaMapAnalyser by Leo_Black/js/app/appContext.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/appContext.js
@@ -75,8 +75,9 @@ export const state = {
     userContentBar: APP_CONFIG.defaults.contentBar,
     userSrText: APP_CONFIG.defaults.srText,
     userDiffText: APP_CONFIG.defaults.diffText,
-    debugUseAmount: APP_CONFIG.defaults.debugUseAmount,
-    useSvDetection: APP_CONFIG.defaults.useSvDetection,
+debugUseAmount: APP_CONFIG.defaults.debugUseAmount,
+useSvDetection: APP_CONFIG.defaults.useSvDetection,
+enableLNRework: APP_CONFIG.defaults.enableLNRework,
     diffText: APP_CONFIG.defaults.diffText,
     estimatorAlgorithm: APP_CONFIG.defaults.estimatorAlgorithm,
     actualEstimatorAlgorithm: APP_CONFIG.defaults.estimatorAlgorithm,
@@ -203,6 +204,7 @@ export const {
     parseCustomBackgroundColorValue,
     parseSvDetectionValue,
     parseWsEndpointValue,
+    parseEnableLNReworkValue,
 } = createSettingsParsers(APP_CONFIG);
 
 export function getActiveContentBar() {

--- a/ManiaMapAnalyser by Leo_Black/js/app/settings.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/settings.js
@@ -30,6 +30,7 @@ import {
     parseCardVisibilityValue,
     parseShowModeTagCapsuleValue,
     parseEnableUpdateCheckValue,
+    parseEnableLNReworkValue,
     parseReverseCardExtendDirectionValue,
     parseUseOsuFontValue,
     parseSrTextValue,
@@ -319,6 +320,13 @@ export function getCounterPathForCommand() {
 export function applyDebugUseAmountSetting(value) {
     const changed = state.debugUseAmount !== value;
     state.debugUseAmount = value;
+    return changed;
+}
+
+export function applyEnableLNReworkSetting(value) {
+    const next = Boolean(value);
+    const changed = state.enableLNRework !== next;
+    state.enableLNRework = next;
     return changed;
 }
 
@@ -672,6 +680,7 @@ export function setupSettingsCommandListener() {
         const contentBarChanged = applyIf("contentBar", applyContentBarSetting, parseContentBarValue(payload));
         const srTextChanged = applyIf("srText", applySrTextSetting, parseSrTextValue(payload));
         const debugChanged = applyIf("debugUseAmount", applyDebugUseAmountSetting, parseDebugUseAmountValue(payload));
+        const lnReworkChanged = applyIf("enableLNRework", applyEnableLNReworkSetting, parseEnableLNReworkValue(payload));
         const diffTextChanged = applyIf("diffText", applyDiffTextSetting, parseDiffTextValue(payload));
         const estimatorChanged = applyIf("estimatorAlgorithm", applyEstimatorAlgorithmSetting, parseEstimatorAlgorithmValue(payload));
         const azusaSunnyReferenceHoChanged = applyIf("azusaSunnyReferenceHo", applyAzusaSunnyReferenceHoSetting, parseAzusaSunnyReferenceHoValue(payload));
@@ -731,11 +740,13 @@ export function setupSettingsCommandListener() {
             || floatingTrianglesChanged
             || coverArtChanged
             || customColorChanged
-            || svChanged;
+            || svChanged
+            || lnReworkChanged;
 
         const recomputeNeeded = contentBarChanged
             || srTextChanged
             || debugChanged
+            || lnReworkChanged
             || diffTextChanged
             || estimatorChanged
             || azusaSunnyReferenceHoChanged
@@ -808,6 +819,7 @@ export async function loadSettings() {
         applyContentBarSetting(parseContentBarValue(source));
         applySrTextSetting(parseSrTextValue(source));
         applyDebugUseAmountSetting(parseDebugUseAmountValue(source));
+        applyEnableLNReworkSetting(parseEnableLNReworkValue(source));
         applyDiffTextSetting(parseDiffTextValue(source));
         applyEstimatorAlgorithmSetting(parseEstimatorAlgorithmValue(source));
         applyAzusaSunnyReferenceHoSetting(parseAzusaSunnyReferenceHoValue(source));

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/azusaEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/azusaEstimator.js
@@ -2,6 +2,9 @@ import { OsuFileParser } from "../parser/osuFileParser.js";
 import { runDanielEstimatorFromText } from "./danielEstimator.js";
 import { runSunnyEstimatorFromText } from "./sunnyEstimator.js";
 import { numericToRcLabel } from "./rcDifficultyFormat.js";
+import { calculate } from "../rework/sunnyAlgorithm.js";
+import { calculateLN } from "../rework/sunnyWindowAlgorithm.js";
+import { DAN_INDEX } from "./intervals/index.js";
 
 const AZUSA_CONFIG = Object.freeze({
     rcLnRatioLimit: 0.18,
@@ -946,10 +949,37 @@ export function runAzusaEstimatorFromText(osuText, options = {}) {
     const outputNumeric = calibrateAzusaOutputNumeric(preOutputNumeric);
     const refCorrection = computeReferenceCorrection(outputNumeric, danielNumericForBlend, sunnyNumeric);
     const finalNumeric = clamp(Number(outputNumeric) + refCorrection, -2, 20);
-    const estDiff = numericToRcLabel(finalNumeric);
+    let estDiff = numericToRcLabel(finalNumeric);
+    const star = Number((3.4 + 0.38 * finalNumeric).toFixed(4));
+
+    if (options.enableLNRework === true) {
+        const lnResult = calculateLN(osuText, speedRate, null, null);
+        let lnStar = 0;
+        if (lnResult !== -3 && Array.isArray(lnResult)) lnStar = lnResult[0];
+        if (lnStar > 0) {
+            const keys = DAN_INDEX[columnCount];
+            if (keys) {
+                const lnTable = keys.LN[Object.keys(keys.LN)[0]] ?? keys.LN.default;
+                let lnDiff = null;
+                for (const [lo, hi, name] of lnTable) {
+                    if (lo <= lnStar && lnStar <= hi) { lnDiff = name; break; }
+                }
+                if (!lnDiff && lnStar < lnTable[0][0]) lnDiff = `< ${lnTable[0][2]}`;
+                if (!lnDiff && lnStar > lnTable[lnTable.length - 1][1]) lnDiff = `> ${lnTable[lnTable.length - 1][1]}`;
+                const gapRatio = star > 0 ? (star - lnStar) / star : 0;
+                // Use Sunny RC star for gap comparison (same scale as LN star)
+                const sunnyRC = calculate(osuText, speedRate, null, null);
+                const sunnyStar = Array.isArray(sunnyRC) ? sunnyRC[0] : star;
+                const gapRatio2 = sunnyStar > 0 ? (sunnyStar - lnStar) / sunnyStar : 0;
+                if (!(gapRatio2 > 0.2 && lnStar < lnTable[0][0]) && lnDiff) {
+                    estDiff = estDiff + " || " + lnDiff;
+                }
+            }
+        }
+    }
 
     const result = {
-        star: Number((3.4 + 0.38 * finalNumeric).toFixed(4)),
+        star,
         lnRatio,
         columnCount,
         estDiff,

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/reworkEstimatorUtils.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/reworkEstimatorUtils.js
@@ -106,6 +106,20 @@ export function estDiff(sr, lnRatio, columnCount) {
     return `${rcDiff} || ${lnDiff}`;
 }
 
+export function estDiff2(sr, srLN, columnCount) {
+    const keys = DAN_INDEX[columnCount];
+    if (!keys) return "Unknown difficulty";
+
+    const rcTable = keys.RC[Object.keys(keys.RC)[0]] ?? keys.RC.default;
+    const rcDiff = intervalLookup(sr, rcTable, "Unknown RC difficulty");
+    if (srLN <= 0) return rcDiff;
+    return rcDiff;
+
+    const lnTable = keys.LN[Object.keys(keys.LN)[0]] ?? keys.LN.default;
+    const lnDiff = intervalLookup(srLN, lnTable, "Unknown LN difficulty");
+    return `${rcDiff} || ${lnDiff}`;
+}
+
 export function normalizeReworkResult(result) {
     if (typeof result === "number") {
         if (result === -1) {

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/reworkEstimatorUtils.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/reworkEstimatorUtils.js
@@ -113,7 +113,6 @@ export function estDiff2(sr, srLN, columnCount) {
     const rcTable = keys.RC[Object.keys(keys.RC)[0]] ?? keys.RC.default;
     const rcDiff = intervalLookup(sr, rcTable, "Unknown RC difficulty");
     if (srLN <= 0) return rcDiff;
-    return rcDiff;
 
     const lnTable = keys.LN[Object.keys(keys.LN)[0]] ?? keys.LN.default;
     const lnDiff = intervalLookup(srLN, lnTable, "Unknown LN difficulty");
@@ -148,7 +147,7 @@ export function normalizeReworkResult(result) {
     }
 
     if (!Number.isFinite(sr) || !Number.isFinite(lnRatio) || !Number.isFinite(columnCount)) {
-        throw new Error("Invalid estimator output");
+        throw new Error("Invalid estimator output" + sr + lnRatio + columnCount);
     }
 
     return {

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/reworkEstimatorUtils.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/reworkEstimatorUtils.js
@@ -114,8 +114,13 @@ export function estDiff2(sr, srLN, columnCount) {
     const rcDiff = intervalLookup(sr, rcTable, "Unknown RC difficulty");
     if (srLN <= 0) return rcDiff;
 
+    // 如果 RC 与 LN 差距大于 20% 且 LN 未达到 LN 5 mid，判定为装饰 LN，不显示
+    const gapRatio = sr > 0 ? (sr - srLN) / sr : 0;
     const lnTable = keys.LN[Object.keys(keys.LN)[0]] ?? keys.LN.default;
     const lnDiff = intervalLookup(srLN, lnTable, "Unknown LN difficulty");
+    if (gapRatio > 0.2 && srLN < lnTable[0][0]) {
+        return rcDiff;
+    }
     return `${rcDiff} || ${lnDiff}`;
 }
 

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/roxyEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/roxyEstimator.js
@@ -4,6 +4,9 @@ import { runDanielEstimatorFromText } from "./danielEstimator.js";
 import { evaluateRoxyMetaModel, ROXY_META_FEATURE_NAMES } from "./roxyMetaModel.generated.js";
 import { numericToRcLabel, rcLabelToNumeric } from "./rcDifficultyFormat.js";
 import { runSunnyEstimatorFromText } from "./sunnyEstimator.js";
+import { calculate } from "../rework/sunnyAlgorithm.js";
+import { calculateLN } from "../rework/sunnyWindowAlgorithm.js";
+import { DAN_INDEX } from "./intervals/index.js";
 
 const ROXY_CONFIG = Object.freeze({
     rcLnRatioLimit: 0.18,
@@ -1503,10 +1506,38 @@ export function runRoxyEstimatorFromText(osuText, options = {}) {
             : 0;
         unguardedNumeric = clamp(unguardedNumeric + azusaHighGapLift, -2, ROXY_NUMERIC_OUTPUT_MAX);
         const finalNumeric = Number(unguardedNumeric.toFixed(2));
-        const estDiff = numericToRoxyRcLabel(finalNumeric);
+        let estDiff = numericToRoxyRcLabel(finalNumeric);
+        const star = Number((3.4 + 0.38 * finalNumeric).toFixed(4));
+
+        // LN Rework: append LN difficulty using shared LN table
+        if (options.enableLNRework === true) {
+            const lnResult = calculateLN(osuText, speedRate, odFlag, null);
+            let lnStar = 0;
+            if (lnResult !== -3 && Array.isArray(lnResult)) lnStar = lnResult[0];
+            if (lnStar > 0) {
+                const keys = DAN_INDEX[columnCount];
+                if (keys) {
+                    const lnTable = keys.LN[Object.keys(keys.LN)[0]] ?? keys.LN.default;
+                    // intervalLookup inline
+                    let lnDiff = null;
+                    for (const [lo, hi, name] of lnTable) {
+                        if (lo <= lnStar && lnStar <= hi) { lnDiff = name; break; }
+                    }
+                    if (!lnDiff && lnStar < lnTable[0][0]) lnDiff = `< ${lnTable[0][2]}`;
+                    if (!lnDiff && lnStar > lnTable[lnTable.length - 1][1]) lnDiff = `> ${lnTable[lnTable.length - 1][2]}`;
+                    // Decorative LN mask: use Sunny RC star for gap comparison (same scale as LN star)
+                    const sunnyRC = calculate(osuText, speedRate, odFlag, null);
+                    const sunnyStar = Array.isArray(sunnyRC) ? sunnyRC[0] : star;
+                    const gapRatio = sunnyStar > 0 ? (sunnyStar - lnStar) / sunnyStar : 0;
+                    if (!(gapRatio > 0.2 && lnStar < lnTable[0][0]) && lnDiff) {
+                        estDiff = estDiff + " || " + lnDiff;
+                    }
+                }
+            }
+        }
 
         return {
-            star: Number((3.4 + 0.38 * finalNumeric).toFixed(4)),
+            star,
             lnRatio,
             columnCount,
             estDiff,

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/sunnyEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/sunnyEstimator.js
@@ -1,14 +1,35 @@
 import { calculate as calculateSunny } from "../rework/sunnyAlgorithm.js";
-import { estDiff, normalizeReworkResult } from "./reworkEstimatorUtils.js";
+import { calculateLN } from "../rework/sunnyWindowAlgorithm.js";
+import { estDiff, estDiff2, normalizeReworkResult, estimateDanielDan } from "./reworkEstimatorUtils.js";
 
 export function runSunnyEstimatorFromText(osuText, options = {}) {
     const speedRate = options.speedRate ?? 1.0;
     const odFlag = options.odFlag ?? null;
     const cvtFlag = options.cvtFlag ?? null;
     const withGraph = options.withGraph === true;
+    const enableLNRework = options.enableLNRework === true;
 
     const rawResult = calculateSunny(osuText, speedRate, odFlag, cvtFlag, { withGraph });
     const parsed = normalizeReworkResult(rawResult);
+
+    // LN Rework: 计算 LN 专属难度
+    let numericDifficulty = null;
+    let numericDifficultyHint = null;
+    if (enableLNRework) {
+        const lnResult = calculateLN(osuText, speedRate, odFlag, cvtFlag);
+        let lnStar = 0;
+        if (lnResult !== -3 && Array.isArray(lnResult)) {
+            lnStar = lnResult[0];
+        }
+        numericDifficulty = estimateDanielDan(parsed.star).numeric;
+        numericDifficultyHint = "sunny-rc-dan";
+        return {
+            ...parsed,
+            estDiff: estDiff2(parsed.star, lnStar, parsed.columnCount),
+            numericDifficulty,
+            numericDifficultyHint,
+        };
+    }
 
     return {
         ...parsed,

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/sunnyWindowEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/sunnyWindowEstimator.js
@@ -1,0 +1,23 @@
+import { calculate as calculateSunny } from "../rework/sunnyAlgorithm.js";
+import { calculateLN } from "../rework/sunnyWindowAlgorithm.js"
+import { estDiff2, normalizeReworkResult } from "./reworkEstimatorUtils.js";
+
+export function runSunnyWindowEstimatorFromText(osuText, options = {}) {
+    const speedRate = options.speedRate ?? 1.0;
+    const odFlag = options.odFlag ?? null;
+    const cvtFlag = options.cvtFlag ?? null;
+    const withGraph = options.withGraph === true;
+
+    const rawResult = calculateSunny(osuText, speedRate, odFlag, cvtFlag, { withGraph });
+    const parsed = normalizeReworkResult(rawResult);
+
+    const rawResultLN = calculateLN(osuText, speedRate, odFlag, cvtFlag, { withGraph });
+    const parsedLN = normalizeReworkResult(rawResultLN);
+
+    return {
+        ...parsed,
+        estDiff: estDiff2(parsed.star, parsedLN.star, parsed.columnCount),
+        numericDifficulty: null,
+        numericDifficultyHint: null,
+    };
+}

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/sunnyWindowEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/sunnyWindowEstimator.js
@@ -12,11 +12,11 @@ export function runSunnyWindowEstimatorFromText(osuText, options = {}) {
     const parsed = normalizeReworkResult(rawResult);
 
     const rawResultLN = calculateLN(osuText, speedRate, odFlag, cvtFlag, { withGraph });
-    const parsedLN = normalizeReworkResult(rawResultLN);
+    const parsedLNStar = rawResultLN === -3 ? 0 : normalizeReworkResult(rawResultLN).star;
 
     return {
         ...parsed,
-        estDiff: estDiff2(parsed.star, parsedLN.star, parsed.columnCount),
+        estDiff: estDiff2(parsed.star, parsedLNStar, parsed.columnCount),
         numericDifficulty: null,
         numericDifficultyHint: null,
     };

--- a/ManiaMapAnalyser by Leo_Black/js/parser/settingsParser.js
+++ b/ManiaMapAnalyser by Leo_Black/js/parser/settingsParser.js
@@ -47,6 +47,7 @@ export function normalizeEstimatorAlgorithmValue(value) {
     if (lowered === "daniel") return "Daniel";
     if (lowered === "companella") return "Companella";
     if (lowered === "campanella") return "Companella";
+    if (lowered === "sunnywindow") return "Sunnywindow";
     return null;
 }
 

--- a/ManiaMapAnalyser by Leo_Black/js/parser/settingsParser.js
+++ b/ManiaMapAnalyser by Leo_Black/js/parser/settingsParser.js
@@ -291,6 +291,11 @@ export function createSettingsParsers(appConfig) {
         return normalizeBooleanSetting(value, appConfig.defaults.debugUseAmount);
     }
 
+    function parseEnableLNReworkValue(settingsPayload) {
+        const value = extractSettingValue(settingsPayload, "enableLNRework");
+        return normalizeBooleanSetting(value, appConfig.defaults.enableLNRework);
+    }
+
     function parseDiffTextValue(settingsPayload) {
         const value = extractSettingValue(settingsPayload, "diffText");
         const normalized = normalizeDiffTextValue(value);
@@ -570,5 +575,6 @@ export function createSettingsParsers(appConfig) {
         parseUseOsuFontValue,
         parseSvDetectionValue,
         parseWsEndpointValue,
+        parseEnableLNReworkValue,
     };
 }

--- a/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
+++ b/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
@@ -1026,6 +1026,7 @@ function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
             currentTime = p.noteStarts[i];
             currentStartIndex = i;
         }
+        if (i < WindowList2[j][0]) continue;
 
         if ((p.noteTypes[i] & 128) !== 0) {
             if (windowStartIndex === -1) windowStartIndex = currentStartIndex;

--- a/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
+++ b/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
@@ -891,7 +891,7 @@ function smoothDForGraph(allCorners, DAll, noteSeq) {
     return Array.from(interpValues(allCorners, uniformTimes, smoothed));
 }
 
-const MIN_WINDOW_LENGTH = 10*1000; // 10s
+const MIN_WINDOW_LENGTH = 30*1000; // 30s
 const MIN_LN_PERCENTAGE = 20; // 20%
 const MIN_LN_DENSITY = MIN_LN_PERCENTAGE * 0.01;
 

--- a/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
+++ b/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
@@ -1,0 +1,1 @@
+import { OsuFileParser } from "../parser/osuFileParser.js";

--- a/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
+++ b/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
@@ -271,6 +271,21 @@ function preprocessFile(osuText, speedRate, odFlag, cvtFlag) {
     const timeScale = speedRate !== 0 ? 1 / speedRate : 1;
 
     const LNParts = getLNParts(osuText, speedRate, odFlag, cvtFlag);
+    if (LNParts.length <= 0) {
+        return {
+            status: "NoLN",
+            x: 0,
+            K: 0,
+            T: 0,
+            noteSeq: [],
+            noteSeqByColumn: [],
+            lnSeq: [],
+            tailSeq: [],
+            lnSeqByColumn: [],
+            lnRatio,
+            columnCount,
+        };
+    }
     const noteSeq = [];
 
     for (let LNPartsIndex = 0; LNPartsIndex < LNParts.length; LNPartsIndex++){
@@ -954,10 +969,11 @@ function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
 
             if (windowStartIndex === -1 && isLNPercentageValid(riceCount, LNCount)) {
                 windowStartIndex = i;
+                windowEndIndex = j;
             }
             else if (windowStartIndex !== -1) {
                 if (isLNPercentageValid(riceCount, LNCount)) windowEndIndex = j;
-                else {
+                else if (windowEndIndex !== -1) {
                     WindowList1.push([windowStartIndex, windowEndIndex]);
                     windowStartIndex = -1;
                     windowEndIndex = -1;
@@ -995,7 +1011,7 @@ function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
             break;
         }
     }
-    windowList1 = null;
+    WindowList1 = null;
 
     // 第三步：剔除米部分，目前剔除了最早的LN
     let WindowList3 = new Array();
@@ -1004,7 +1020,7 @@ function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
     let currentStartIndex = -1; // 等效于与当前note同一时间的最左边的note的index
     currentTime = NaN;
     let windowEndTime = -1e308;
-    let j = 0; // WindowList2的index
+    j = 0; // WindowList2的index
     for (let i = WindowList2[0][0]; i < p.columns.length; i += 1) {
         if (p.noteStarts[i] !== currentTime) {
             currentTime = p.noteStarts[i];
@@ -1030,7 +1046,7 @@ function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
         }
     }
 
-    windowList2 = null;
+    WindowList2 = null;
     return WindowList3;
 }
 
@@ -1052,6 +1068,7 @@ export function calculateLN(osuText, speedRate = 1.0, odFlag = null, cvtFlag = n
 
     if (status === "Fail") return -1;
     if (status === "NotMania") return -2;
+    if (status === "NoLN") return -3;
     if (!noteSeq.length || K <= 0) return -1;
 
     const { allCorners, baseCorners, ACorners } = getCorners(T, noteSeq);

--- a/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
+++ b/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
@@ -1,1 +1,1167 @@
+// Copied from sunnyAlgorithm.js
 import { OsuFileParser } from "../parser/osuFileParser.js";
+
+const BREAK_ZERO_THRESHOLD_MS = 400;
+const GRAPH_RESAMPLE_INTERVAL_MS = 100;
+const SMOOTH_SIGMA_MS = 800;
+
+function bisectLeft(arr, target) {
+    let lo = 0;
+    let hi = arr.length;
+    while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid] < target) lo = mid + 1;
+    else hi = mid;
+    }
+    return lo;
+}
+
+function bisectRight(arr, target) {
+    let lo = 0;
+    let hi = arr.length;
+    while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (arr[mid] <= target) lo = mid + 1;
+    else hi = mid;
+    }
+    return lo;
+}
+
+function cumulativeSum(x, f) {
+    const F = new Float64Array(x.length);
+    for (let i = 1; i < x.length; i += 1) {
+    F[i] = F[i - 1] + f[i - 1] * (x[i] - x[i - 1]);
+    }
+    return F;
+}
+
+function queryCumsum(q, x, F, f) {
+    if (q <= x[0]) return 0;
+    if (q >= x[x.length - 1]) return F[F.length - 1];
+    const i = bisectRight(x, q) - 1;
+    return F[i] + f[i] * (q - x[i]);
+}
+
+function smoothOnCorners(x, f, window, scale = 1.0, mode = "sum") {
+    const F = cumulativeSum(x, f);
+    const g = new Float64Array(f.length);
+    for (let i = 0; i < x.length; i += 1) {
+    const s = x[i];
+    const a = Math.max(s - window, x[0]);
+    const b = Math.min(s + window, x[x.length - 1]);
+    const val = queryCumsum(b, x, F, f) - queryCumsum(a, x, F, f);
+    if (mode === "avg") {
+            g[i] = b - a > 0 ? val / (b - a) : 0;
+    } else {
+            g[i] = scale * val;
+    }
+    }
+    return g;
+}
+
+function interpSingle(newX, oldX, oldVals) {
+    if (newX <= oldX[0]) return oldVals[0];
+    if (newX >= oldX[oldX.length - 1]) return oldVals[oldVals.length - 1];
+    const idx = bisectRight(oldX, newX) - 1;
+    const x0 = oldX[idx];
+    const x1 = oldX[idx + 1];
+    const y0 = oldVals[idx];
+    const y1 = oldVals[idx + 1];
+    if (x1 === x0) return y0;
+    const t = (newX - x0) / (x1 - x0);
+    return y0 + t * (y1 - y0);
+}
+
+function interpValues(newX, oldX, oldVals) {
+    const out = new Float64Array(newX.length);
+    let idx = 0;
+
+    for (let i = 0; i < newX.length; i += 1) {
+    const x = newX[i];
+
+    if (x <= oldX[0]) {
+        out[i] = oldVals[0];
+        continue;
+    }
+    if (x >= oldX[oldX.length - 1]) {
+        out[i] = oldVals[oldVals.length - 1];
+        continue;
+    }
+
+    while (idx + 1 < oldX.length && oldX[idx + 1] < x) {
+        idx += 1;
+    }
+
+    const x0 = oldX[idx];
+    const x1 = oldX[idx + 1];
+    const y0 = oldVals[idx];
+    const y1 = oldVals[idx + 1];
+
+    if (x1 === x0) {
+        out[i] = y0;
+        continue;
+    }
+
+    const t = (x - x0) / (x1 - x0);
+    out[i] = y0 + t * (y1 - y0);
+    }
+
+    return out;
+}
+
+function stepInterp(newX, oldX, oldVals) {
+    const out = new Float64Array(newX.length);
+    let idx = 0;
+    for (let i = 0; i < newX.length; i += 1) {
+    const x = newX[i];
+    while (idx + 1 < oldX.length && oldX[idx + 1] <= x) {
+        idx += 1;
+    }
+    const clamped = Math.max(0, Math.min(idx, oldVals.length - 1));
+    out[i] = oldVals[clamped];
+    }
+    return out;
+}
+
+function gaussianFilter1d(data, sigmaSamples) {
+    if (!Number.isFinite(sigmaSamples) || sigmaSamples <= 0) {
+    return Array.from(data);
+    }
+
+    const radius = Math.max(1, Math.trunc(4 * sigmaSamples + 0.5));
+    const kernelSize = radius * 2 + 1;
+    const kernel = new Float64Array(kernelSize);
+    let kernelSum = 0;
+
+    for (let i = -radius; i <= radius; i += 1) {
+    const v = Math.exp(-0.5 * ((i / sigmaSamples) ** 2));
+    kernel[i + radius] = v;
+    kernelSum += v;
+    }
+    for (let i = 0; i < kernelSize; i += 1) {
+    kernel[i] /= kernelSum;
+    }
+
+    const padded = new Float64Array(data.length + radius * 2);
+    for (let i = 0; i < data.length; i += 1) {
+    padded[i + radius] = data[i];
+    }
+
+    const out = new Float64Array(data.length);
+    for (let i = 0; i < data.length; i += 1) {
+    let acc = 0;
+    for (let k = 0; k < kernelSize; k += 1) {
+        acc += padded[i + k] * kernel[k];
+    }
+    out[i] = acc;
+    }
+    return Array.from(out);
+}
+
+function rescaleHigh(sr) {
+    if (sr <= 9) return sr;
+    return 9 + (sr - 9) * (1 / 1.2);
+}
+
+function mergeByHead(a, b) {
+    const result = [];
+    let i = 0;
+    let j = 0;
+    while (i < a.length && j < b.length) {
+    if (a[i][1] <= b[j][1]) {
+            result.push(a[i]);
+            i += 1;
+    } else {
+            result.push(b[j]);
+            j += 1;
+    }
+    }
+    while (i < a.length) {
+    result.push(a[i]);
+    i += 1;
+    }
+    while (j < b.length) {
+    result.push(b[j]);
+    j += 1;
+    }
+    return result;
+}
+
+function findNextNoteInColumn(note, times, noteSeqByColumn) {
+    const k = note[0];
+    const h = note[1];
+    const idx = bisectLeft(times, h);
+    return idx + 1 < noteSeqByColumn[k].length ? noteSeqByColumn[k][idx + 1] : [0, 1e9, 1e9];
+}
+
+function preprocessFile(osuText, speedRate, odFlag, cvtFlag) {
+    const pObj = new OsuFileParser(osuText);
+    pObj.process();
+    let p = pObj.getParsedData();
+    let lnRatio = p.lnRatio;
+
+    if (cvtFlag) {
+    if (String(cvtFlag).includes("IN")) {
+            try {
+        pObj.modIN();
+        lnRatio = pObj.getLNRatio();
+            } catch {
+        // keep original on convert error
+            }
+    }
+    if (String(cvtFlag).includes("HO")) {
+            try {
+        pObj.modHO();
+        lnRatio = pObj.getLNRatio();
+            } catch {
+        // keep original on convert error
+            }
+    }
+    }
+
+    pObj.noteTimes = pObj.getNoteTimes();
+    pObj.objectIntervals = pObj.getObjectIntervals();
+    p = pObj.getParsedData();
+    lnRatio = pObj.getLNRatio();
+
+    const columnCount = pObj.getColumnCount();
+
+    if (p.status === "Fail") {
+    return {
+            status: "Fail",
+            x: 0,
+            K: 0,
+            T: 0,
+            noteSeq: [],
+            noteSeqByColumn: [],
+            lnSeq: [],
+            tailSeq: [],
+            lnSeqByColumn: [],
+            lnRatio,
+            columnCount,
+    };
+    }
+    if (p.status === "NotMania") {
+    return {
+            status: "NotMania",
+            x: 0,
+            K: 0,
+            T: 0,
+            noteSeq: [],
+            noteSeqByColumn: [],
+            lnSeq: [],
+            tailSeq: [],
+            lnSeqByColumn: [],
+            lnRatio,
+            columnCount,
+    };
+    }
+
+    let od = 0;
+    if (odFlag == null) {
+    od = p.od;
+    } else if (odFlag === "HR") {
+    od = 6.462 + 0.715 * p.od;
+    } else if (odFlag === "EZ") {
+    od = -20.761 + 2.566 * p.od;
+    } else {
+    od = Number.parseFloat(odFlag);
+    }
+
+    const timeScale = speedRate !== 0 ? 1 / speedRate : 1;
+
+    const LNParts = getLNParts(osuText, speedRate, odFlag, cvtFlag);
+    const noteSeq = [];
+
+    for (let LNPartsIndex = 0; LNPartsIndex < LNParts.length; LNPartsIndex++){
+    for (let i = LNParts[LNPartsIndex][0]; i <= LNParts[LNPartsIndex][1]; i += 1) {
+        const k = p.columns[i];
+        let h = p.noteStarts[i];
+        let t = (p.noteTypes[i] & 128) !== 0 ? p.noteEnds[i] : -1;
+
+        h = Math.floor(h * timeScale);
+        t = t >= 0 ? Math.floor(t * timeScale) : t;
+
+        noteSeq.push([k, h, t]);
+    }
+    }
+
+    let x = 0.3 * Math.sqrt((64.5 - Math.ceil(od * 3)) / 500);
+    x = Math.min(x, 0.6 * (x - 0.09) + 0.09);
+
+    noteSeq.sort((a, b) => {
+    if (a[1] !== b[1]) return a[1] - b[1];
+    return a[0] - b[0];
+    });
+
+    const K = p.columnCount;
+    const noteSeqByColumn = Array.from({ length: K }, () => []);
+    for (const n of noteSeq) {
+    const col = n[0];
+    if (col >= 0 && col < K) noteSeqByColumn[col].push(n);
+    }
+
+    const lnSeq = noteSeq.filter((n) => n[2] >= 0);
+    const tailSeq = [...lnSeq].sort((a, b) => a[2] - b[2]);
+
+    const lnSeqByColumn = Array.from({ length: K }, () => []);
+    for (const n of lnSeq) {
+    const col = n[0];
+    if (col >= 0 && col < K) lnSeqByColumn[col].push(n);
+    }
+
+    const maxHead = noteSeq.length ? Math.max(...noteSeq.map((n) => n[1])) : 0;
+    const maxTail = noteSeq.length ? Math.max(...noteSeq.map((n) => n[2])) : 0;
+    const T = Math.max(maxHead, maxTail) + 1;
+
+    return {
+    status: "OK",
+    x,
+    K,
+    T,
+    noteSeq,
+    noteSeqByColumn,
+    lnSeq,
+    tailSeq,
+    lnSeqByColumn,
+    lnRatio,
+    columnCount,
+    };
+}
+
+function getCorners(T, noteSeq) {
+    const cornersBase = new Set();
+    for (const [, h, t] of noteSeq) {
+    cornersBase.add(h);
+    if (t >= 0) cornersBase.add(t);
+    }
+
+    const copyBase = [...cornersBase];
+    for (const s of copyBase) {
+    cornersBase.add(s + 501);
+    cornersBase.add(s - 499);
+    cornersBase.add(s + 1);
+    }
+    cornersBase.add(0);
+    cornersBase.add(T);
+
+    const baseCorners = [...cornersBase]
+    .filter((s) => s >= 0 && s <= T)
+    .sort((a, b) => a - b);
+
+    const cornersA = new Set();
+    for (const [, h, t] of noteSeq) {
+    cornersA.add(h);
+    if (t >= 0) cornersA.add(t);
+    }
+
+    const copyA = [...cornersA];
+    for (const s of copyA) {
+    cornersA.add(s + 1000);
+    cornersA.add(s - 1000);
+    }
+    cornersA.add(0);
+    cornersA.add(T);
+
+    const ACorners = [...cornersA]
+    .filter((s) => s >= 0 && s <= T)
+    .sort((a, b) => a - b);
+
+    const allCorners = [...new Set([...baseCorners, ...ACorners])].sort((a, b) => a - b);
+
+    return { allCorners, baseCorners, ACorners };
+}
+
+function getKeyUsage(K, T, noteSeq, baseCorners) {
+    const keyUsage = {};
+    for (let k = 0; k < K; k += 1) {
+    keyUsage[k] = new Array(baseCorners.length).fill(false);
+    }
+
+    for (const [k, h, t] of noteSeq) {
+    const startTime = Math.max(h - 150, 0);
+    const endTime = t < 0 ? h + 150 : Math.min(t + 150, T - 1);
+    const leftIdx = bisectLeft(baseCorners, startTime);
+    const rightIdx = bisectLeft(baseCorners, endTime);
+    for (let idx = leftIdx; idx < rightIdx; idx += 1) {
+            keyUsage[k][idx] = true;
+    }
+    }
+
+    return keyUsage;
+}
+
+function getKeyUsage400(K, T, noteSeq, baseCorners) {
+    const keyUsage400 = {};
+    for (let k = 0; k < K; k += 1) {
+    keyUsage400[k] = new Array(baseCorners.length).fill(0);
+    }
+
+    for (const [k, h, t] of noteSeq) {
+    const startTime = Math.max(h, 0);
+    const endTime = t < 0 ? h : Math.min(t, T - 1);
+
+    const left400Idx = bisectLeft(baseCorners, startTime - 400);
+    const leftIdx = bisectLeft(baseCorners, startTime);
+    const rightIdx = bisectLeft(baseCorners, endTime);
+    const right400Idx = bisectLeft(baseCorners, endTime + 400);
+
+    for (let idx = leftIdx; idx < rightIdx; idx += 1) {
+            keyUsage400[k][idx] += 3.75 + Math.min(endTime - startTime, 1500) / 150;
+    }
+
+    for (let idx = left400Idx; idx < leftIdx; idx += 1) {
+            keyUsage400[k][idx] += 3.75 - (3.75 / (400 ** 2)) * ((baseCorners[idx] - startTime) ** 2);
+    }
+
+    for (let idx = rightIdx; idx < right400Idx; idx += 1) {
+            keyUsage400[k][idx] += 3.75 - (3.75 / (400 ** 2)) * (Math.abs(baseCorners[idx] - endTime) ** 2);
+    }
+    }
+
+    return keyUsage400;
+}
+
+function computeAnchor(K, keyUsage400, baseCorners) {
+    const anchor = new Array(baseCorners.length).fill(0);
+
+    for (let idx = 0; idx < baseCorners.length; idx += 1) {
+    const counts = new Array(K).fill(0).map((_, k) => keyUsage400[k][idx]);
+    counts.sort((a, b) => b - a);
+
+    const nonZeroCounts = counts.filter((v) => v !== 0);
+    if (nonZeroCounts.length > 1) {
+            let walk = 0;
+            let maxWalk = 0;
+            for (let i = 0; i < nonZeroCounts.length - 1; i += 1) {
+        walk += nonZeroCounts[i] * (1 - 4 * ((0.5 - (nonZeroCounts[i + 1] / nonZeroCounts[i])) ** 2));
+        maxWalk += nonZeroCounts[i];
+            }
+            anchor[idx] = walk / maxWalk;
+    } else {
+            anchor[idx] = 0;
+    }
+    }
+
+    for (let i = 0; i < anchor.length; i += 1) {
+    anchor[i] = 1 + Math.min(anchor[i] - 0.18, 5 * ((anchor[i] - 0.22) ** 3));
+    }
+    return anchor;
+}
+
+function lnBodiesCountSparseRepresentation(lnSeq, T) {
+    const diff = new Map();
+
+    for (const [, h, t] of lnSeq) {
+    const t0 = Math.min(h + 60, t);
+    const t1 = Math.min(h + 120, t);
+
+    diff.set(t0, (diff.get(t0) || 0) + 1.3);
+    diff.set(t1, (diff.get(t1) || 0) + (-1.3 + 1));
+    diff.set(t, (diff.get(t) || 0) - 1);
+    }
+
+    const pointsSet = new Set([0, T]);
+    for (const k of diff.keys()) pointsSet.add(k);
+    const points = [...pointsSet].sort((a, b) => a - b);
+
+    const values = [];
+    const cumsum = [0];
+    let curr = 0;
+
+    for (let i = 0; i < points.length - 1; i += 1) {
+    const t = points[i];
+    if (diff.has(t)) curr += diff.get(t);
+
+    const v = Math.min(curr, 2.5 + 0.5 * curr);
+    values.push(v);
+
+    const segLength = points[i + 1] - points[i];
+    cumsum.push(cumsum[cumsum.length - 1] + segLength * v);
+    }
+
+    return { points, cumsum, values };
+}
+
+function lnSum(a, b, lnRep) {
+    const { points, cumsum, values } = lnRep;
+
+    const i = bisectRight(points, a) - 1;
+    const j = bisectRight(points, b) - 1;
+
+    if (i === j) {
+    return (b - a) * values[i];
+    }
+
+    let total = 0;
+    total += (points[i + 1] - a) * values[i];
+    total += cumsum[j] - cumsum[i + 1];
+    total += (b - points[j]) * values[j];
+    return total;
+}
+
+function computeJbar(K, x, noteSeqByColumn, baseCorners) {
+    const jackNerfer = (delta) => 1 - 7e-5 * ((0.15 + Math.abs(delta - 0.08)) ** (-4));
+
+    const Jks = {};
+    const deltaKs = {};
+    for (let k = 0; k < K; k += 1) {
+    Jks[k] = new Array(baseCorners.length).fill(0);
+    deltaKs[k] = new Array(baseCorners.length).fill(1e9);
+    }
+
+    for (let k = 0; k < K; k += 1) {
+    const notes = noteSeqByColumn[k] || [];
+    for (let i = 0; i < notes.length - 1; i += 1) {
+            const start = notes[i][1];
+            const end = notes[i + 1][1];
+
+            const leftIdx = bisectLeft(baseCorners, start);
+            const rightIdx = bisectLeft(baseCorners, end);
+            if (leftIdx >= rightIdx) continue;
+
+            const delta = 0.001 * (end - start);
+            const val = (delta ** -1) * ((delta + 0.11 * (x ** 0.25)) ** -1);
+            const jVal = val * jackNerfer(delta);
+
+            for (let idx = leftIdx; idx < rightIdx; idx += 1) {
+        Jks[k][idx] = jVal;
+        deltaKs[k][idx] = delta;
+            }
+    }
+    }
+
+    const JbarKs = {};
+    for (let k = 0; k < K; k += 1) {
+    JbarKs[k] = smoothOnCorners(baseCorners, Jks[k], 500, 0.001, "sum");
+    }
+
+    const Jbar = new Array(baseCorners.length).fill(0);
+    for (let i = 0; i < baseCorners.length; i += 1) {
+    let num = 0;
+    let den = 0;
+    for (let k = 0; k < K; k += 1) {
+            const v = JbarKs[k][i];
+            const w = 1 / deltaKs[k][i];
+            num += (Math.max(v, 0) ** 5) * w;
+            den += w;
+    }
+    const raw = num / Math.max(1e-9, den);
+    Jbar[i] = raw ** (1 / 5);
+    }
+
+    return { deltaKs, Jbar };
+}
+
+function computeXbar(K, x, noteSeqByColumn, activeColumns, baseCorners) {
+    const crossMatrix = [
+    [-1],
+    [0.075, 0.075],
+    [0.125, 0.05, 0.125],
+    [0.125, 0.125, 0.125, 0.125],
+    [0.175, 0.25, 0.05, 0.25, 0.175],
+    [0.175, 0.25, 0.175, 0.175, 0.25, 0.175],
+    [0.225, 0.35, 0.25, 0.05, 0.25, 0.35, 0.225],
+    [0.225, 0.35, 0.25, 0.225, 0.225, 0.25, 0.35, 0.225],
+    [0.275, 0.45, 0.35, 0.25, 0.05, 0.25, 0.35, 0.45, 0.275],
+    [0.275, 0.45, 0.35, 0.25, 0.275, 0.275, 0.25, 0.35, 0.45, 0.275],
+    [0.325, 0.55, 0.45, 0.35, 0.25, 0.05, 0.25, 0.35, 0.45, 0.55, 0.325],
+    ];
+
+    if (K < 1 || K > 10) {
+    return new Array(baseCorners.length).fill(0);
+    }
+
+    const Xks = {};
+    const fastCross = {};
+    for (let k = 0; k <= K; k += 1) {
+    Xks[k] = new Array(baseCorners.length).fill(0);
+    fastCross[k] = new Array(baseCorners.length).fill(0);
+    }
+
+    const crossCoeff = crossMatrix[K];
+
+    for (let k = 0; k <= K; k += 1) {
+    let notesInPair = [];
+    if (k === 0) {
+            notesInPair = noteSeqByColumn[0] || [];
+    } else if (k === K) {
+            notesInPair = noteSeqByColumn[K - 1] || [];
+    } else {
+            notesInPair = mergeByHead(noteSeqByColumn[k - 1] || [], noteSeqByColumn[k] || []);
+    }
+
+    for (let i = 1; i < notesInPair.length; i += 1) {
+            const start = notesInPair[i - 1][1];
+            const end = notesInPair[i][1];
+            const idxStart = bisectLeft(baseCorners, start);
+            const idxEnd = bisectLeft(baseCorners, end);
+            if (idxStart >= idxEnd) continue;
+
+            const delta = 0.001 * (end - start);
+            let val = 0.16 * (Math.max(x, delta) ** -2);
+
+            const leftActive = activeColumns[Math.min(idxStart, activeColumns.length - 1)] || [];
+            const rightActive = activeColumns[Math.min(idxEnd, activeColumns.length - 1)] || [];
+
+            if (
+        ((!leftActive.includes(k - 1)) && (!rightActive.includes(k - 1))) ||
+        ((!leftActive.includes(k)) && (!rightActive.includes(k)))
+            ) {
+        val *= (1 - crossCoeff[k]);
+            }
+
+            const fast = Math.max(0, 0.4 * (Math.max(delta, 0.06, 0.75 * x) ** -2) - 80);
+            for (let idx = idxStart; idx < idxEnd; idx += 1) {
+        Xks[k][idx] = val;
+        fastCross[k][idx] = fast;
+            }
+    }
+    }
+
+    const xBase = new Array(baseCorners.length).fill(0);
+    for (let i = 0; i < baseCorners.length; i += 1) {
+    let sum1 = 0;
+    for (let k = 0; k <= K; k += 1) {
+            sum1 += Xks[k][i] * crossCoeff[k];
+    }
+
+    let sum2 = 0;
+    for (let k = 0; k < K; k += 1) {
+            sum2 += Math.sqrt(
+        fastCross[k][i] * crossCoeff[k] * fastCross[k + 1][i] * crossCoeff[k + 1]
+            );
+    }
+
+    xBase[i] = sum1 + sum2;
+    }
+
+    return smoothOnCorners(baseCorners, xBase, 500, 0.001, "sum");
+}
+
+function computePbar(x, noteSeq, lnRep, anchor, baseCorners) {
+    const streamBooster = (delta) => {
+    const expr = (7.5 / delta);
+    if (160 < expr && expr < 360) {
+            return 1 + 1.7e-7 * (expr - 160) * ((expr - 360) ** 2);
+    }
+    return 1;
+    };
+
+    const pStep = new Array(baseCorners.length).fill(0);
+
+    for (let i = 0; i < noteSeq.length - 1; i += 1) {
+    const hL = noteSeq[i][1];
+    const hR = noteSeq[i + 1][1];
+    const deltaTime = hR - hL;
+
+    if (deltaTime < 1e-9) {
+            const spike = 1000 * ((0.02 * (4 / x - 24)) ** 0.25);
+            const leftIdx = bisectLeft(baseCorners, hL);
+            const rightIdx = bisectRight(baseCorners, hL);
+            for (let idx = leftIdx; idx < rightIdx; idx += 1) {
+        pStep[idx] += spike;
+            }
+            continue;
+    }
+
+    const leftIdx = bisectLeft(baseCorners, hL);
+    const rightIdx = bisectLeft(baseCorners, hR);
+    if (leftIdx >= rightIdx) continue;
+
+    const delta = 0.001 * deltaTime;
+    const v = 1 + 6 * 0.001 * lnSum(hL, hR, lnRep);
+    const bVal = streamBooster(delta);
+
+    let inc = 0;
+    if (delta < (2 * x) / 3) {
+            inc = (delta ** -1) * ((0.08 * (x ** -1) * (1 - 24 * (x ** -1) * ((delta - x / 2) ** 2))) ** 0.25) * Math.max(bVal, v);
+    } else {
+            inc = (delta ** -1) * ((0.08 * (x ** -1) * (1 - 24 * (x ** -1) * ((x / 6) ** 2))) ** 0.25) * Math.max(bVal, v);
+    }
+
+    for (let idx = leftIdx; idx < rightIdx; idx += 1) {
+            pStep[idx] += Math.min(inc * anchor[idx], Math.max(inc, inc * 2 - 10));
+    }
+    }
+
+    return smoothOnCorners(baseCorners, pStep, 500, 0.001, "sum");
+}
+
+function computeAbar(K, activeColumns, deltaKs, ACorners, baseCorners) {
+    const dks = {};
+    for (let k = 0; k < K - 1; k += 1) {
+    dks[k] = new Array(baseCorners.length).fill(0);
+    }
+
+    for (let i = 0; i < baseCorners.length; i += 1) {
+    const cols = activeColumns[i] || [];
+    for (let j = 0; j < cols.length - 1; j += 1) {
+            const k0 = cols[j];
+            const k1 = cols[j + 1];
+            dks[k0][i] = Math.abs(deltaKs[k0][i] - deltaKs[k1][i]) + 0.4 * Math.max(0, Math.max(deltaKs[k0][i], deltaKs[k1][i]) - 0.11);
+    }
+    }
+
+    const aStep = new Array(ACorners.length).fill(1);
+
+    for (let i = 0; i < ACorners.length; i += 1) {
+    const s = ACorners[i];
+    let idx = bisectLeft(baseCorners, s);
+    if (idx >= baseCorners.length) idx = baseCorners.length - 1;
+
+    const cols = activeColumns[idx] || [];
+    for (let j = 0; j < cols.length - 1; j += 1) {
+            const k0 = cols[j];
+            const k1 = cols[j + 1];
+            const dVal = dks[k0][idx];
+
+            if (dVal < 0.02) {
+        aStep[i] *= Math.min(0.75 + 0.5 * Math.max(deltaKs[k0][idx], deltaKs[k1][idx]), 1);
+            } else if (dVal < 0.07) {
+        aStep[i] *= Math.min(0.65 + 5 * dVal + 0.5 * Math.max(deltaKs[k0][idx], deltaKs[k1][idx]), 1);
+            }
+    }
+    }
+
+    return smoothOnCorners(ACorners, aStep, 250, 1, "avg");
+}
+
+function computeRbar(K, x, noteSeqByColumn, tailSeq, baseCorners) {
+    const RStep = new Array(baseCorners.length).fill(0);
+
+    const timesByColumn = {};
+    for (let i = 0; i < K; i += 1) {
+    timesByColumn[i] = (noteSeqByColumn[i] || []).map((note) => note[1]);
+    }
+
+    const IList = [];
+    for (let i = 0; i < tailSeq.length; i += 1) {
+    const [k, hI, tI] = tailSeq[i];
+    const [, hJ] = findNextNoteInColumn([k, hI, tI], timesByColumn[k], noteSeqByColumn);
+    const I_h = 0.001 * Math.abs(tI - hI - 80) / x;
+    const I_t = 0.001 * Math.abs(hJ - tI - 80) / x;
+    IList.push(2 / (2 + Math.exp(-5 * (I_h - 0.75)) + Math.exp(-5 * (I_t - 0.75))));
+    }
+
+    for (let i = 0; i < tailSeq.length - 1; i += 1) {
+    const tStart = tailSeq[i][2];
+    const tEnd = tailSeq[i + 1][2];
+
+    const leftIdx = bisectLeft(baseCorners, tStart);
+    const rightIdx = bisectLeft(baseCorners, tEnd);
+    if (leftIdx >= rightIdx) continue;
+
+    const deltaR = 0.001 * (tEnd - tStart);
+    const rValue = 0.08 * (deltaR ** -0.5) * (x ** -1) * (1 + 0.8 * (IList[i] + IList[i + 1]));
+
+    for (let idx = leftIdx; idx < rightIdx; idx += 1) {
+            RStep[idx] = rValue;
+    }
+    }
+
+    return smoothOnCorners(baseCorners, RStep, 500, 0.001, "sum");
+}
+
+function computeCAndKs(K, noteSeq, keyUsage, baseCorners) {
+    const noteHitTimes = noteSeq.map((n) => n[1]).sort((a, b) => a - b);
+
+    const CStep = new Float64Array(baseCorners.length);
+    let lo = 0;
+    let hi = 0;
+    for (let i = 0; i < baseCorners.length; i += 1) {
+    const s = baseCorners[i];
+    const low = s - 500;
+    const high = s + 500;
+
+    while (lo < noteHitTimes.length && noteHitTimes[lo] < low) {
+            lo += 1;
+    }
+    while (hi < noteHitTimes.length && noteHitTimes[hi] < high) {
+            hi += 1;
+    }
+
+    CStep[i] = hi - lo;
+    }
+
+    const KsStep = new Float64Array(baseCorners.length);
+    for (let i = 0; i < baseCorners.length; i += 1) {
+    let count = 0;
+    for (let k = 0; k < K; k += 1) {
+            if (keyUsage[k][i]) count += 1;
+    }
+    KsStep[i] = Math.max(count, 1);
+    }
+
+    return { CStep, KsStep };
+}
+
+function applyProximityEnvelope(allCorners, DAll, noteSeq) {
+    if (!noteSeq.length) {
+    return Array.from(DAll);
+    }
+
+    const noteTimes = noteSeq
+    .map((n) => Number(n[1]))
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => a - b);
+
+    if (!noteTimes.length) {
+    return Array.from(DAll);
+    }
+
+    const proximityFadeMs = 500;
+    const out = new Float64Array(allCorners.length);
+    for (let i = 0; i < allCorners.length; i += 1) {
+    const t = allCorners[i];
+    const idx = bisectLeft(noteTimes, t);
+    const after = idx < noteTimes.length ? Math.abs(noteTimes[idx] - t) : Number.POSITIVE_INFINITY;
+    const before = idx > 0 ? Math.abs(noteTimes[idx - 1] - t) : Number.POSITIVE_INFINITY;
+    const d = Math.min(after, before);
+    const ratio = Math.max(0, Math.min(d / proximityFadeMs, 1));
+    const envelope = 0.5 * (1 + Math.cos(Math.PI * ratio));
+    out[i] = DAll[i] * envelope;
+    }
+    return Array.from(out);
+}
+
+function smoothDForGraph(allCorners, DAll, noteSeq) {
+    if (!allCorners.length || !DAll.length) {
+    return [];
+    }
+
+    const tStart = allCorners[0];
+    const tEnd = allCorners[allCorners.length - 1];
+    const uniformTimes = [];
+    for (let t = tStart; t <= tEnd + GRAPH_RESAMPLE_INTERVAL_MS; t += GRAPH_RESAMPLE_INTERVAL_MS) {
+    uniformTimes.push(t);
+    }
+
+    const noteTimes = noteSeq
+    .map((n) => Number(n[1]))
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => a - b);
+
+    const uniformD = interpValues(uniformTimes, allCorners, DAll);
+
+    if (noteTimes.length) {
+    for (let i = 0; i < uniformTimes.length; i += 1) {
+            const t = uniformTimes[i];
+            const idx = bisectLeft(noteTimes, t);
+            const after = idx < noteTimes.length ? Math.abs(noteTimes[idx] - t) : Number.POSITIVE_INFINITY;
+            const before = idx > 0 ? Math.abs(noteTimes[idx - 1] - t) : Number.POSITIVE_INFINITY;
+            const dist = Math.min(after, before);
+            if (dist > BREAK_ZERO_THRESHOLD_MS) {
+        uniformD[i] = 0;
+            }
+    }
+    }
+
+    const sigmaSamples = SMOOTH_SIGMA_MS / GRAPH_RESAMPLE_INTERVAL_MS;
+    const smoothed = gaussianFilter1d(uniformD, sigmaSamples);
+
+    if (noteTimes.length) {
+    for (let i = 0; i < uniformTimes.length; i += 1) {
+            const t = uniformTimes[i];
+            const idx = bisectLeft(noteTimes, t);
+            const after = idx < noteTimes.length ? Math.abs(noteTimes[idx] - t) : Number.POSITIVE_INFINITY;
+            const before = idx > 0 ? Math.abs(noteTimes[idx - 1] - t) : Number.POSITIVE_INFINITY;
+            const dist = Math.min(after, before);
+            if (dist > BREAK_ZERO_THRESHOLD_MS) {
+        smoothed[i] = 0;
+            }
+    }
+    }
+
+    return Array.from(interpValues(allCorners, uniformTimes, smoothed));
+}
+
+const MIN_WINDOW_LENGTH = 10*1000; // 10s
+const MIN_LN_PERCENTAGE = 20; // 20%
+const MIN_LN_DENSITY = MIN_LN_PERCENTAGE * 0.01;
+
+function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
+    const pObj = new OsuFileParser(osuText);
+    pObj.process();
+    let p = pObj.getParsedData();
+    let lnRatio = p.lnRatio;
+
+    if (cvtFlag) {
+    if (String(cvtFlag).includes("IN")) {
+            try {
+        pObj.modIN();
+        lnRatio = pObj.getLNRatio();
+            } catch {
+        // keep original on convert error
+            }
+    }
+    if (String(cvtFlag).includes("HO")) {
+            try {
+        pObj.modHO();
+        lnRatio = pObj.getLNRatio();
+            } catch {
+        // keep original on convert error
+            }
+    }
+    }
+
+    pObj.noteTimes = pObj.getNoteTimes();
+    pObj.objectIntervals = pObj.getObjectIntervals();
+    p = pObj.getParsedData();
+    lnRatio = pObj.getLNRatio();
+
+    const columnCount = pObj.getColumnCount();
+
+    if (p.status === "Fail" || p.status === "NotMania") return new Array();
+
+    const speedRate = _speedRate !== 0 ? _speedRate : 1;
+    // p.noteStarts[j]/speedRate > p.noteStarts[i]/speedRate + MIN_WINDOW_LENGTH
+    // 等效于 p.noteStarts[j] > p.noteStarts[i] + MIN_WINDOW_LENGTH * speedRate
+    const MIN_WINDOW_LENGTH_AFTER_SCALE = MIN_WINDOW_LENGTH * speedRate;
+
+    function isLNPercentageValid(riceCount, LNCount) {return (LNCount / (riceCount + LNCount)) > MIN_LN_DENSITY;}
+
+    // 第一步：框出所有区间
+    let currentTime = undefined;
+    let riceCount = 0;
+    let LNCount = 0;
+    let windowStartIndex = -1;
+    let windowEndIndex = -1;
+    let WindowList1 = new Array();
+    let j = 0; // 音符i在处理倍速后向后MIN_WINDOW_LENGTH毫秒内的最后一个音符的位置
+    for (let i = 0; i < p.columns.length; i += 1) {
+        /*
+        const k = p.columns[i];
+        let h = p.noteStarts[i];
+        let t = (p.noteTypes[i] & 128) !== 0 ? p.noteEnds[i] : -1;
+        h = Math.floor(h * timeScale);
+        t = t >= 0 ? Math.floor(t * timeScale) : t;
+        noteSeq.push([k, h, t]);
+        */
+        if (p.noteStarts[i] !== currentTime) {
+            currentTime = p.noteStarts[i];
+            while (j < p.columns.length) {
+                j++;
+                if (j >= p.columns.length) break;
+                if (p.noteStarts[j] > currentTime + MIN_WINDOW_LENGTH_AFTER_SCALE) {j--; break;}
+                if ((p.noteTypes[j] & 128) === 0) riceCount++; else LNCount++;
+            };
+
+            if (j >= p.columns.length) {
+                if (windowStartIndex !== -1) WindowList1.push([windowStartIndex, windowEndIndex]);
+                break;
+            } // 窗口够到了最后一个音符的开头，即所有音符都被尝试覆盖过了；这个break会跳出for循环
+
+            if (windowStartIndex === -1 && isLNPercentageValid(riceCount, LNCount)) {
+                windowStartIndex = i;
+            }
+            else if (windowStartIndex !== -1) {
+                if (isLNPercentageValid(riceCount, LNCount)) windowEndIndex = j;
+                else {
+                    WindowList1.push([windowStartIndex, windowEndIndex]);
+                    windowStartIndex = -1;
+                    windowEndIndex = -1;
+                }
+            }
+        }
+
+        if ((p.noteTypes[i] & 128) === 0) riceCount--; else LNCount--; // 范围的开头离开了那个音符，减去对应的Count
+    }
+
+    if (WindowList1.length === 0) return WindowList1;
+
+    // 第二步：合并区间
+    let WindowList2 = new Array();
+    windowStartIndex = -1;
+    windowEndIndex = -1;
+    for (let i = 0; i < WindowList1.length; i++) {
+        if (windowStartIndex !== -1) {
+            if (WindowList1[i][0] <= windowEndIndex) {
+                windowEndIndex = WindowList1[i][1];
+            } // 合并重合区间
+            else {
+                WindowList2.push([windowStartIndex, windowEndIndex]);
+                windowStartIndex = -1;
+            }
+        }
+        // 不要合并上下两个if，windowStartIndex被修改了
+        if (windowStartIndex === -1) {
+            windowStartIndex = WindowList1[i][0];
+            windowEndIndex = WindowList1[i][1];
+        }
+
+        if (i + 1 >= WindowList1.length && windowStartIndex !== -1) {
+            WindowList2.push([windowStartIndex, windowEndIndex]); // 收尾
+            break;
+        }
+    }
+    windowList1 = null;
+
+    // 第三步：剔除米部分，目前剔除了最早的LN
+    let WindowList3 = new Array();
+    windowStartIndex = -1;
+    windowEndIndex = -1;
+    let currentStartIndex = -1; // 等效于与当前note同一时间的最左边的note的index
+    currentTime = NaN;
+    let windowEndTime = -1e308;
+    let j = 0; // WindowList2的index
+    for (let i = WindowList2[0][0]; i < p.columns.length; i += 1) {
+        if (p.noteStarts[i] !== currentTime) {
+            currentTime = p.noteStarts[i];
+            currentStartIndex = i;
+        }
+
+        if ((p.noteTypes[i] & 128) !== 0) {
+            if (windowStartIndex === -1) windowStartIndex = currentStartIndex;
+            windowEndTime = Math.max(windowEndTime, p.noteEnds[i]);
+            windowEndIndex = i;
+        }
+        else if (p.noteStarts[i] >= windowEndTime) {
+            windowEndIndex = i;
+        }
+
+        if (i >= WindowList2[j][1]) {
+            j++;
+            WindowList3.push([windowStartIndex, windowEndIndex]);
+            windowStartIndex = -1;
+            windowEndIndex = -1;
+            windowEndTime = -1e308;
+            if (j >= WindowList2.length) break;
+        }
+    }
+
+    windowList2 = null;
+    return WindowList3;
+}
+
+export function calculateLN(osuText, speedRate = 1.0, odFlag = null, cvtFlag = null, options = {}) {
+    const withGraph = options?.withGraph === true;
+
+    const {
+    status,
+    x,
+    K,
+    T,
+    noteSeq,
+    noteSeqByColumn,
+    lnSeq,
+    tailSeq,
+    lnRatio,
+    columnCount,
+    } = preprocessFile(osuText, speedRate, odFlag, cvtFlag);
+
+    if (status === "Fail") return -1;
+    if (status === "NotMania") return -2;
+    if (!noteSeq.length || K <= 0) return -1;
+
+    const { allCorners, baseCorners, ACorners } = getCorners(T, noteSeq);
+
+    const keyUsage = getKeyUsage(K, T, noteSeq, baseCorners);
+    const activeColumns = baseCorners.map((_, i) => {
+    const active = [];
+    for (let k = 0; k < K; k += 1) {
+            if (keyUsage[k][i]) active.push(k);
+    }
+    return active;
+    });
+
+    const keyUsage400 = getKeyUsage400(K, T, noteSeq, baseCorners);
+    const anchor = computeAnchor(K, keyUsage400, baseCorners);
+
+    const { deltaKs, Jbar: JbarBase } = computeJbar(K, x, noteSeqByColumn, baseCorners);
+    const Jbar = interpValues(allCorners, baseCorners, JbarBase);
+
+    const XbarBase = computeXbar(K, x, noteSeqByColumn, activeColumns, baseCorners);
+    const Xbar = interpValues(allCorners, baseCorners, XbarBase);
+
+    const lnRep = lnBodiesCountSparseRepresentation(lnSeq, T);
+    const PbarBase = computePbar(x, noteSeq, lnRep, anchor, baseCorners);
+    const Pbar = interpValues(allCorners, baseCorners, PbarBase);
+
+    const AbarBase = computeAbar(K, activeColumns, deltaKs, ACorners, baseCorners);
+    const Abar = interpValues(allCorners, ACorners, AbarBase);
+
+    const RbarBase = computeRbar(K, x, noteSeqByColumn, tailSeq, baseCorners);
+    const Rbar = interpValues(allCorners, baseCorners, RbarBase);
+
+    const { CStep, KsStep } = computeCAndKs(K, noteSeq, keyUsage, baseCorners);
+    const CArr = stepInterp(allCorners, baseCorners, CStep);
+    const KsArr = stepInterp(allCorners, baseCorners, KsStep);
+
+    const DAll = new Array(allCorners.length).fill(0);
+    for (let i = 0; i < allCorners.length; i += 1) {
+    const leftPart = 0.4 * ((Abar[i] ** (3 / KsArr[i]) * Math.min(Jbar[i], 8 + 0.85 * Jbar[i])) ** 1.5);
+    const rightPart = 0.6 * ((Abar[i] ** (2 / 3) * (0.8 * Pbar[i] + Rbar[i] * 35 / (CArr[i] + 8))) ** 1.5);
+    const SAll = (leftPart + rightPart) ** (2 / 3);
+    const TAll = (Abar[i] ** (3 / KsArr[i]) * Xbar[i]) / (Xbar[i] + SAll + 1);
+    DAll[i] = 2.7 * (SAll ** 0.5) * (TAll ** 1.5) + SAll * 0.27;
+    }
+
+    const gaps = new Array(allCorners.length).fill(0);
+    gaps[0] = (allCorners[1] - allCorners[0]) / 2;
+    gaps[gaps.length - 1] = (allCorners[allCorners.length - 1] - allCorners[allCorners.length - 2]) / 2;
+    for (let i = 1; i < allCorners.length - 1; i += 1) {
+    gaps[i] = (allCorners[i + 1] - allCorners[i - 1]) / 2;
+    }
+
+    const effectiveWeights = CArr.map((c, i) => c * gaps[i]);
+    const sortedIndices = DAll.map((_, i) => i).sort((a, b) => DAll[a] - DAll[b]);
+    const DSorted = sortedIndices.map((i) => DAll[i]);
+    const wSorted = sortedIndices.map((i) => effectiveWeights[i]);
+
+    const cumWeights = new Array(wSorted.length).fill(0);
+    let running = 0;
+    for (let i = 0; i < wSorted.length; i += 1) {
+    running += wSorted[i];
+    cumWeights[i] = running;
+    }
+
+    const totalWeight = cumWeights[cumWeights.length - 1];
+    const normCumWeights = cumWeights.map((w) => w / totalWeight);
+
+    const targetPercentiles = [0.945, 0.935, 0.925, 0.915, 0.845, 0.835, 0.825, 0.815];
+    const percentileIndices = targetPercentiles.map((p) => bisectLeft(normCumWeights, p));
+
+    const firstGroup = percentileIndices.slice(0, 4).map((idx) => DSorted[Math.min(idx, DSorted.length - 1)]);
+    const secondGroup = percentileIndices.slice(4, 8).map((idx) => DSorted[Math.min(idx, DSorted.length - 1)]);
+
+    const percentile93 = firstGroup.reduce((acc, v) => acc + v, 0) / firstGroup.length;
+    const percentile83 = secondGroup.reduce((acc, v) => acc + v, 0) / secondGroup.length;
+
+    let num = 0;
+    let den = 0;
+    for (let i = 0; i < DSorted.length; i += 1) {
+    num += (DSorted[i] ** 5) * wSorted[i];
+    den += wSorted[i];
+    }
+    const weightedMean = (num / den) ** (1 / 5);
+
+    let sr = (0.88 * percentile93) * 0.25 + (0.94 * percentile83) * 0.2 + weightedMean * 0.55;
+    sr = (sr ** 1) / (8 ** 1) * 8;
+
+    let lnLengthTerm = 0;
+    for (const [, h, t] of lnSeq) {
+    lnLengthTerm += Math.min((t - h), 1000) / 200;
+    }
+    const totalNotes = noteSeq.length + 0.5 * lnLengthTerm;
+
+    sr *= totalNotes / (totalNotes + 60);
+    sr = rescaleHigh(sr);
+    sr *= 0.975;
+
+    if (withGraph) {
+    const DPre = applyProximityEnvelope(allCorners, DAll, noteSeq);
+    const DGraph = smoothDForGraph(allCorners, DPre, noteSeq);
+    return {
+            star: sr,
+            lnRatio,
+            columnCount,
+            graph: {
+        times: Array.from(allCorners),
+        values: DGraph,
+            },
+    };
+    }
+
+    return [sr, lnRatio, columnCount];
+}

--- a/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
+++ b/ManiaMapAnalyser by Leo_Black/js/rework/sunnyWindowAlgorithm.js
@@ -891,9 +891,98 @@ function smoothDForGraph(allCorners, DAll, noteSeq) {
     return Array.from(interpValues(allCorners, uniformTimes, smoothed));
 }
 
-const MIN_WINDOW_LENGTH = 30*1000; // 30s
+
 const MIN_LN_PERCENTAGE = 20; // 20%
 const MIN_LN_DENSITY = MIN_LN_PERCENTAGE * 0.01;
+
+/**
+ * 解析 .osu 文本中的 timing points。
+ * 返回 {timings, isSV}：
+ *   timings = 非继承 timing point 数组 {offset, beatLength, signature}
+ *   isSV = 如果谱面存在复杂 SV（非1.0x速度持续超过2秒），则为 true
+ */
+function parseTimingsAndDetectSV(osuText) {
+    const lines = osuText.split('\n');
+    let inTiming = false;
+    const uninherited = [];
+    let svTotalMs = 0;
+    let svIntervals = 0;
+    let inSV = false;
+    let svStartTime = 0;
+    const SV_EPS = 0.05;
+
+    for (const line of lines) {
+        const t = line.trim();
+        if (t === '[TimingPoints]') { inTiming = true; continue; }
+        if (inTiming && t.startsWith('[')) break;
+        if (!inTiming || t.startsWith('//') || t === '') continue;
+        const parts = t.split(',');
+        const offset = parseFloat(parts[0]);
+        const beatLength = parseFloat(parts[1]);
+        const signature = parseInt(parts[2]) || 4;
+
+        if (beatLength > 0) {
+            uninherited.push({ offset, beatLength, signature });
+        } else {
+            // 继承 timing point：beatLength < 0，速度 = -100 / beatLength
+            const vel = -100 / beatLength;
+            const isNonOne = Math.abs(vel - 1) > SV_EPS;
+            if (isNonOne && !inSV) {
+                svIntervals++;
+                inSV = true;
+                svStartTime = offset;
+            } else if (!isNonOne && inSV) {
+                svTotalMs += offset - svStartTime;
+                inSV = false;
+            }
+        }
+    }
+    // 处理末尾仍在 SV 中的情况
+    if (inSV) svTotalMs += (uninherited.length > 0 ? uninherited[uninherited.length - 1].offset : 0) - svStartTime;
+
+    const timings = uninherited.length > 0 ? uninherited : [{ offset: 0, beatLength: 500, signature: 4 }];
+    const isSV = svIntervals > 1 && svTotalMs > 2000;
+    return { timings, isSV };
+}
+
+/**
+ * 计算给定时间戳处的单位长度（4小节）的毫秒数。
+ */
+function getUnitLength(timings, timeMs) {
+    let active = timings[0];
+    for (const tp of timings) {
+        if (tp.offset <= timeMs) active = tp;
+        else break;
+    }
+    return active.signature * active.beatLength * 4;
+}
+
+/**
+ * 计算 [timeStart, timeEnd) 范围内的 LN 时长覆盖。
+ * 返回 LN 占据的总毫秒数（合并重叠区间，不重复计算）。
+ */
+function computeLNDuration(p, timeStart, timeEnd, noteStartIdx, noteEndIdx) {
+    const intervals = [];
+    for (let k = noteStartIdx; k <= noteEndIdx; k++) {
+        if (p.noteStarts[k] >= timeEnd) break;
+        if ((p.noteTypes[k] & 128) !== 0) {
+            const s = Math.max(p.noteStarts[k], timeStart);
+            const e = Math.min(p.noteEnds[k], timeEnd);
+            if (e > s) intervals.push([s, e]);
+        }
+    }
+    // 合并重叠区间
+    intervals.sort((a, b) => a[0] - b[0]);
+    let merged = 0;
+    let curStart = -1, curEnd = -1;
+    for (const [s, e] of intervals) {
+        if (curStart === -1) { curStart = s; curEnd = e; }
+        else if (s <= curEnd) { curEnd = Math.max(curEnd, e); }
+        else { merged += curEnd - curStart; curStart = s; curEnd = e; }
+    }
+    if (curStart !== -1) merged += curEnd - curStart;
+    return merged;
+}
 
 function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
     const pObj = new OsuFileParser(osuText);
@@ -930,120 +1019,169 @@ function getLNParts(osuText, _speedRate, odFlag, cvtFlag) {
     if (p.status === "Fail" || p.status === "NotMania") return new Array();
 
     const speedRate = _speedRate !== 0 ? _speedRate : 1;
-    // p.noteStarts[j]/speedRate > p.noteStarts[i]/speedRate + MIN_WINDOW_LENGTH
-    // 等效于 p.noteStarts[j] > p.noteStarts[i] + MIN_WINDOW_LENGTH * speedRate
-    const MIN_WINDOW_LENGTH_AFTER_SCALE = MIN_WINDOW_LENGTH * speedRate;
 
-    function isLNPercentageValid(riceCount, LNCount) {return (LNCount / (riceCount + LNCount)) > MIN_LN_DENSITY;}
+    // 解析 timing points 并检测 SV
+    const { timings: tpTimings, isSV } = parseTimingsAndDetectSV(osuText);
 
-    // 第一步：框出所有区间
-    let currentTime = undefined;
-    let riceCount = 0;
-    let LNCount = 0;
-    let windowStartIndex = -1;
-    let windowEndIndex = -1;
+    // SV 回退：复杂 SV → 固定5秒区块；否则 → 4小节区块
+    const SV_FIXED_BLOCK = 5000;
+    function getBlockLength(timeMs) {
+        if (isSV) return SV_FIXED_BLOCK * speedRate;
+        return getUnitLength(tpTimings, timeMs) * speedRate;
+    }
+
+    // 判断 LN 占比是否达到阈值（基于音符数量）
+    function isLNPercentageValid(riceCount, LNCount) {
+        if (riceCount + LNCount === 0) return false;
+        return (LNCount / (riceCount + LNCount)) > MIN_LN_DENSITY;
+    }
+
+    /**
+     * 判断区块内 LN 时长覆盖是否超过阈值。
+     * 使用合并的 LN 区间避免重复计算。
+     */
+    function isLNDurationValid(noteStartIdx, noteEndIdx, blockStart, blockEnd, threshold) {
+        if (noteStartIdx === -1) return false;
+        const duration = computeLNDuration(p, blockStart, blockEnd, noteStartIdx, noteEndIdx);
+        return duration / (blockEnd - blockStart) > threshold;
+    }
+
+    /**
+     * 统计 [timeStart, timeEnd) 范围内的音符数量（从 startIndex 开始扫描）。
+     * 返回 {riceCount, lnCount, noteStartIdx, noteEndIdx, nextIndex}
+     */
+    function countNotesInRange(timeStart, timeEnd, startIndex) {
+        let rc = 0, ln = 0;
+        let noteStartIdx = -1, noteEndIdx = -1;
+        let idx = startIndex;
+        while (idx < p.columns.length && p.noteStarts[idx] < timeEnd) {
+            if (p.noteStarts[idx] >= timeStart) {
+                if ((p.noteTypes[idx] & 128) === 0) rc++; else ln++;
+                if (noteStartIdx === -1) noteStartIdx = idx;
+                noteEndIdx = idx;
+            }
+            idx++;
+        }
+        return { riceCount: rc, lnCount: ln, noteStartIdx, noteEndIdx, nextIndex: idx };
+    }
+
+    // 第一步：按单位长度步进，框出所有区间
+    const firstNoteTime = p.noteStarts[0];
+    const lastNoteTime = p.noteStarts[p.columns.length - 1];
+    let blockStart = firstNoteTime;
     let WindowList1 = new Array();
-    let j = 0; // 音符i在处理倍速后向后MIN_WINDOW_LENGTH毫秒内的最后一个音符的位置
-    for (let i = 0; i < p.columns.length; i += 1) {
-        /*
-        const k = p.columns[i];
-        let h = p.noteStarts[i];
-        let t = (p.noteTypes[i] & 128) !== 0 ? p.noteEnds[i] : -1;
-        h = Math.floor(h * timeScale);
-        t = t >= 0 ? Math.floor(t * timeScale) : t;
-        noteSeq.push([k, h, t]);
-        */
-        if (p.noteStarts[i] !== currentTime) {
-            currentTime = p.noteStarts[i];
-            while (j < p.columns.length) {
-                j++;
-                if (j >= p.columns.length) break;
-                if (p.noteStarts[j] > currentTime + MIN_WINDOW_LENGTH_AFTER_SCALE) {j--; break;}
-                if ((p.noteTypes[j] & 128) === 0) riceCount++; else LNCount++;
-            };
 
-            if (j >= p.columns.length) {
-                if (windowStartIndex !== -1) WindowList1.push([windowStartIndex, windowEndIndex]);
-                break;
-            } // 窗口够到了最后一个音符的开头，即所有音符都被尝试覆盖过了；这个break会跳出for循环
+    let scanIndex = 0;
 
-            if (windowStartIndex === -1 && isLNPercentageValid(riceCount, LNCount)) {
-                windowStartIndex = i;
-                windowEndIndex = j;
-            }
-            else if (windowStartIndex !== -1) {
-                if (isLNPercentageValid(riceCount, LNCount)) windowEndIndex = j;
-                else if (windowEndIndex !== -1) {
-                    WindowList1.push([windowStartIndex, windowEndIndex]);
-                    windowStartIndex = -1;
-                    windowEndIndex = -1;
-                }
-            }
+    while (blockStart <= lastNoteTime) {
+        const blockLen = getBlockLength(blockStart);
+        const blockEnd = blockStart + blockLen;
+
+        const block = countNotesInRange(blockStart, blockEnd, scanIndex);
+        scanIndex = block.nextIndex;
+
+        if (block.noteStartIdx === -1) {
+            blockStart = blockEnd;
+            continue;
         }
 
-        if ((p.noteTypes[i] & 128) === 0) riceCount--; else LNCount--; // 范围的开头离开了那个音符，减去对应的Count
+        if (isLNPercentageValid(block.riceCount, block.lnCount)) {
+            // 强区块：向后扩展，条件是下一个区块 >25% LN 时长 且 合并后 >20% LN 占比
+            let extendEnd = blockEnd;
+            let extendNoteEnd = block.noteEndIdx;
+            let accumRC = block.riceCount;
+            let accumLN = block.lnCount;
+
+            while (true) {
+                const nextStart = extendEnd;
+                const nextEnd = nextStart + getBlockLength(nextStart);
+                const peek = countNotesInRange(nextStart, nextEnd, scanIndex);
+
+                if (peek.noteStartIdx === -1) break;
+                // 基于时长判断：下一个区块 LN 时长覆盖 >25%？
+                if (!isLNDurationValid(peek.noteStartIdx, peek.noteEndIdx, nextStart, nextEnd, 0.25)) break;
+                // 合并后 LN 占比 >20%？
+                if (!isLNPercentageValid(accumRC + peek.riceCount, accumLN + peek.lnCount)) break;
+
+                extendEnd = nextEnd;
+                extendNoteEnd = peek.noteEndIdx;
+                accumRC += peek.riceCount;
+                accumLN += peek.lnCount;
+                scanIndex = peek.nextIndex;
+            }
+
+            WindowList1.push([block.noteStartIdx, extendNoteEnd]);
+            blockStart = extendEnd;
+        } else {
+            // 弱区块：窥视下一个区块，如果 LN 时长覆盖 >25% → 扩展1个单位
+            const nextStart = blockEnd;
+            const nextEnd = nextStart + getBlockLength(nextStart);
+            const peek = countNotesInRange(nextStart, nextEnd, scanIndex);
+
+            if (peek.noteStartIdx !== -1 && isLNDurationValid(peek.noteStartIdx, peek.noteEndIdx, nextStart, nextEnd, 0.25)) {
+                WindowList1.push([block.noteStartIdx, peek.noteEndIdx]);
+                scanIndex = peek.nextIndex;
+                blockStart = nextEnd;
+            } else {
+                scanIndex = peek.nextIndex;
+                blockStart = nextEnd;
+            }
+        }
     }
 
     if (WindowList1.length === 0) return WindowList1;
 
     // 第二步：合并区间
     let WindowList2 = new Array();
-    windowStartIndex = -1;
-    windowEndIndex = -1;
+    let windowStartIndex = -1;
+    let windowEndIndex = -1;
     for (let i = 0; i < WindowList1.length; i++) {
         if (windowStartIndex !== -1) {
-            if (WindowList1[i][0] <= windowEndIndex) {
+            if (WindowList1[i][0] <= windowEndIndex + 1) {
                 windowEndIndex = WindowList1[i][1];
-            } // 合并重合区间
-            else {
+            } else {
                 WindowList2.push([windowStartIndex, windowEndIndex]);
                 windowStartIndex = -1;
             }
         }
-        // 不要合并上下两个if，windowStartIndex被修改了
         if (windowStartIndex === -1) {
             windowStartIndex = WindowList1[i][0];
             windowEndIndex = WindowList1[i][1];
         }
-
         if (i + 1 >= WindowList1.length && windowStartIndex !== -1) {
-            WindowList2.push([windowStartIndex, windowEndIndex]); // 收尾
-            break;
+            WindowList2.push([windowStartIndex, windowEndIndex]);
         }
     }
     WindowList1 = null;
 
-    // 第三步：剔除米部分，目前剔除了最早的LN
+    // 第三步：剔除米部分 — 对每个窗口独立处理
     let WindowList3 = new Array();
-    windowStartIndex = -1;
-    windowEndIndex = -1;
-    let currentStartIndex = -1; // 等效于与当前note同一时间的最左边的note的index
-    currentTime = NaN;
-    let windowEndTime = -1e308;
-    j = 0; // WindowList2的index
-    for (let i = WindowList2[0][0]; i < p.columns.length; i += 1) {
-        if (p.noteStarts[i] !== currentTime) {
-            currentTime = p.noteStarts[i];
-            currentStartIndex = i;
-        }
-        if (i < WindowList2[j][0]) continue;
+    for (let w = 0; w < WindowList2.length; w++) {
+        const wStart = WindowList2[w][0];
+        const wEnd = WindowList2[w][1];
+        let windowStartIndex = -1;
+        let windowEndIndex = -1;
+        let currentStartIndex = -1;
+        let curTime = NaN;
+        let windowEndTime = -1e308;
 
-        if ((p.noteTypes[i] & 128) !== 0) {
-            if (windowStartIndex === -1) windowStartIndex = currentStartIndex;
-            windowEndTime = Math.max(windowEndTime, p.noteEnds[i]);
-            windowEndIndex = i;
-        }
-        else if (p.noteStarts[i] >= windowEndTime) {
-            windowEndIndex = i;
-        }
+        for (let i = wStart; i <= wEnd; i++) {
+            if (p.noteStarts[i] !== curTime) {
+                curTime = p.noteStarts[i];
+                currentStartIndex = i;
+            }
 
-        if (i >= WindowList2[j][1]) {
-            j++;
+            if ((p.noteTypes[i] & 128) !== 0) {
+                if (windowStartIndex === -1) windowStartIndex = currentStartIndex;
+                windowEndTime = Math.max(windowEndTime, p.noteEnds[i]);
+                windowEndIndex = i;
+            }
+            else if (p.noteStarts[i] >= windowEndTime) {
+                windowEndIndex = i;
+            }
+        }
+        if (windowStartIndex !== -1) {
             WindowList3.push([windowStartIndex, windowEndIndex]);
-            windowStartIndex = -1;
-            windowEndIndex = -1;
-            windowEndTime = -1e308;
-            if (j >= WindowList2.length) break;
         }
     }
 

--- a/ManiaMapAnalyser by Leo_Black/settings.json
+++ b/ManiaMapAnalyser by Leo_Black/settings.json
@@ -298,7 +298,7 @@
 			"Sunny",
 			"Daniel",
 			"Companella",
-			"SunnyWindow"
+			"Sunnywindow"
 		],
 		"value": "Mixed"
 	},

--- a/ManiaMapAnalyser by Leo_Black/settings.json
+++ b/ManiaMapAnalyser by Leo_Black/settings.json
@@ -297,7 +297,8 @@
 			"Roxy",
 			"Sunny",
 			"Daniel",
-			"Companella"
+			"Companella",
+			"SunnyWindow"
 		],
 		"value": "Mixed"
 	},

--- a/ManiaMapAnalyser by Leo_Black/settings.json
+++ b/ManiaMapAnalyser by Leo_Black/settings.json
@@ -297,8 +297,7 @@
 			"Roxy",
 			"Sunny",
 			"Daniel",
-			"Companella",
-			"Sunnywindow"
+			"Companella"
 		],
 		"value": "Mixed"
 	},
@@ -369,5 +368,13 @@
 		"description": "When enabled, Azusa always calls Sunny reference with cvtFlag=HO to remove LN inflation from partial LN maps.",
 		"options": [],
 		"value": true
+	},
+	{
+		"uniqueID": "enableLNRework",
+		"type": "checkbox",
+		"title": "LN Rework (Experimental)",
+		"description": "Extract LN-only segments and calculate the difficulty instead of treating all notes as a whole.",
+		"options": [],
+		"value": false
 	}
 ]


### PR DESCRIPTION
因为在设计用途上感到和[pull 31](https://github.com/LeoBlackMT/osumania_map_analyser/pull/31)稍微有一定不同所以决定单开一个了。

**首先，总体来说，它并不会改变rework星数，因此benchmark上应该是完全一致的。**
本项激进改动（LN Rework）旨在抑制RC（尤其是大段RC）对于LN难度计算的干扰。

工作思路的话，用了timing时间窗计算小节长，取了4小节去求（SV timing太复杂取了5s）。
按照平均不低于20%+延伸节LN长不低于25%（部分Collock的LN密度不高所以需要考虑）去求窗。
ReworkSR下 $$SR_{LN}> min(0.8\times SR_{RC}, SR_{LN5})$$ 才显示（即LN本身不水才显示）。

补充的是把它做到debug里面有个按钮，目前是作用于Azusa、Roxy、Sunny以及会调用它们结果的Mixed。
按钮开启后强制对全部谱面（而并非仅RC，因为发现这样可能更有用一点）使用`calculateLN`求其LN难度，各算法保持各自的RC难度映射不变，LN难度通过共享的ln4K表追加。

预期将显著改变被RC拉低其LN难度谱面的LN难度**示数**，但不会对星数产生影响。

在该极端例下，将5dan谱面和LN14按1:1混合，在Mixed下会得到alpha和LN11，但用本方法可测出LN14。
<img width="1920" height="1080" alt="ef49418d87641f96a897a62e5ec18683" src="https://github.com/user-attachments/assets/f9829729-7d93-4f94-a1d0-575742e2d82d" />

通过观察，部分LN谱面存在此类抑制情况，用该方法可以一定程度上改善。