### PR TITLE
feat(contentBar): multi-select card body via tosu commands + order-aware layout

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/config.js
+++ b/ManiaMapAnalyser by Leo_Black/config.js
@@ -3,7 +3,7 @@ export const APP_CONFIG = {
     socketHost: "localhost:24050",
 
     options: {
-        contentBar: ["None", "Auto", "Pattern", "Etterna", "Graph", "ReworkPP", "Full"],
+        contentBar: ["Pattern", "Etterna", "Graph", "ReworkPP"],
         srText: ["Auto", "ReworkSR", "MSD", "Pattern", "InterludeSR", "ReworkPP"],
         diffText: ["None", "Graph", "Difficulty", "MSD", "Pattern", "ReworkSR", "InterludeSR"],
         estimatorAlgorithm: ["Azusa", "Roxy", "Mixed", "Sunny", "Daniel", "Companella", "SunnyWindow"],
@@ -104,7 +104,8 @@ export const APP_CONFIG = {
         enableFloatingTriangles: true,
         enableCoverArt: true,
         customBackgroundColor: "#000000",
-        contentBar: "Auto",
+        autoContentBar: true,
+        contentBar: [],
         srText: "ReworkSR",
         diffText: "Difficulty",
         debugUseAmount: false,

--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -234,7 +234,12 @@ function shouldShowBodySkeletonDuringExpand(previousCardHeight, activeContentBar
         return false;
     }
 
-    if (activeContentBar !== "Pattern" && activeContentBar !== "Etterna" && activeContentBar !== "Full") {
+    if (Array.isArray(activeContentBar)) {
+        // 多选列表：仅在含 Pattern 或 Etterna 时启用骨架屏
+        if (!activeContentBar.includes("Pattern") && !activeContentBar.includes("Etterna")) {
+            return false;
+        }
+    } else if (activeContentBar !== "Pattern" && activeContentBar !== "Etterna" && activeContentBar !== "Full") {
         return false;
     }
 
@@ -361,16 +366,19 @@ export async function fetchBeatmapFile(reason) {
     try {
         let parsedInfo = null;
         let rawText = null;
-        // 谱面级内容栏 override：keycount 不受 Graph 支持时把主体降级为 Pattern（None/Full 除外）。
+        // 谱面级内容栏 override：keycount 不受 Graph 支持时从显示列表移除 Graph（保序）。
         const applyContentBarOverride = (columnCount) => {
             const parsedKeycount = Number(columnCount) || 0;
-            // In Full mode the graph block shows its own "Unsupported Keys" notice,
-            // so don't collapse the whole body to Pattern on unsupported keycounts.
-            const shouldFallbackBodyToPattern = parsedKeycount > 0
+            const activeList = Array.isArray(state.contentBar) ? state.contentBar : [];
+            const shouldDropGraph = parsedKeycount > 0
                 && !GRAPH_SUPPORTED_KEY_SET.has(parsedKeycount)
-                && state.contentBar !== "None"
-                && state.contentBar !== "Full";
-            setEffectiveContentBarForMap(shouldFallbackBodyToPattern ? "Pattern" : null);
+                && activeList.includes("Graph");
+            if (!shouldDropGraph) {
+                setEffectiveContentBarForMap(null);
+                return;
+            }
+            const nextList = activeList.filter((section) => section !== "Graph");
+            setEffectiveContentBarForMap(nextList);
         };
         if (cached) {
             parsedInfo = cached.parsedInfo;
@@ -893,7 +901,8 @@ export async function fetchBeatmapFile(reason) {
         }
 
         const fallbackModeTag = modeTagFromLnRatio(Number(rework?.lnRatio ?? parsedInfo.lnRatio));
-        let resolvedModeTag = (activeContentBar === "None")
+        const activeListForTag = Array.isArray(activeContentBar) ? activeContentBar : [];
+        let resolvedModeTag = (activeListForTag.length === 0)
             ? fallbackModeTag
             : (patternResult?.report?.ModeTag || fallbackModeTag);
         let shouldShowSvTag = false;
@@ -944,7 +953,7 @@ export async function fetchBeatmapFile(reason) {
             ) && !needPatternAnalysis;
 
             if (profileChanged && ((missingEtterna || missingPattern)
-                || state.contentBar !== beforeContent
+                || JSON.stringify(state.contentBar) !== JSON.stringify(beforeContent)
                 || state.srText !== beforeSrText)) {
                 scheduleRecompute("auto profile switched", false);
                 return;

--- a/ManiaMapAnalyser by Leo_Black/js/app/appContext.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/appContext.js
@@ -80,6 +80,7 @@ export const state = {
     classicMod: false,
     contentBar: APP_CONFIG.defaults.contentBar,
     effectiveContentBar: null,
+    autoContentBar: APP_CONFIG.defaults.autoContentBar,
     srText: APP_CONFIG.defaults.srText,
     userContentBar: APP_CONFIG.defaults.contentBar,
     userSrText: APP_CONFIG.defaults.srText,
@@ -236,7 +237,7 @@ export function getActiveContentBar() {
 
 export function contentBarShows(section) {
     const active = getActiveContentBar();
-    return active === section || active === "Full";
+    return Array.isArray(active) ? active.includes(section) : active === section;
 }
 
 export const GRAPH_VIEW_DEFS = [
@@ -293,5 +294,5 @@ export function isAutoSrTextEnabled() {
 }
 
 export function isAutoContentBarEnabled() {
-    return state.userContentBar === "Auto";
+    return state.autoContentBar === true;
 }

--- a/ManiaMapAnalyser by Leo_Black/js/app/settings.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/settings.js
@@ -47,7 +47,6 @@ import {
     patternClustersEl,
     ppBarsEl,
     reworkStarEl,
-    sepPpEl,
     socket,
     state,
     SETTINGS_COMMAND_TIMEOUT_MS,
@@ -55,7 +54,7 @@ import {
 } from "./appContext.js";
 import {
     normalizeBooleanSetting,
-    normalizeContentBarValue,
+    normalizeContentBarList,
     normalizeDiffTextValue,
     normalizeSrTextValue,
 } from "../parser/settingsParser.js";
@@ -80,21 +79,50 @@ import { clearResultCache } from "./resultCache.js";
 import { setTelemetryConfig } from "./telemetry.js";
 
 function isAutoDisplayEnabled() {
-    return state.userSrText === "Auto" || state.userContentBar === "Auto";
+    return state.userSrText === "Auto" || state.autoContentBar === true;
 }
 
 function resolveRuntimeDisplayProfile(modeTag = state.currentModeTag || "Mix") {
     const auto = resolveAutoDisplayProfile(modeTag);
     return {
-        contentBar: state.userContentBar === "Auto" ? auto.contentBar : state.userContentBar,
+        contentBar: state.autoContentBar === true ? [auto.contentBar] : state.userContentBar,
         srText: state.userSrText === "Auto" ? auto.srText : state.userSrText,
         diffText: state.userDiffText,
     };
 }
 
+// 每个主体区块的 grid item：separator + block 成对，顺序由数组下标决定。
+const CONTENT_BAR_SECTIONS = [
+    { section: "Pattern", sepEl: null, blockEl: null },
+    { section: "Etterna", sepEl: null, blockEl: null },
+    { section: "Graph", sepEl: null, blockEl: null },
+    { section: "ReworkPP", sepEl: null, blockEl: null },
+];
+
+function resolveContentBarSectionElements() {
+    const sepMap = {
+        Pattern: document.getElementById("sep-pattern"),
+        Etterna: document.getElementById("sep-etterna"),
+        Graph: document.getElementById("sep-graph"),
+        ReworkPP: document.getElementById("sep-pp"),
+    };
+    const blockMap = {
+        Pattern: patternClustersEl,
+        Etterna: ettSkillBarsEl,
+        Graph: bodyGraphWrapEl,
+        ReworkPP: ppBarsEl,
+    };
+    for (const entry of CONTENT_BAR_SECTIONS) {
+        entry.sepEl = sepMap[entry.section];
+        entry.blockEl = blockMap[entry.section];
+    }
+}
+
 function updateContentBarVisibility() {
     const activeContentBar = getActiveContentBar();
-    const isFull = activeContentBar === "Full";
+    const activeList = Array.isArray(activeContentBar) ? activeContentBar : [];
+    const count = activeList.length;
+    const isMulti = count >= 2;
 
     patternClustersEl.hidden = !contentBarShows("Pattern");
     ettSkillBarsEl.hidden = !contentBarShows("Etterna");
@@ -105,23 +133,29 @@ function updateContentBarVisibility() {
         ppBarsEl.hidden = !contentBarShows("ReworkPP");
     }
 
-    mainCardEl.classList.toggle("bars-full", isFull);
-    mainCardEl.classList.toggle("bars-pattern", !isFull && activeContentBar === "Pattern");
-    mainCardEl.classList.toggle("bars-etterna", !isFull && activeContentBar === "Etterna");
-    mainCardEl.classList.toggle("bars-graph", !isFull && activeContentBar === "Graph");
-    mainCardEl.classList.toggle("bars-pp", !isFull && activeContentBar === "ReworkPP");
-    mainCardEl.classList.toggle("bars-none", !isFull && activeContentBar === "None");
+    mainCardEl.classList.toggle("bars-multi", isMulti);
+    mainCardEl.classList.toggle("bars-pattern", !isMulti && count === 1 && activeList[0] === "Pattern");
+    mainCardEl.classList.toggle("bars-etterna", !isMulti && count === 1 && activeList[0] === "Etterna");
+    mainCardEl.classList.toggle("bars-graph", !isMulti && count === 1 && activeList[0] === "Graph");
+    mainCardEl.classList.toggle("bars-pp", !isMulti && count === 1 && activeList[0] === "ReworkPP");
+    mainCardEl.classList.toggle("bars-none", count === 0);
 
     if (!contentBarShows("Etterna")) {
         mainCardEl.classList.remove("bars-etterna-compact");
     }
 
-    const separatorEls = document.querySelectorAll(".full-separator");
-    separatorEls.forEach(el => {
-        el.hidden = !isFull;
-    });
-    if (sepPpEl) {
-        sepPpEl.hidden = !isFull;
+    // separator 仅多选时显示；按列表顺序给每个区块 (separator+block) 设 CSS order。
+    resolveContentBarSectionElements();
+    for (const entry of CONTENT_BAR_SECTIONS) {
+        const index = activeList.indexOf(entry.section);
+        const shown = index !== -1;
+        if (entry.sepEl) {
+            entry.sepEl.hidden = !(isMulti && shown);
+            entry.sepEl.style.order = String(index * 2 + 1);
+        }
+        if (entry.blockEl) {
+            entry.blockEl.style.order = String(index * 2 + 2);
+        }
     }
 }
 
@@ -399,9 +433,9 @@ export function applyEnableAlwaysShowLNDifficultySetting(value) {
 
 export function setRuntimeContentBar(contentBar) {
     const previousCardHeight = mainCardEl ? (Number(mainCardEl.getBoundingClientRect().height) || 0) : 0;
-    const normalized = normalizeContentBarValue(contentBar);
-    const nextBar = (!normalized || normalized === "Auto") ? "Pattern" : normalized;
-    const changed = state.contentBar !== nextBar;
+    // 入参为有序 section 数组（或旧字符串迁移）；空/非法 → 空列表（None）
+    const nextBar = normalizeContentBarList(contentBar, APP_CONFIG.options.contentBar);
+    const changed = !arraysEqual(state.contentBar, nextBar);
     state.contentBar = nextBar;
 
     if (!contentBarShows("Pattern")) {
@@ -434,9 +468,11 @@ export function setRuntimeContentBar(contentBar) {
 
 export function setEffectiveContentBarForMap(contentBarOrNull) {
     const previousCardHeight = mainCardEl ? (Number(mainCardEl.getBoundingClientRect().height) || 0) : 0;
-    const normalized = normalizeContentBarValue(contentBarOrNull);
-    const next = (!normalized || normalized === "Auto") ? null : normalized;
-    const changed = state.effectiveContentBar !== next;
+    // 谱面级覆盖：有序 section 数组；null 表示无覆盖
+    const next = contentBarOrNull == null
+        ? null
+        : normalizeContentBarList(contentBarOrNull, APP_CONFIG.options.contentBar);
+    const changed = !arraysEqual(state.effectiveContentBar, next);
     state.effectiveContentBar = next;
 
     if (!contentBarShows("Pattern")) {
@@ -455,6 +491,18 @@ export function setEffectiveContentBarForMap(contentBarOrNull) {
     }
 
     return changed;
+}
+
+// 数组内容比较（含 null 与空数组），避免引用比较误判。
+function arraysEqual(a, b) {
+    if (a === b) return true;
+    if (a == null || b == null) return false;
+    if (!Array.isArray(a) || !Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+        if (a[i] !== b[i]) return false;
+    }
+    return true;
 }
 
 export function setRuntimeSrText(srText) {
@@ -489,12 +537,26 @@ export function refreshAutoDisplayProfile(modeTag = state.currentModeTag || "Mix
 }
 
 export function applyContentBarSetting(contentBar) {
-    // 输入已由 parseContentBarValue 归一化并校验（contentBarSet 成员）——不再二次 normalize。
-    const nextBar = contentBar || "Pattern";
-    const changed = state.userContentBar !== nextBar;
+    // 输入已由 parseContentBarValue 归一化并校验——有序 section 数组（可空）。
+    const nextBar = Array.isArray(contentBar) ? contentBar : [];
+    const changed = !arraysEqual(state.userContentBar, nextBar);
     state.userContentBar = nextBar;
 
-    if (state.userContentBar === "Auto") {
+    if (state.autoContentBar === true) {
+        refreshAutoDisplayProfile();
+    } else {
+        setRuntimeContentBar(state.userContentBar);
+    }
+
+    return changed;
+}
+
+export function applyAutoContentBarSetting(value) {
+    const next = normalizeBooleanSetting(value, APP_CONFIG.defaults.autoContentBar);
+    const changed = state.autoContentBar !== next;
+    state.autoContentBar = next;
+
+    if (state.autoContentBar === true) {
         refreshAutoDisplayProfile();
     } else {
         setRuntimeContentBar(state.userContentBar);
@@ -762,6 +824,7 @@ export function setupSettingsCommandListener() {
         state.settingsReceivedFromCommand = true;
         const wsEndpointChanged = applyIf("wsEndpoint", applyWsEndpointSetting, parseWsEndpointValue(payload));
         const contentBarChanged = applyIf("contentBar", applyContentBarSetting, parseContentBarValue(payload));
+        const autoContentBarChanged = applyIf("autoContentBar", applyAutoContentBarSetting, parseAutoContentBarValue(payload));
         const srTextChanged = applyIf("srText", applySrTextSetting, parseSrTextValue(payload));
         const debugChanged = applyIf("debugUseAmount", applyDebugUseAmountSetting, parseDebugUseAmountValue(payload));
         const diffTextChanged = applyIf("diffText", applyDiffTextSetting, parseDiffTextValue(payload));
@@ -800,11 +863,12 @@ export function setupSettingsCommandListener() {
         const legacyAutoMode = parseAutoModeValue(payload);
         if (legacyAutoMode && !isAutoDisplayEnabled()) {
             state.userSrText = "Auto";
-            state.userContentBar = "Auto";
+            state.autoContentBar = true;
             refreshAutoDisplayProfile();
         }
 
         const changed = contentBarChanged
+            || autoContentBarChanged
             || wsEndpointChanged
             || srTextChanged
             || debugChanged
@@ -842,6 +906,7 @@ export function setupSettingsCommandListener() {
             || enableTelemetryChanged;
 
         const recomputeNeeded = contentBarChanged
+            || autoContentBarChanged
             || srTextChanged
             || debugChanged
             || diffTextChanged
@@ -941,6 +1006,7 @@ export async function loadSettings() {
     function applySettingsFrom(source) {
         applyWsEndpointSetting(parseWsEndpointValue(source));
         applyContentBarSetting(parseContentBarValue(source));
+        applyAutoContentBarSetting(parseAutoContentBarValue(source));
         applySrTextSetting(parseSrTextValue(source));
         applyDebugUseAmountSetting(parseDebugUseAmountValue(source));
         applyDiffTextSetting(parseDiffTextValue(source));
@@ -984,6 +1050,7 @@ export async function loadSettings() {
         // File unavailable — apply config defaults as fallback
         applySettingsFrom({
             wsEndpoint: APP_CONFIG.defaults.wsEndpoint || APP_CONFIG.socketHost,
+            autoContentBar: APP_CONFIG.defaults.autoContentBar,
             contentBar: APP_CONFIG.defaults.contentBar,
             srText: APP_CONFIG.defaults.srText,
             debugUseAmount: APP_CONFIG.defaults.debugUseAmount,

--- a/ManiaMapAnalyser by Leo_Black/js/parser/settingsParser.js
+++ b/ManiaMapAnalyser by Leo_Black/js/parser/settingsParser.js
@@ -18,6 +18,40 @@ export function normalizeContentBarValue(value) {
     return null;
 }
 
+// 将 commands 类型的 contentBar 值（有序数组）或旧版字符串值规范化为
+// 有序的合法 section 数组。保序：数组顺序即前端显示顺序。
+// - 数组：逐项取 item.section，校验 ∈ 候选集，保序收集，非法项丢弃。
+// - 旧字符串：迁移映射（"Full"→4 元素全选、"None"→[]、单值→单元素数组）。
+export function normalizeContentBarList(value, candidates) {
+    const sectionSet = createSet(candidates);
+
+    if (Array.isArray(value)) {
+        const result = [];
+        for (const item of value) {
+            const section = item && typeof item === "object" ? item.section : null;
+            const normalized = normalizeContentBarValue(section);
+            if (normalized && sectionSet.has(normalized.toLowerCase()) && !result.includes(normalized)) {
+                result.push(normalized);
+            }
+        }
+        return result;
+    }
+
+    if (typeof value === "string") {
+        const normalized = normalizeContentBarValue(value);
+        if (!normalized) return [];
+        if (normalized === "Full") {
+            return ["Pattern", "Etterna", "Graph", "ReworkPP"].filter(
+                (section) => sectionSet.has(section.toLowerCase())
+            );
+        }
+        if (normalized === "None" || normalized === "Auto") return [];
+        return sectionSet.has(normalized.toLowerCase()) ? [normalized] : [];
+    }
+
+    return [];
+}
+
 export function normalizeSrTextValue(value) {
     if (typeof value !== "string") {
         return null;
@@ -233,7 +267,6 @@ export function extractSettingValue(settingsPayload, settingKey) {
 }
 
 export function createSettingsParsers(appConfig) {
-    const contentBarSet = createSet(appConfig?.options?.contentBar);
     const srTextSet = createSet(appConfig?.options?.srText);
     const diffTextSet = createSet(appConfig?.options?.diffText);
     const estimatorAlgorithmSet = createSet(appConfig?.options?.estimatorAlgorithm);
@@ -269,13 +302,22 @@ export function createSettingsParsers(appConfig) {
 
     function parseContentBarValue(settingsPayload) {
         const value = extractSettingValue(settingsPayload, "contentBar");
-        const normalized = normalizeContentBarValue(value);
-        if (normalized && contentBarSet.has(normalized.toLowerCase())) {
-            return normalized;
+        if (value !== undefined && value !== null) {
+            // commands 数组（保序）或旧字符串（迁移）→ 有序合法 section 数组
+            return normalizeContentBarList(value, appConfig.options.contentBar);
         }
 
+        // legacy enablePatternAnalysis fallback（旧版设置格式，无 contentBar 键时）
         const enabled = parseEnablePatternValue(settingsPayload);
-        return enabled ? "Pattern" : "None";
+        return enabled ? ["Pattern"] : [];
+    }
+
+    function parseAutoContentBarValue(settingsPayload) {
+        const value = extractSettingValue(settingsPayload, "autoContentBar");
+        if (value === undefined || value === null) {
+            return appConfig.defaults.autoContentBar;
+        }
+        return normalizeBooleanSetting(value, appConfig.defaults.autoContentBar);
     }
 
     function parseSrTextValue(settingsPayload) {
@@ -572,6 +614,7 @@ export function createSettingsParsers(appConfig) {
     return {
         parseEnablePatternValue,
         parseContentBarValue,
+        parseAutoContentBarValue,
         parseSrTextValue,
         parseDebugUseAmountValue,
         parseDiffTextValue,

--- a/ManiaMapAnalyser by Leo_Black/settings.json
+++ b/ManiaMapAnalyser by Leo_Black/settings.json
@@ -48,20 +48,39 @@
 		"value": ""
 	},
 	{
+		"uniqueID": "autoContentBar",
+		"type": "checkbox",
+		"title": "Auto Card Body Content",
+		"description": "Automatically pick the card body based on the map mode. Disable to choose your own sections below.",
+		"options": [],
+		"value": true
+	},
+	{
 		"uniqueID": "contentBar",
-		"type": "options",
+		"type": "commands",
 		"title": "Card Body Content",
-		"description": "Select what to show in the card body. Full shows Pattern, Etterna and Graph together.",
+		"description": "One section per row, shown in row order. Add rows to show multiple sections; remove all rows to show nothing.",
 		"options": [
-			"None",
-			"Auto",
-			"Pattern",
-			"Etterna",
-			"Graph",
-			"ReworkPP",
-			"Full"
+			{
+				"type": "options",
+				"name": "section",
+				"title": "Content Section",
+				"description": "",
+				"values": [
+					"Pattern",
+					"Etterna",
+					"Graph",
+					"ReworkPP"
+				],
+				"value": "Pattern"
+			}
 		],
-		"value": "Auto"
+		"value": [
+			{
+				"section": "Pattern"
+			}
+		],
+		"uniqueCheck": "section"
 	},
 	{
 		"uniqueID": "srText",

--- a/ManiaMapAnalyser by Leo_Black/styles/card-modes.css
+++ b/ManiaMapAnalyser by Leo_Black/styles/card-modes.css
@@ -11,9 +11,11 @@
     overflow: hidden;
 }
 
-/* Full mode: show Pattern + Etterna + Graph stacked together.
-   Height grows to fit all three blocks; nothing is compressed or scrolled. */
-.main-card.bars-full {
+/* Multi mode (2+ sections): show selected blocks stacked together.
+   Height grows to fit all blocks; nothing is compressed or scrolled.
+   bars-full kept as alias for migration compatibility. */
+.main-card.bars-full,
+.main-card.bars-multi {
     grid-template-rows: none;
     grid-auto-rows: auto;
     align-content: start;
@@ -25,23 +27,27 @@
 }
 
 .main-card.bars-full .cluster-bars,
-.main-card.bars-full .ett-skill-bars {
+.main-card.bars-multi .cluster-bars,
+.main-card.bars-full .ett-skill-bars,
+.main-card.bars-multi .ett-skill-bars {
     overflow-x: hidden;
     overflow-y: visible;
     max-height: none;
 }
 
-.main-card.bars-full .body-graph-wrap {
+.main-card.bars-full .body-graph-wrap,
+.main-card.bars-multi .body-graph-wrap {
     width: 100%;
     margin: 0 auto 28px;
 }
 
-/* Full mode section separators — hr-like with centered text */
+/* Multi mode section separators — hr-like with centered text */
 .full-separator {
     display: none;
 }
 
-.main-card.bars-full .full-separator {
+.main-card.bars-full .full-separator,
+.main-card.bars-multi .full-separator {
     display: flex;
     align-items: center;
     gap: 8px;
@@ -56,7 +62,9 @@
 }
 
 .main-card.bars-full .full-separator::before,
-.main-card.bars-full .full-separator::after {
+.main-card.bars-multi .full-separator::before,
+.main-card.bars-full .full-separator::after,
+.main-card.bars-multi .full-separator::after {
     content: "";
     flex: 1;
     height: 1px;
@@ -256,8 +264,9 @@
     overflow-wrap: anywhere;
 }
 
-/* Full 模式：pp 块不内部滚动，随卡片高度生长全部展开 */
-.main-card.bars-full .pp-bars {
+/* Full/Multi 模式：pp 块不内部滚动，随卡片高度生长全部展开 */
+.main-card.bars-full .pp-bars,
+.main-card.bars-multi .pp-bars {
     overflow-x: hidden;
     overflow-y: visible;
     max-height: none;

--- a/ManiaMapAnalyser by Leo_Black/styles/responsive.css
+++ b/ManiaMapAnalyser by Leo_Black/styles/responsive.css
@@ -58,6 +58,15 @@
         max-height: none;
     }
 
+    .main-card.bars-multi {
+        grid-template-rows: none;
+        grid-auto-rows: auto;
+        align-content: start;
+        height: auto;
+        min-height: 540px;
+        max-height: none;
+    }
+
     .star-value {
         font-size: 40px;
     }

--- a/ManiaMapAnalyser by Leo_Black/styles/status.css
+++ b/ManiaMapAnalyser by Leo_Black/styles/status.css
@@ -193,8 +193,10 @@
     color: #ff9f9f;
 }
 
-/* Full mode: slight upward shift to avoid graph overlap */
+/* Full/Multi mode: slight upward shift to avoid graph overlap */
 .main-card.bars-full .mode-tag-group,
-.main-card.bars-full .pause-count {
+.main-card.bars-multi .mode-tag-group,
+.main-card.bars-full .pause-count,
+.main-card.bars-multi .pause-count {
     bottom: 12px;
 }

--- a/ManiaMapAnalyser by Leo_Black/styles/theme.css
+++ b/ManiaMapAnalyser by Leo_Black/styles/theme.css
@@ -161,10 +161,10 @@ html.ma-theme-osu #pattern-clusters.cluster-bars {
 
 /* 谱面背景图 + 压暗罩层：罩层在上、封面在下。封面是 .ma-fx-cover 专属特性，
    且依赖上面 .ma-theme-osu 给块的 position:relative 才能正确定位，故双 class 限定。 */
-html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full) #pattern-clusters.cluster-bars::before,
-html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full) #ett-skill-bars.ett-skill-bars:not([hidden])::before,
-html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full) #pp-bars.pp-bars:not([hidden])::before,
-html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full) #body-graph-wrap:not([hidden])::before {
+html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full):not(.bars-multi) #pattern-clusters.cluster-bars::before,
+html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full):not(.bars-multi) #ett-skill-bars.ett-skill-bars:not([hidden])::before,
+html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full):not(.bars-multi) #pp-bars.pp-bars:not([hidden])::before,
+html.ma-theme-osu.ma-fx-cover .main-card:not(.bars-full):not(.bars-multi) #body-graph-wrap:not([hidden])::before {
     content: "";
     position: absolute;
     /* 高斯模糊会向元素外采样透明像素，导致边缘透出块底色，所以按模糊半径把伪元素
@@ -192,10 +192,11 @@ html.ma-theme-osu.ma-fx-cover #body-graph-wrap > * {
     z-index: 1;
 }
 
-/* Full mode: single shared background across all three content blocks.
+/* Full/Multi mode: single shared background across all content blocks.
    The ::before always exists (content:"") so opacity transitions work smoothly.
    Visibility is controlled by opacity — ma-fx-cover toggles it between 0 and 1. */
-html.ma-theme-osu .main-card.bars-full::before {
+html.ma-theme-osu .main-card.bars-full::before,
+html.ma-theme-osu .main-card.bars-multi::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -214,7 +215,8 @@ html.ma-theme-osu .main-card.bars-full::before {
     opacity: 0;
     transition: opacity 250ms ease;
 }
-html.ma-theme-osu.ma-fx-cover .main-card.bars-full::before {
+html.ma-theme-osu.ma-fx-cover .main-card.bars-full::before,
+html.ma-theme-osu.ma-fx-cover .main-card.bars-multi::before {
     opacity: 1;
 }
 
@@ -280,13 +282,17 @@ html.ma-theme-osu #body-graph-wrap:not([hidden]) {
     box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.18);
 }
 
-/* Full mode: make section backgrounds transparent so the shared ::before
+/* Full/Multi mode: make section backgrounds transparent so the shared ::before
    cover background (gradient + cover image) on .card.main-card shows through.
    The gradient overlay on ::before already provides sufficient dimming. */
 html.ma-theme-osu.ma-fx-cover .main-card.bars-full #pattern-clusters.cluster-bars,
+html.ma-theme-osu.ma-fx-cover .main-card.bars-multi #pattern-clusters.cluster-bars,
 html.ma-theme-osu.ma-fx-cover .main-card.bars-full #ett-skill-bars.ett-skill-bars,
+html.ma-theme-osu.ma-fx-cover .main-card.bars-multi #ett-skill-bars.ett-skill-bars,
 html.ma-theme-osu.ma-fx-cover .main-card.bars-full #pp-bars.pp-bars,
-html.ma-theme-osu.ma-fx-cover .main-card.bars-full #body-graph-wrap:not([hidden]) {
+html.ma-theme-osu.ma-fx-cover .main-card.bars-multi #pp-bars.pp-bars,
+html.ma-theme-osu.ma-fx-cover .main-card.bars-full #body-graph-wrap:not([hidden]),
+html.ma-theme-osu.ma-fx-cover .main-card.bars-multi #body-graph-wrap:not([hidden]) {
     background-color: transparent;
 }
 

--- a/docs/breakings/2026-08-15-contentbar-multi.md
+++ b/docs/breakings/2026-08-15-contentbar-multi.md
@@ -1,0 +1,134 @@
+# 2026-08-15 contentBar 多选改造（commands 类型）
+
+> 重大破坏性更改说明 / Major breaking-change note. Bilingual, five elements.
+
+## 修改内容（What changed）
+
+- `contentBar`（Card Body Content）设置从**单选项（options）**改为 tosu **`commands`** 类型：
+  用户可添加多行，每行从 Pattern / Etterna / Graph / ReworkPP 中选择一个 section，
+  **行顺序 = 前端显示顺序**；`uniqueCheck: "section"` 阻止重复。
+- 删除 `"Full"`、`"None"`、`"Auto"` 三个旧选项值；新增独立 checkbox `autoContentBar`
+  （默认 true）：勾选时忽略列表、按谱面 mode 自动选择单一主体（RC→Etterna，其余→Pattern）；
+  关闭时使用列表，**空列表 = None（不显示主体）**。
+- 内部数据模型：`state.contentBar` / `state.effectiveContentBar` / `state.userContentBar`
+  由单字符串改为**有序数组 `string[]`**；`contentBarShows(section)` 改为
+  `getActiveContentBar().includes(section)`。
+- 显示顺序实现：DOM 不变，`updateContentBarVisibility` 按列表顺序为 8 个 grid item
+  （4 个 separator + 4 个 block）设置 CSS `order`；多选（≥2 项）启用新布局类 `bars-multi`
+  （复用原 `bars-full` 的高度自适应堆叠），单块保留 `bars-pattern/etterna/graph/pp`，
+  空列表用 `bars-none`。
+- 非 4/6/7K 谱面：主体 override 从"整体降级为 Pattern"改为"**从列表移除 Graph**（保序）"。
+- `resolvedModeTag`：`activeContentBar === "None"` 特判改为 `activeContentBar.length === 0`。
+- Auto 切换检测：`state.contentBar !== beforeContent` 引用比较改为 `JSON.stringify` 序列化比较。
+
+## 修改原因（Why）
+
+用户希望自由组合卡片主体内容（任意多个 section 同时显示）并自定义顺序，旧单选
++ Full 固定布局无法满足。tosu 的 `commands` 是唯一支持动态多行值的设置类型；
+其 `options` 子字段可声明为 `type:"options"` 下拉，天然满足"每行选一个 section"。
+顺序要求决定了数据模型必须保序（数组而非 Set）。
+
+## 影响范围（Scope）
+
+- 设置定义与解析：`settings.json`、`config.js`、`js/parser/settingsParser.js`。
+- 状态与显示：`js/app/appContext.js`（`contentBarShows`/`isAutoContentBarEnabled`）、
+  `js/app/settings.js`（apply/visibility/order/legacy autoMode）、`js/app/analysis.js`
+  （override/resolvedModeTag/Auto 切换检测）。
+- 样式：`styles/card-modes.css`、`theme.css`、`status.css`、`responsive.css`（`bars-multi`）。
+- 缓存：`contentBar`/`autoContentBar` 属"特殊显示类"——只改变 `needComputed` 布尔集，
+  由命中覆盖检查处理，**不加入 `clearResultCache()` 失效列表**；`autoContentBarChanged`
+  加入 `recomputeNeeded` 触发按需重算。
+- 共享模块（estimator/parser/ett/patterns/pipeline）**零改动**，Benchmark runner 不受影响。
+
+## 兼容策略（Compat）
+
+- 旧值迁移（`parseContentBarValue`/`normalizeContentBarList`）：
+  `"Full"` → 四元素全选数组；`"None"` → `[]`；`"Auto"` → `[]`（由 `autoContentBar=true`
+  默认恢复自动行为）；`"Pattern"/"Etterna"/"Graph"/"ReworkPP"` → 单元素数组。
+- 旧 `enablePatternAnalysis` fallback：true → `["Pattern"]`，false → `[]`。
+- 旧 `autoMode` 强制路径：写 `autoContentBar=true`（原写 `userContentBar="Auto"`）。
+- `bars-full` CSS 类保留为迁移别名（与 `bars-multi` 共用规则）。
+
+## 验证方式（Verification）
+
+- 解析冒烟（temp/contentbar-smoke.mjs）：**24/24 PASS**——保序、去重、非法项丢弃、
+  旧字符串迁移（Full/None/Auto/单值）、`enablePatternAnalysis` fallback、
+  `autoContentBar` 默认值、`contentBarShows` 多选/空/单元素语义。
+- 语法检查：`node --check` 全部通过（settings.js/analysis.js/appContext.js/settingsParser.js/config.js）。
+- settings.json：`ConvertFrom-Json` 校验通过（47 条目，contentBar=commands、autoContentBar=checkbox）。
+- 版本核对：`index.js` `_VERSION` == `metadata.txt` Version == **1.7.4**。
+- 浏览器实测（实施时执行）：增删行、uniqueCheck 提示、Auto 切换、None 空态、
+  多选 separator 与顺序断言（getBoundingClientRect）、非 4/6/7K Graph 移除、
+  缓存命中/重算无陈旧。
+
+---
+
+# English
+
+## What changed
+
+- `contentBar` (Card Body Content) changed from single-choice `options` to tosu
+  **`commands`** type: users add rows, each row picks one section from
+  Pattern / Etterna / Graph / ReworkPP, **row order = display order**;
+  `uniqueCheck: "section"` prevents duplicates.
+- Removed legacy `"Full"`, `"None"`, `"Auto"` option values; added independent
+  checkbox `autoContentBar` (default true): when on, the list is ignored and the
+  body is auto-picked by map mode (RC→Etterna, else→Pattern); when off, the list
+  is used, and **an empty list means None (no body)**.
+- Internal model: `state.contentBar` / `state.effectiveContentBar` /
+  `state.userContentBar` changed from single string to **ordered `string[]`**;
+  `contentBarShows(section)` → `getActiveContentBar().includes(section)`.
+- Display order: DOM unchanged; `updateContentBarVisibility` sets CSS `order` on
+  the 8 grid items (4 separators + 4 blocks) by list position; multi-select
+  (≥2) uses new `bars-multi` layout class (reuses `bars-full` adaptive stacking),
+  single block keeps `bars-pattern/etterna/graph/pp`, empty list uses `bars-none`.
+- Non-4/6/7K beatmaps: body override changed from "collapse whole body to Pattern"
+  to "**remove Graph from the list** (order preserved)".
+- `resolvedModeTag`: `activeContentBar === "None"` check → `activeContentBar.length === 0`.
+- Auto-switch detection: `state.contentBar !== beforeContent` reference compare →
+  `JSON.stringify` serialized compare.
+
+## Why
+
+Users want to freely combine multiple card-body sections with custom order; the
+old single-choice + fixed Full layout cannot express that. tosu `commands` is
+the only setting type supporting dynamic multi-row values, and its `options`
+sub-field can be declared as a dropdown — naturally "one section per row". The
+order requirement dictates an order-preserving array model (not a Set).
+
+## Scope
+
+- Settings definition/parsing: `settings.json`, `config.js`, `js/parser/settingsParser.js`.
+- State & display: `js/app/appContext.js` (`contentBarShows`/`isAutoContentBarEnabled`),
+  `js/app/settings.js` (apply/visibility/order/legacy autoMode), `js/app/analysis.js`
+  (override/resolvedModeTag/Auto-switch detection).
+- Styles: `styles/card-modes.css`, `theme.css`, `status.css`, `responsive.css` (`bars-multi`).
+- Cache: `contentBar`/`autoContentBar` are "special display-class" settings — they
+  only change the `needComputed` booleans, handled by the hit coverage check;
+  **not added to `clearResultCache()`**; `autoContentBarChanged` joins
+  `recomputeNeeded` for on-demand recompute.
+- Shared modules (estimator/parser/ett/patterns/pipeline) untouched — Benchmark
+  runner unaffected.
+
+## Compatibility
+
+- Legacy migration (`parseContentBarValue`/`normalizeContentBarList`):
+  `"Full"` → 4-element array; `"None"` → `[]`; `"Auto"` → `[]` (default
+  `autoContentBar=true` restores auto behavior); single values → 1-element array.
+- Legacy `enablePatternAnalysis` fallback: true → `["Pattern"]`, false → `[]`.
+- Legacy `autoMode` force path writes `autoContentBar=true` (was `userContentBar="Auto"`).
+- `bars-full` CSS kept as migration alias (shared rules with `bars-multi`).
+
+## Verification
+
+- Parse smoke (temp/contentbar-smoke.mjs): **24/24 PASS** — order preserved,
+  dedupe, invalid-item drop, legacy string migration (Full/None/Auto/single),
+  `enablePatternAnalysis` fallback, `autoContentBar` default, `contentBarShows`
+  multi/empty/single semantics.
+- Syntax: `node --check` passes for all modified JS files.
+- settings.json: `ConvertFrom-Json` OK (47 entries, contentBar=commands,
+  autoContentBar=checkbox).
+- Version: `index.js` `_VERSION` == `metadata.txt` Version == **1.7.4**.
+- Browser checks (during implementation): add/remove rows, uniqueCheck prompt,
+  Auto toggle, None empty state, multi separators and order assertion
+  (getBoundingClientRect), non-4/6/7K Graph removal, cache hit/recompute freshness.

--- a/docs/breakings/README.md
+++ b/docs/breakings/README.md
@@ -17,6 +17,7 @@
 | 文档 | 日期 | 分支/主题 | 说明 |
 | --- | --- | --- | --- |
 | [2026-08-09-perf-analysis-pipeline.md](2026-08-09-perf-analysis-pipeline.md) | 2026-08-09 | perf/analysis-pipeline-optimization | 分析管线性能优化：worker 单次往返协议、runAnalysisPipeline 纯函数、共享模块纯度（worker 根因修复）、缓存失效收窄与命中重派生、vibro 修复披露、perf 验收口径修订（12 项） |
+| [2026-08-15-contentbar-multi.md](2026-08-15-contentbar-multi.md) | 2026-08-15 | feat/contentbar-commands | contentBar 多选改造：commands 类型、行序=显示顺序、autoContentBar 独立开关、空列表=None、bars-multi 布局、非 4/6/7K Graph 移除（五要素双语） |
 
 [返回 docs 索引](../README.md)
 
@@ -41,5 +42,6 @@
 | Document | Date | Branch/Topic | Description |
 | --- | --- | --- | --- |
 | [2026-08-09-perf-analysis-pipeline.md](2026-08-09-perf-analysis-pipeline.md) | 2026-08-09 | perf/analysis-pipeline-optimization | Analysis pipeline optimization: worker single-round-trip protocol, runAnalysisPipeline pure function, shared-module purity (worker root-cause fix), cache invalidation narrowing + hit re-derivation, vibro fix disclosure, perf acceptance-criteria revision (12 items) |
+| [2026-08-15-contentbar-multi.md](2026-08-15-contentbar-multi.md) | 2026-08-15 | feat/contentbar-commands | contentBar multi-select: commands type, row order = display order, standalone autoContentBar toggle, empty list = None, bars-multi layout, non-4/6/7K Graph removal (five elements, bilingual) |
 
 [Back to docs index](../README.md)

--- a/docs/features/graph-visualization.md
+++ b/docs/features/graph-visualization.md
@@ -16,7 +16,7 @@
 | body（主体图） | `body-graph` 系列元素 | `state.contentBar`（或 `effectiveContentBar`）包含 Graph | 卡片主体 |
 
 - `state.diffText`（右上角内容）与 `state.contentBar`（主体内容）的设置语义见 [settings.md](../settings.md) 的 "Graph: 显示难度变化图"（`settings.md:13`）与右上角 Graph 选项说明（`settings.md:24`）。
-- **非 4/6/7K 谱面图表不可用**：`ManiaMapAnalyser by Leo_Black/js/app/appContext.js:180 GRAPH_SUPPORTED_KEY_SET`（`new Set([4, 6, 7])`）。分析管线在 `analysis.js:328` / `analysis.js:354` 用其判断是否需要把主体回退为 Pattern；渲染入口 `analysis.js:567` 对不支持键数直接调用 `showDiffGraphError("Unsupported Keys")`。
+- **非 4/6/7K 谱面图表不可用**：`ManiaMapAnalyser by Leo_Black/js/app/appContext.js:186 GRAPH_SUPPORTED_KEY_SET`（`new Set([4, 6, 7])`）。分析管线在 `analysis.js:370 applyContentBarOverride` 用其把 Graph 从 contentBar 显示列表**移除**（保序保留其余，2026-08-15 起；此前为整体回退 Pattern）；渲染入口 `analysis.js:571` 对不支持键数直接调用 `showDiffGraphError("Unsupported Keys")`。
 
 ## 2. DOM 引用与视图定义（GRAPH_VIEW_DEFS）
 
@@ -32,11 +32,11 @@
 `appContext.js:237 GRAPH_VIEW_DEFS` 是视图定义的统一描述数组，每个视图含 `key`、各 DOM ref 字段与 `isEnabled()` 判定：
 
 - header 视图：`isEnabled: () => state.diffText === "Graph"`（`appContext.js:250`）。
-- body 视图：`isEnabled: () => contentBarShows("Graph")`（`appContext.js:264`，内部经 `appContext.js:232 contentBarShows` → `appContext.js:228 getActiveContentBar` 读取 `effectiveContentBar || contentBar`）。
+- body 视图：`isEnabled: () => contentBarShows("Graph")`（`appContext.js:268`，内部经 `appContext.js:238 contentBarShows` → `appContext.js:234 getActiveContentBar` 读取 `effectiveContentBar || contentBar`，多选有序数组 `includes` 判定）。
 
 遍历工具：
 
-- `appContext.js:268 hasAnyGraphModeEnabled()`：`diffText === "Graph" || contentBarShows("Graph")`，用于判断图表功能整体是否激活。
+- `appContext.js:273 hasAnyGraphModeEnabled()`：`diffText === "Graph" || contentBarShows("Graph")`，用于判断图表功能整体是否激活。
 - `appContext.js:272 forEachGraphView(callback)`：无条件遍历两个视图（清空、重置等必须覆盖隐藏视图的场合）。
 - `appContext.js:278 forEachEnabledGraphView(callback)`：只遍历 `isEnabled()` 为真的视图（渲染、游标更新等仅对可见视图生效的场合）。
 

--- a/docs/features/mode-tagging.md
+++ b/docs/features/mode-tagging.md
@@ -60,7 +60,7 @@ let resolvedModeTag = (activeContentBar === "None")
 ```
 
 - `analysis.js:792` — 回退标签来自 `modeTagFromLnRatio`，输入优先取 rework 结果的 `lnRatio`，取不到再用解析器 `parsedInfo.lnRatio`。
-- `analysis.js:793-795` — 当 contentBar 为 `"None"` 时只用回退标签（此时不展示键型分析区，避免依赖 pattern 报告）；否则优先取 `patternResult.report.ModeTag`（`summary.js:74 ModeTag: modeTag`），缺失时回退。
+- `analysis.js:903-906` — 当 contentBar 显示列表为空（`activeContentBar.length === 0`，即 None）时只用回退标签（此时不展示键型分析区，避免依赖 pattern 报告）；否则优先取 `patternResult.report.ModeTag`（`summary.js:74 ModeTag: modeTag`），缺失时回退。
 
 ### 2.3 Mixed 估算器内的标签使用
 
@@ -85,11 +85,11 @@ let resolvedModeTag = (activeContentBar === "None")
 - `modeLogic.js:32-37` — `modeTag === "RC"` → `{ contentBar: "Etterna", srText: "MSD" }`（RC 谱面自动展示 Etterna 技能条 + MSD）
 - `modeLogic.js:39-42` — 其他（LN/HB/Mix）→ `{ contentBar: "Pattern", srText: "ReworkSR" }`
 
-调用链（仅当用户将 `contentBar` 或 `srText` 设为 `"Auto"` 时生效）：
+调用链（仅当 `autoContentBar` 开启或 `srText` 设为 `"Auto"` 时生效）：
 
-- `ManiaMapAnalyser by Leo_Black/js/app/settings.js:84 isAutoDisplayEnabled()` — 任一 user 字段为 "Auto" 即开启。
-- `settings.js:88 resolveRuntimeDisplayProfile(modeTag)` — 将 Auto 字段替换为 `resolveAutoDisplayProfile` 的输出，非 Auto 字段保持用户选择。
-- `settings.js:473 refreshAutoDisplayProfile(modeTag = state.currentModeTag || "Mix")` — 运行时刷新入口；在 `analysis.js:829` 每次分析完成后调用（`refreshAutoDisplayProfile(resolvedModeTag)`），以及在 `settings.js:484`/`:498` 用户设置变更时调用。
+- `ManiaMapAnalyser by Leo_Black/js/app/settings.js:82 isAutoDisplayEnabled()` — `userSrText === "Auto" || state.autoContentBar === true` 即开启。
+- `settings.js:86 resolveRuntimeDisplayProfile(modeTag)` — 将 Auto 字段替换为 `resolveAutoDisplayProfile` 的输出（contentBar 包成单元素数组 `[auto.contentBar]`），非 Auto 字段保持用户选择。
+- `settings.js:535 refreshAutoDisplayProfile(modeTag = state.currentModeTag || "Mix")` — 运行时刷新入口；在 `analysis.js:829` 每次分析完成后调用（`refreshAutoDisplayProfile(resolvedModeTag)`），以及在 `settings.js:546`/`:560` 用户设置变更时调用。
 - 注意：`refreshAutoDisplayProfile` 的默认参数取 `state.currentModeTag`（`ManiaMapAnalyser by Leo_Black/js/app/appContext.js:124 currentModeTag: "Mix"`），而分析路径显式传入 `resolvedModeTag` 以保证与实际判定一致。
 
 ## 4. Vibro 检测
@@ -284,7 +284,7 @@ setSvTagVisible(shouldShowSvTag);
 ## 9. 注意事项
 
 1. **SV 标签依赖胶囊开关**：`showModeTagCapsule` 关闭时，`updateModeTagVisibility`（`hud.js:225-228`）与 `setSvTagVisible`（`hud.js:244-247`）都会立即隐藏 SV 徽章（见 `docs/settings.md:78` 与 `:204` 的说明）。不要期望单独控制 SV 徽章。
-2. **`modeTagFromLnRatio` 无 HB**：HB 标签仅来自键型分析（`summary.js:28 resolveModeTag`）。若 pattern 分析被禁用（contentBar 为 None），HB 永远不会出现，此时只有 RC/LN/Mix 回退。
+2. **`modeTagFromLnRatio` 无 HB**：HB 标签仅来自键型分析（`summary.js:28 resolveModeTag`）。若 pattern 分析被禁用（contentBar 显示列表为空，None），HB 永远不会出现，此时只有 RC/LN/Mix 回退。
 3. **SV 检测不替换模式标签**：SV 命中只置 `patternReport.Category = "SV"`（`analysis.js:803`）并显示独立徽章；`resolvedModeTag` 保持 HB/RC/LN/Mix。`MODE_TAG_OPTIONS` 中的 `"SV"` 仅为枚举完整性，当前渲染路径不使用。
 4. **`enableAnalyzeLN` 前置依赖**：`forceSunnyWindow` 关闭时 `typePercentageData` 恒为 `null`（`analysis.js:521-524`），标签胶囊退回单标签模式。改动 `analysis.js:521` 分支时需同步考虑该依赖。
 5. **currentModeTag 是 graph 的输入**：`hud.js:186-189` 注释明确"currentModeTag用于graph的显示"（`graph.js:217` 的 LN 难度门控）。修改标签判定时不要破坏 `state.currentModeTag` 的语义。

--- a/docs/features/pattern-analysis.md
+++ b/docs/features/pattern-analysis.md
@@ -207,14 +207,14 @@
 模式标签判定存在**两层**，需注意区分：
 
 1. **`js/patterns/` 内部（共享层）**：`summary.js:28` `resolveModeTag` 基于 `lnPercent`/`hbRowRatio` 产出 `report.ModeTag`（RC/LN/HB/Mix，阈值 `config.js:95-97`），并据此过滤 LN 模式（`summary.js:41-43`）与选择倍率表（第 6 节）。
-2. **`js/app/modeLogic.js`（浏览器层）**：`modeTagFromLnRatio`（`modeLogic.js:1`，仅按 LN 比例 0.15/0.9 二分 RC/Mix/LN，无 HB）作为**兜底**（`analysis.js:792` 用 `rework.lnRatio ?? parsedInfo.lnRatio`）；最终 `resolvedModeTag = (activeContentBar === "None") ? fallbackModeTag : (report.ModeTag || fallbackModeTag)`（`analysis.js:793-795`）——即只要显示 Pattern 内容，优先用 `js/patterns/` 内部更完整的判定。
+2. **`js/app/modeLogic.js`（浏览器层）**：`modeTagFromLnRatio`（`modeLogic.js:1`，仅按 LN 比例 0.15/0.9 二分 RC/Mix/LN，无 HB）作为**兜底**（`analysis.js:792` 用 `rework.lnRatio ?? parsedInfo.lnRatio`）；最终 `resolvedModeTag = (activeContentBar.length === 0) ? fallbackModeTag : (report.ModeTag || fallbackModeTag)`（`analysis.js:903-906`，activeContentBar 为多选有序数组）——即只要主体显示非空，优先用 `js/patterns/` 内部更完整的判定。
 3. 标签渲染：`setModeTag`（`js/app/hud.js:143`）/ `setModeTagAdvanced`（`hud.js:171`，基于 typePercentageData）；`resolveAutoDisplayProfile`（`modeLogic.js:31`）据此决定自动档位（RC → Etterna/MSD，其余 → Pattern/ReworkSR）。
 
 详细模式标签功能见 [mode-tagging.md](mode-tagging.md)。
 
 ## 9. 注意事项
 
-1. **非 4/6/7K 谱面主体回退 Pattern 显示**：`js/app/appContext.js:180` `GRAPH_SUPPORTED_KEY_SET = Set([4, 6, 7])`。当键数不在其中、且 `state.contentBar` 非 "None"/"Full" 时，`analysis.js:353-357` 通过 `setEffectiveContentBarForMap("Pattern")`（`js/app/settings.js:422`，per-map 覆盖，存于 `state.effectiveContentBar`）把主体内容强制回退为 Pattern 显示（Full 模式下由图表块自行显示 "Unsupported Keys" 提示，`analysis.js:351-352` 注释）。`js/patterns/` 本身对任意键数均能计算（`SPECIFIC_OTHER` 兜底）。
+1. **非 4/6/7K 谱面移除 Graph**：`js/app/appContext.js:186` `GRAPH_SUPPORTED_KEY_SET = Set([4, 6, 7])`。当键数不在其中、且 contentBar 显示列表含 Graph 时，`analysis.js:370-378 applyContentBarOverride` 通过 `setEffectiveContentBarForMap(移除Graph后的数组)`（`js/app/settings.js:470`，per-map 覆盖，存于 `state.effectiveContentBar`）把 Graph 从主体**移除**（保序保留其余；2026-08-15 起，此前为整体回退 Pattern）。`js/patterns/` 本身对任意键数均能计算（`SPECIFIC_OTHER` 兜底）。
 2. **SV 检测对分类的影响**：`useSvDetection` 开启时（`analysis.js:798-806`），若 `report.SVAmount ≥ SV_AMOUNT_THRESHOLD`（2000ms，`config.js:102`，由 `svTime` `primitives.js:152` 计算），`report.Category` 被覆盖为 `"SV"` 并显示 SV 标签；`svTime` 对极端 BPM 会强制超阈值（`primitives.js:217-219`）。注意 SV 覆盖发生在 app 层，`js/patterns/` 内的 `Category` 不受影响。
 3. **vibro 检测的影响**：vibro 检测在 `js/app/vibro.js`——`detectVibro`（`vibro.js:16`，基于 Etterna 数值与 jack 速度比，`analysis.js:655-657`）与 `detectVibroFromLongjackPattern`（`vibro.js:27`，基于 pattern report 的 Longjacks 簇）。它**不直接改 Category**，命中时 `setForceHideNumericDifficulty(isVibroMap)`（`analysis.js:824`）隐藏 Numeric Difficulty 显示。`config.js:107-108` 的 `LONGJACK_VIBRO_*` 阈值供 vibro 判定使用。
 4. **`needPatternAnalysis` 触发条件**（`analysis.js:410-415`）：Pattern 显示、srText/diffText 为 "Pattern"、`useSvDetection`、vibro 检测或自动档位启用任一满足即运行——模式分析可能被"顺带"执行以服务其他功能，即使界面上没显示 Pattern 条。

--- a/docs/features/rework-pp.md
+++ b/docs/features/rework-pp.md
@@ -5,7 +5,7 @@
 
 ## 1. 功能说明
 
-ReworkPP 是 **Card Body Content（contentBar）** 的一个选项值（**无空格**，settings.json:61、config.js:6、settingsParser.js `normalizeContentBarValue` 的 `"reworkpp" → "ReworkPP"` 分支三处一致），同时也是 **Top-left Capsule Text（srText）** 的一个选项值（settings.json:77、settingsParser.js `normalizeSrTextValue` 的 `"reworkpp" → "ReworkPP"` 分支，见 §1.1）。选中后卡片主体（`#pp-bars`，index.html）显示 **5 行柱状图**，每行由标签 + 轨道 + 值胶囊（pill）组成：
+ReworkPP 是 **Card Body Content（contentBar）** 的一个候选 section（**无空格**，settings.json `commands` 的 `values`、config.js:6 候选列表、settingsParser.js `normalizeContentBarList` 的 `"reworkpp" → "ReworkPP"` 分支三处一致），同时也是 **Top-left Capsule Text（srText）** 的一个选项值（settings.json:77、settingsParser.js `normalizeSrTextValue` 的 `"reworkpp" → "ReworkPP"` 分支，见 §1.1）。选中后卡片主体（`#pp-bars`，index.html）显示 **5 行柱状图**，每行由标签 + 轨道 + 值胶囊（pill）组成：
 
 | 行 | key | 取值范围（min~max） | 中心锚定 |
 | --- | --- | --- | --- |
@@ -123,7 +123,7 @@ const effectiveWeights = (options?.classicMod === true ? CArr : CArrV2).map((c, 
 ## 5. 缓存与实时机制
 
 - **ppMetrics 进快照**：写门 put 对象含 `ppMetrics: pipelineResult.ppMetrics || null`（analysis.js:868，JSON-safe 纯数值对象，无需 jsonSafe）；命中恢复 `state.ppMetrics = cached.ppMetrics || null`（analysis.js:533）。
-- **computed 第 5 项**：`needComputed.pp = contentBarShows("ReworkPP") || state.srText === "ReworkPP"`（analysis.js:340），覆盖检查比对 `snapshot.computed.pp === needComputed.pp`（analysis.js:353，5 项全等）——contentBar 切到 ReworkPP/Full 或 srText 切到 ReworkPP 会触发按需重算，而非全缓存失效。
+- **computed 第 5 项**：`needComputed.pp = contentBarShows("ReworkPP") || state.srText === "ReworkPP"`（analysis.js:342），覆盖检查比对 `snapshot.computed.pp === needComputed.pp`（analysis.js:355，5 项全等）——contentBar 多选列表中加入/移除 ReworkPP（`contentBarShows` 布尔变）或 srText 切到 ReworkPP 会触发按需重算，而非全缓存失效。
 - **live 值不缓存**：只缓存谱面侧 ppMetrics；Live PP 是实时渲染值，每次由当前计数重算。
 - **pipeline options**：`withPpMetrics: needComputed.pp`、`classicMod: state.classicMod === true`（analysis.js:425-426）。
 - **每消息更新 + 计数守卫**：socketHandlers.js 在 `updateSongTimeState(data)` 之后、beatmap 守卫之前调 `updateLivePp(data)`（:180），入口守卫 `(contentBarShows("ReworkPP") || state.srText === "ReworkPP") && state.ppMetrics`，livePp 内部自带守卫，成本极低；不建立节流/RAF（每消息 + CSS 过渡即满足平滑需求）。

--- a/docs/guides/adding-a-setting.md
+++ b/docs/guides/adding-a-setting.md
@@ -156,7 +156,7 @@ parseEnableExampleValue,
 parseExampleModeValue,
 ```
 
-**显示相关设置注意双层 state**（settings-pipeline.md §4）：`state.userContentBar` / `state.userSrText` / `state.userDiffText`（appContext.js:79-81）是用户意图层（可为 `"Auto"`），`state.contentBar` / `state.srText` / `state.diffText`（appContext.js:76-78）是解析值层。规则：**写 `user*` 字段、读解析值字段**（展示代码读解析值层；`contentBar` 之上还有谱面级覆盖，正确读法是 `getActiveContentBar()` appContext.js:228 / `contentBarShows(section)` appContext.js:232）。若新设置是这类显示选项，需要同时建 `user*` 与解析值两层并仿 `applyContentBarSetting` settings.js:478 写 apply 函数。
+**显示相关设置注意双层 state**（settings-pipeline.md §4）：`state.userContentBar`（有序数组，2026-08-15 起）/ `state.userSrText` / `state.userDiffText`（appContext.js:79-81）是用户意图层（`srText` 可为 `"Auto"`），`state.contentBar`（有序数组）/ `state.srText` / `state.diffText`（appContext.js:76-78）是解析值层。规则：**写 `user*` 字段、读解析值字段**（展示代码读解析值层；`contentBar` 之上还有谱面级覆盖，正确读法是 `getActiveContentBar()` appContext.js:234 / `contentBarShows(section)` appContext.js:238）。若新设置是这类显示选项，需要同时建 `user*` 与解析值两层并仿 `applyContentBarSetting` settings.js:540 写 apply 函数（`contentBar` 的 Auto 由独立 `autoContentBar` 布尔开关控制，见 `applyAutoContentBarSetting` settings.js:555）。
 
 > ⚠️ 陷阱：
 > - state 字段名小驼峰，uniqueID PascalCase——命名时对照 `state.vibroDetection`（appContext.js:111）↔ `"VibroDetection"`。

--- a/docs/guides/cache-invalidation.md
+++ b/docs/guides/cache-invalidation.md
@@ -93,7 +93,8 @@ snapshot.computed.graph === needComputed.graph
 && snapshot.computed.pp === needComputed.pp
 ```
 
-- contentBar/srText/diffText 是**特殊显示类**：它们被织入 needComputed（`analysis.js:322-339`，如 `state.diffText === "Graph"` → graph、`state.srText === "MSD"` → ett、`contentBarShows("ReworkPP")` → pp）。改显示需求但没改计算需求 → 命中（如 diffText 在 "Difficulty" 类选项间切换）；改计算需求（如切到 "Graph" 或 ReworkPP 主体）→ 检查自动判 miss 重算。因此它们不在失效列表。
+- contentBar/srText/diffText 是**特殊显示类**：它们被织入 needComputed（`analysis.js:322-343`，如 `state.diffText === "Graph"` → graph、`state.srText === "MSD"` → ett、`contentBarShows("ReworkPP")` → pp）。改显示需求但没改计算需求 → 命中（如 diffText 在 "Difficulty" 类选项间切换）；改计算需求（如切到 "Graph" 或 ReworkPP 主体）→ 检查自动判 miss 重算。因此它们不在失效列表。
+  - `contentBar` 自 2026-08-15 起为**多选有序数组**（tosu `commands` 类型），`contentBarShows(section)` = `getActiveContentBar().includes(section)`——布尔输出语义不变，覆盖检查机制不变；新增 `autoContentBar` 开关同样只改变 needComputed 布尔（经 `contentBarShows`），属显示类，`autoContentBarChanged` 进 `recomputeNeeded`（settings.js:909）但**不进** `clearResultCache()` 列表。
 - 纯显示设置（cardOpacity、主题、字体……）根本不进 needComputed，也不进快照 → 命中后渲染时从 state 取新值，天然正确。
 - 注意 `needComputed` 用 fetch 前的保守值（`analysis.js:284-286` 注释：未经谱面级 `effectiveContentBar` override），仅用于覆盖检查；实际 shows*/need* 在执行块内 override 后重算（`analysis.js:362-365`）。
 

--- a/docs/guides/module-conventions.md
+++ b/docs/guides/module-conventions.md
@@ -74,10 +74,10 @@ Worker 创建与资源路径解析必须用 `new URL(specifier, import.meta.url)
 
 `state` 定义于 `js/app/appContext.js:64`，关键字段在 `appContext.js:76-89`：
 
-- **写** `user*` 字段（用户真实偏好，可为 `"Auto"`）：`userContentBar`/`userSrText`/`userDiffText`（`appContext.js:79-81`）
-- **读** 解析后字段：`contentBar`/`srText`/`diffText`（`appContext.js:76-78, 87`）；`effectiveContentBar`（`appContext.js:77`）为谱面级覆盖
+- **写** `user*` 字段（用户真实偏好，`srText` 可为 `"Auto"`）：`userContentBar`（有序数组，2026-08-15 起）/`userSrText`/`userDiffText`（`appContext.js:79-81`）
+- **读** 解析后字段：`contentBar`（有序数组）/`srText`/`diffText`（`appContext.js:76-78, 87`）；`effectiveContentBar`（有序数组或 null，`appContext.js:77`）为谱面级覆盖；`autoContentBar`（bool，`appContext.js:83`）为独立 Auto 开关
 - **估计算法双层**：`estimatorAlgorithm`（用户选择，`appContext.js:88`）vs `actualEstimatorAlgorithm`（实际执行，`appContext.js:89`，如 Azusa 因 LN 过高降级为 Sunny）——分析后读后者，缓存命中时从快照恢复，勿重算
-- 写入 `state.contentBar = "Auto"` 是 bug
+- 写入 `state.contentBar = "Auto"` 是 bug（contentBar 为数组；Auto 由 `state.autoContentBar` 控制）
 - 设置全流程见 [../pipeline/settings-pipeline.md](../pipeline/settings-pipeline.md)
 
 ### 8. 新计算影响设置必须进失效列表

--- a/docs/pipeline/analysis-pipeline.md
+++ b/docs/pipeline/analysis-pipeline.md
@@ -170,7 +170,7 @@ const isStaleRequest = () => requestSeq !== state.analysisRequestSeq;
 
 ### 7.1 缓存查找与覆盖检查（简述，详见 result-cache.md §6）
 
-- `analysis.js:287-304 needComputed`：本次需要的计算产物布尔集 `{pattern, ett, graph, interlude, pp}`，由显示需求与算法需求推导（例如 `state.diffText === "Graph" || contentBarShows("Graph")` 需要 graph，:334；Companella/Mixed 需要 ett 与 interlude，:333、:337-338；`contentBarShows("ReworkPP")` 需要 pp，:339）。
+- `analysis.js:325-343 needComputed`：本次需要的计算产物布尔集 `{pattern, ett, graph, interlude, pp}`，由显示需求与算法需求推导（例如 `state.diffText === "Graph" || contentBarShows("Graph")` 需要 graph，:337；Companella/Mixed 需要 ett 与 interlude，:336、:340-341；`contentBarShows("ReworkPP")` 需要 pp，:342）。`contentBar` 为多选有序数组（2026-08-15）后 `contentBarShows` 输出布尔语义不变。
 - `analysis.js:305 cacheKey`：`${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`（版本前缀 `star-v2` + 三段，modSignature 四段含 classic）。
 - `analysis.js:306 isMetaDegraded`：identity 以 `meta:` 开头。
 - `analysis.js:308-317`：`state.enableResultCache && state.lastBeatmapIdentity` 时查 `resultCache.get(cacheKey)`，取到后比对快照 `computed` 五项（graph/pattern/ett/interlude/pp）与 needComputed——全等才命中（`cached = snapshot`），任一不等视为 miss 走完整重算。

--- a/docs/pipeline/result-cache.md
+++ b/docs/pipeline/result-cache.md
@@ -99,7 +99,7 @@ snapshot.computed.graph === needComputed.graph
 
 **五项**全匹配才命中，任一不匹配视为 miss 走完整重算。
 
-- `needComputed` 是**本次分析需要哪些计算产物**的布尔集（`analysis.js:287-304`）：pattern（键型）、ett（Etterna MSD）、graph（难度图）、interlude（Interlude 星数）、pp（ReworkPP 谱面侧指标，`contentBarShows("ReworkPP")`，`analysis.js:339`）。各项由当前显示需求与算法需求推导（如 `state.diffText === "Graph" || contentBarShows("Graph")` 需要 graph，`analysis.js:334`；Companella/Mixed 需要 ett 与 interlude，`analysis.js:333`、:337-338）。
+- `needComputed` 是**本次分析需要哪些计算产物**的布尔集（`analysis.js:325-343`）：pattern（键型）、ett（Etterna MSD）、graph（难度图）、interlude（Interlude 星数）、pp（ReworkPP 谱面侧指标，`contentBarShows("ReworkPP")`，`analysis.js:342`）。各项由当前显示需求与算法需求推导（如 `state.diffText === "Graph" || contentBarShows("Graph")` 需要 graph，`analysis.js:337`；Companella/Mixed 需要 ett 与 interlude，`analysis.js:336`、:340-341）。`contentBar` 为多选有序数组后 `contentBarShows` 输出布尔语义不变。
 - `snapshot.computed` 在写入时保存：`analysis.js:775` `computed: needComputed`。
 - **显示类设置（contentBar/srText/diffText 切换等）由覆盖检查处理，而不是缓存失效**——改了显示需求但没改计算需求时仍可命中（如从"显示难度"切到"显示 MSD"若 needComputed 不变）；改了计算需求（如切到 ReworkPP 主体，`needComputed.pp` 由 false 变 true）则检查自动判 miss 重算。
 - `needComputed` 用 fetch 前的保守值（`analysis.js:284-286` 注释：尚未经过谱面级 `effectiveContentBar` override），仅用于覆盖检查；实际 shows*/need* 在执行块内 override 之后重新计算。

--- a/docs/pipeline/settings-pipeline.md
+++ b/docs/pipeline/settings-pipeline.md
@@ -49,14 +49,14 @@ config.js 的 `APP_CONFIG.defaults`（config.js:76-115）与 settings.json 字�
 
 | 层 | 字段 | 语义 |
 | --- | --- | --- |
-| 用户意图层 | `state.userContentBar` / `state.userSrText` / `state.userDiffText`（appContext.js:79-81） | 用户实际选择，`contentBar`/`srText` 可为 `"Auto"` |
-| 解析值层 | `state.contentBar` / `state.srText` / `state.diffText`（appContext.js:76-78、:87） | 运行时实际使用的具体值，永不为 `"Auto"` |
-| 谱面级覆盖 | `state.effectiveContentBar`（appContext.js:77） | 按谱面覆盖 contentBar，由 `settings.js:422 setEffectiveContentBarForMap(contentBarOrNull)` 写入（null 表示无覆盖） |
+| 用户意图层 | `state.userContentBar`（有序数组 `string[]`）/ `state.userSrText` / `state.userDiffText`（appContext.js:79-81） | 用户实际选择，`srText` 可为 `"Auto"`；`contentBar` 为 commands 列表（空数组=None） |
+| 解析值层 | `state.contentBar`（有序数组）/ `state.srText` / `state.diffText`（appContext.js:76-78、:87） | 运行时实际使用的具体值，永不为 `"Auto"` |
+| 谱面级覆盖 | `state.effectiveContentBar`（有序数组或 null，appContext.js:77） | 按谱面覆盖 contentBar，由 `settings.js:470 setEffectiveContentBarForMap(contentBarOrNull)` 写入（null 表示无覆盖） |
 
-**规则：写 `user*` 字段、读解析值字段。** 例如 `applyContentBarSetting`（settings.js:478-490）：写 `state.userContentBar`，若为 `"Auto"` 则 `refreshAutoDisplayProfile()` 解析出具体值，否则 `setRuntimeContentBar(state.userContentBar)` 写入解析值层。
+**规则：写 `user*` 字段、读解析值字段。** 例如 `applyContentBarSetting`（settings.js:540）：写 `state.userContentBar`（有序数组）；`autoContentBar` 为 true 时 `refreshAutoDisplayProfile()` 解析出单元素数组，否则 `setRuntimeContentBar(state.userContentBar)` 写入解析值层。
 
-- **Auto 解析**：`settings.js:84 isAutoDisplayEnabled()`（`userSrText === "Auto" || userContentBar === "Auto"`）→ `settings.js:88 resolveRuntimeDisplayProfile(modeTag)` 调 `resolveAutoDisplayProfile`（modeLogic.js）得出 `{contentBar, srText}` 映射，再经 `setRuntimeDisplayProfile`（settings.js:466-471）→ `setRuntimeContentBar`（settings.js:393）/`setRuntimeSrText`（settings.js:447）/`setRuntimeDiffText`（settings.js:458）写入解析值层。`diffText` 无 Auto 选项，直接透传。
-- **读取约定**：展示代码一律读解析值层；`state.contentBar` 之上还有谱面级覆盖，正确读法是 `appContext.js:228 getActiveContentBar()`（`state.effectiveContentBar || state.contentBar`）与 `appContext.js:232 contentBarShows(section)`（active === section 或 Full）。
+- **Auto 解析**：`settings.js:82 isAutoDisplayEnabled()`（`userSrText === "Auto" || state.autoContentBar === true`）→ `settings.js:86 resolveRuntimeDisplayProfile(modeTag)` 调 `resolveAutoDisplayProfile`（modeLogic.js）得出 `{contentBar, srText}` 映射（contentBar 包成单元素数组 `[auto.contentBar]`），再经 `setRuntimeDisplayProfile`（settings.js:528）→ `setRuntimeContentBar`（settings.js:435）/`setRuntimeSrText`/`setRuntimeDiffText` 写入解析值层。`diffText` 无 Auto 选项，直接透传。
+- **读取约定**：展示代码一律读解析值层；`state.contentBar` 之上还有谱面级覆盖，正确读法是 `appContext.js:234 getActiveContentBar()`（`state.effectiveContentBar || state.contentBar`，均为数组）与 `appContext.js:238 contentBarShows(section)`（`getActiveContentBar().includes(section)`，多选列表包含判定）。
 
 **估计算法层**：`state.estimatorAlgorithm`（appContext.js:88）是用户选择，`state.actualEstimatorAlgorithm`（appContext.js:89）记录实际执行的算法（如 Azusa 因 LN 比例过高回退 Sunny）。分析完成后读取后者；缓存命中时从快照恢复，不得重算（详见 [result-cache.md](result-cache.md)）。
 
@@ -75,14 +75,14 @@ config.js 的 `APP_CONFIG.defaults`（config.js:76-115）与 settings.json 字�
 
 ## 6. 遗留逻辑（注意事项）
 
-- **autoMode 强制 Auto**：settings.js:769-774——`parseAutoModeValue(payload)` 为真且 `isAutoDisplayEnabled()` 为假（即用户当前不是 Auto）时，**直接写** `state.userSrText = "Auto"`、`state.userContentBar = "Auto"` 并 `refreshAutoDisplayProfile()`。这是对所有设置的独立检查之后运行的全局覆盖，新设置项迁移自旧 `autoMode` 配置时需留意。
+- **autoMode 强制 Auto**：settings.js:864-869——`parseAutoModeValue(payload)` 为真且 `isAutoDisplayEnabled()` 为假（即用户当前不是 Auto）时，**直接写** `state.userSrText = "Auto"`、`state.autoContentBar = true` 并 `refreshAutoDisplayProfile()`。这是对所有设置的独立检查之后运行的全局覆盖，新设置项迁移自旧 `autoMode` 配置时需留意。
 - **4 个遗留 parser（无对应 uniqueID）**：
   - `parseAutoModeValue` settingsParser.js:307（键 `autoMode`，回退 `defaults.autoMode`=false）
   - `parseUseDanielAlgorithmValue` settingsParser.js:312（键 `useDanielAlgorithm`——实际上它转调 `parseEstimatorAlgorithmValue` 判断结果是否为 "Daniel"，不再读独立键）
   - `parseDisableVibroDetectionValue` settingsParser.js:382（= `!parseVibroDetectionValue()`）
   - `parseEnablePatternValue` settingsParser.js:246（键 `enablePatternAnalysis`，供 `parseContentBarValue` 回退使用）
 - **普通 parser 内部的遗留键回退**（迁移路径，非独立 parser）：
-  - `parseContentBarValue` settingsParser.js:275-276：无 `contentBar` 键时读 `enablePatternAnalysis`，为真 → `"Pattern"`，否则 → `"None"`（`parseEnablePatternValue` 的回退）。
+  - `parseContentBarValue` settingsParser.js:304：`contentBar` 键存在时经 `normalizeContentBarList` 解析为**有序 section 数组**（commands 数组保序收集，旧字符串迁移：Full→四元素、None/Auto→[]、单值→单元素）；无 `contentBar` 键时读 `enablePatternAnalysis`，为真 → `["Pattern"]`，否则 → `[]`。`autoContentBar` 由独立 `parseAutoContentBarValue`（settingsParser.js:319）解析（默认 `defaults.autoContentBar`=true）。
   - `parseDiffTextValue` settingsParser.js:300-304：遗留键 `enableEstDiff` → 真 `"Difficulty"` / 假 `"None"`。
   - `parseEstimatorAlgorithmValue` settingsParser.js:324-327：遗留键 `useDanielAlgorithm` → 真 `"Daniel"` / 假 `"Sunny"`。
   - `parseVibroDetectionValue` settingsParser.js:392-395：遗留键 `disableVibroDetection` → 取反。

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -5,15 +5,16 @@
 ## 中文
 
 - **模块设定**：
-    - **Card Body Content**：选择在卡片主体显示的内容。
-        - None: 不显示任何内容。即短卡片模式。
-        - Auto: 根据谱面LN占比自动选择显示Pattern或Etterna。
+    - **Auto Card Body Content**: 是否根据谱面模式自动选择卡片主体内容。
+        - 启用（默认）：按谱面 LN 占比自动选择显示 Pattern 或 Etterna。
+        - 关闭：完全使用下方 Card Body Content 列表；列表为空即不显示主体（短卡片模式）。
+    - **Card Body Content**：选择在卡片主体显示的内容（每行一个，按行顺序从上到下显示）。
         - Pattern: 显示键型分析。
         - Etterna: 显示Etterna 7大键型分。
         - Graph: 显示难度变化图。
         - ReworkPP: 显示最大/实时 Rework PP 及其相关参数。
-        - Full: 显示完整内容，包括键型分析、难度图表和Etterna分数。不推荐日常使用，可能会比较拥挤。
-        - 注：对于非4/6/7K谱面，主体内容将自动回退为Pattern显示。
+        - 可添加多行同时显示多个内容；删除所有行即不显示主体。
+        - 注：对于非4/6/7K谱面，Graph 将自动从列表中移除。
     - **Top-left Capsule Text**：选择在卡片左上角胶囊显示的内容。
         - Auto: 根据谱面LN占比自动选择显示ReworkSR或MSD。
         - ReworkSR: 显示[Sunny Rework](https://github.com/sunnyxxy/Star-Rating-Rebirth)星数。
@@ -136,15 +137,16 @@
 ## English
 
 - **Module Settings**:
-    - **Card Body Content**: Select what to display in the main body of the card.
-        - None: Displays nothing. Short card mode.
-        - Auto: Automatically selects Pattern or Etterna based on the LN ratio of the beatmap.
+    - **Auto Card Body Content**: Whether to automatically pick the card body based on the map mode.
+        - On (default): Automatically selects Pattern or Etterna based on the LN ratio of the beatmap.
+        - Off: Uses the Card Body Content list below; an empty list shows no body (short card mode).
+    - **Card Body Content**: Select what to display in the main body of the card (one section per row, shown top to bottom in row order).
         - Pattern: Displays pattern analysis.
         - Etterna: Displays Etterna's 7 major skill set breakdowns.
         - Graph: Displays the difficulty variation graph.
         - ReworkPP: Displays the max/live Rework PP performance and related parameters.
-        - Full: Displays full content including pattern analysis, difficulty graph, and Etterna scores. Not recommended for daily use — may feel crowded.
-        - Note: For non-4/6/7K beatmaps, body content automatically falls back to Pattern.
+        - Add multiple rows to show several sections at once; remove all rows to show nothing.
+        - Note: On non-4/6/7K beatmaps, Graph is automatically removed from the list.
     - **Top-left Capsule Text**: Select what to display in the top-left capsule.
         - Auto: Automatically selects ReworkSR or MSD based on the LN ratio of the beatmap.
         - ReworkSR: Displays [Sunny Rework](https://github.com/sunnyxxy/Star-Rating-Rebirth) star rating.


### PR DESCRIPTION
## 概述

将**卡片主体内容（contentBar）**设置从单选项（options）改为 tosu 的
**`commands`** 类型多选：用户可自由组合 Pattern / Etterna / Graph / ReworkPP 中
的任意多个，**列表顺序即显示顺序**（行序 = 前端显示顺序）。删除 `Full` 选项
（等价于四项全选）；空列表表示不显示主体（None）。`Auto` 拆分为独立的
`autoContentBar` 开关（默认开启），与自定义列表互不干扰。

## 修改内容

- `settings.json`：`contentBar` 改为 `commands` 类型（每行一个 `section` 下拉，
  `uniqueCheck: "section"` 防重复）；新增 `autoContentBar` 复选框（置于其前，
  符合 checkbox 前置约定）；选项列表删除 `Full`/`None`/`Auto`。
- `config.js`：`options.contentBar` 改为 4 个候选；`defaults.contentBar` 改为 `[]`；
  新增 `defaults.autoContentBar: true`。
- `settingsParser.js`：重写 `parseContentBarValue` 解析有序 `string[]`（经新增的
  `normalizeContentBarList`，含旧字符串迁移：`Full`→四元素、`None`/`Auto`→`[]`、
  单值→单元素）；新增 `parseAutoContentBarValue`。
- `appContext.js`：`contentBar`/`effectiveContentBar`/`userContentBar` 全部改为
  有序数组 `string[]`；`contentBarShows(section)` 改为
  `getActiveContentBar().includes(section)`；新增 `state.autoContentBar`。
- `settings.js`：`updateContentBarVisibility` 按列表顺序为各区块设置 CSS `order`，
  新增 `bars-multi` 布局类（≥2 项），单块保留原有单块类，空列表用 `bars-none`；
  `isAutoDisplayEnabled` 改读 `autoContentBar`；遗留 `autoMode` 映射为
  `autoContentBar=true`；`autoContentBarChanged` 加入 `recomputeNeeded`
  （走缓存覆盖检查，**不**加入 `clearResultCache()`——与 contentBar 的
  "特殊显示类"处理一致）。
- `analysis.js`：非 4/6/7K 键数时从有效列表**移除 Graph**（保序保留其余，而非
  整体降级为 Pattern）；`resolvedModeTag` 用空列表判定 None；Auto 切换检测改用
  序列化比较。
- CSS：`bars-multi` 复用 `bars-full` 的高度自适应堆叠；`theme.css`/`status.css`/
  `responsive.css` 同步补充 `bars-multi` 选择器。
- 文档：`docs/settings.md`（中英）、settings-pipeline、result-cache、
  analysis-pipeline、rework-pp、graph-visualization、pattern-analysis、
  mode-tagging、adding-a-setting、cache-invalidation、module-conventions；
  新增 `docs/breakings/2026-08-15-contentbar-multi.md`（双语五要素）。

## 修改原因

让用户完全掌控卡片主体显示哪些内容、以什么顺序显示，取代固定的 `Full` 布局。
`commands` 是 tosu 唯一支持动态多行值的设置类型；其 `options` 子字段可声明为
下拉，天然表达"每行一个 section"；顺序要求决定了保序数组（而非 Set）的数据模型。

## 影响范围

- 卡片主体显示管线（设置 → 状态 → 可见性 → CSS）。
- 缓存语义不变：`contentBar`/`autoContentBar` 仍属"显示类"设置，由
  `needComputed` 覆盖检查处理。
- 估算器/解析器/ETT/键型等共享模块零改动——Benchmark runner 不受影响。

## 兼容策略

- 旧值迁移：`"Full"` → 四元素有序数组；`"None"` → `[]`；`"Auto"` → `[]`
  （默认 `autoContentBar=true` 自动恢复 Auto 行为）；单值 → 单元素数组。
- 遗留 `enablePatternAnalysis` 回退保留（true → `["Pattern"]`）。
- 旧 `autoMode` 配置映射为 `autoContentBar=true`。
- `bars-full` CSS 类保留为迁移别名（与 `bars-multi` 共用规则）。