### PR TITLE
fix/feat: time filter, hover raw values, auto-refresh, numeric difficulty

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -1,6 +1,7 @@
 import { runAnalysisPipeline } from "../pipeline/runAnalysisPipeline.js";
 import { calculateReworkPp } from "../rework/reworkPerformance.js";
 import { applyCompanellaToMixedResult } from "../estimator/mixedEstimator.js";
+import { rcLabelToNumeric } from "../estimator/rcDifficultyFormat.js";
 import { classifyCompanellaDifficulty } from "../estimator/companellaEstimator.js";
 import { calculateInterludeStar } from "../interlude/index.js";
 import { analyzePatternFromText } from "../patterns/service.js";
@@ -1048,7 +1049,17 @@ export async function fetchBeatmapFile(reason) {
         }
 
         if (rework && metadataErrors.length === 0 && !isStaleRequest()) {
-            trackTelemetryAnalyze({
+            // 数值化难度（Reform 段位体系，.0 = mid）：Azusa/Roxy 的原生值已是
+            // 标准尺度，直接用；其余算法（Sunny/Companella/Daniel——Daniel 的
+            // 原生值是其 DP 尺度，比标准约高 0.5）用 estDiff 标签反向换算。
+            // 边界标签（< Alpha Low 等）反解为 null → 不上报该字段。
+            const rcNative = state.actualEstimatorAlgorithm === "Azusa" || state.actualEstimatorAlgorithm === "Roxy";
+            const numericDifficulty = rcNative
+                && typeof resolvedNumericDifficulty === "number"
+                && Number.isFinite(resolvedNumericDifficulty)
+                ? resolvedNumericDifficulty
+                : rcLabelToNumeric(resolvedEstDiff);
+            const payload = {
                 algorithm: state.estimatorAlgorithm,
                 actualAlgorithm: state.actualEstimatorAlgorithm,
                 keycount: Number(rework.columnCount),
@@ -1059,7 +1070,11 @@ export async function fetchBeatmapFile(reason) {
                 lnRatio: Number(rework.lnRatio ?? parsedInfo.lnRatio),
                 typeBreakdown: typePercentageData ?? null,
                 durationMs: Math.max(0, Math.round(performance.now() - analysisStartedAt)),
-            });
+            };
+            if (Number.isFinite(numericDifficulty)) {
+                payload.numericDifficulty = numericDifficulty;
+            }
+            trackTelemetryAnalyze(payload);
         }
     } catch (error) {
         if (isStaleRequest()) return;

--- a/ManiaMapAnalyser by Leo_Black/js/app/telemetry.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/telemetry.js
@@ -8,7 +8,7 @@
 import { state } from "./appContext.js";
 
 const INSTALL_ID_KEY = "mma.telemetry.installId.v1";
-const HEARTBEAT_INTERVAL_MS = 5 * 60 * 1000;
+const HEARTBEAT_INTERVAL_MS = 10 * 60 * 1000;
 const ACTIVITY_WINDOW_MS = 30 * 1000;
 const REQUEST_TIMEOUT_MS = 5000;
 

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/mixedEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/mixedEstimator.js
@@ -207,11 +207,15 @@ export function shouldPreferAzusaRcResult(roxyResult, azusaResult) {
 
 export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) {
     const sunnyBaseline = options.precomputedSunnyResult || runSunnyEstimatorFromText(osuText, options, parsed);
+    // Track which sub-algorithm actually won the routing chain below so callers
+    // (analysis pipeline → telemetry) can report the real algorithm, not "Mixed".
+    let actualAlgorithm = "Sunny";
     const columnCount = Number(sunnyBaseline.columnCount);
     if (!Number.isFinite(columnCount) || !MIXED_SUPPORTED_KEYS.has(columnCount)) {
         return {
             ...sunnyBaseline,
             mixedCompanellaPlan: null,
+            actualEstimatorAlgorithm: actualAlgorithm,
         };
     }
 
@@ -223,6 +227,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
         return {
             ...sunnyBaseline,
             mixedCompanellaPlan: null,
+            actualEstimatorAlgorithm: actualAlgorithm,
         };
     }
 
@@ -239,6 +244,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
         }, parsed);
         if (canUseRcResult(roxyResult)) {
             selectedRework = roxyResult;
+            actualAlgorithm = "Roxy";
             estDiff = roxyResult.estDiff;
             numericDifficulty = roxyResult.numericDifficulty;
             numericDifficultyHint = roxyResult.numericDifficultyHint;
@@ -250,6 +256,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
                 }, parsed);
                 if (shouldPreferAzusaRcResult(roxyResult, azusaResult)) {
                     selectedRework = azusaResult;
+                    actualAlgorithm = "Azusa";
                     estDiff = azusaResult.estDiff;
                     numericDifficulty = azusaResult.numericDifficulty;
                     numericDifficultyHint = azusaResult.numericDifficultyHint;
@@ -263,6 +270,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
             }, parsed);
             if (canUseRcResult(azusaResult)) {
                 selectedRework = azusaResult;
+                actualAlgorithm = "Azusa";
                 estDiff = azusaResult.estDiff;
                 numericDifficulty = azusaResult.numericDifficulty;
                 numericDifficultyHint = azusaResult.numericDifficultyHint;
@@ -274,6 +282,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
 
                 if (canUseDaniel) {
                     selectedRework = danielResult;
+                    actualAlgorithm = "Daniel";
                     estDiff = danielResult.estDiff;
                     numericDifficulty = danielResult.numericDifficulty;
                     numericDifficultyHint = danielResult.numericDifficultyHint;
@@ -295,6 +304,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
                     lnRatio,
                     lnDifficulty,
                 };
+                actualAlgorithm = "Companella";
             } else {
                 const danielResult = tryRunDanielFallback(osuText, options, parsed);
                 const canUseDaniel = danielResult
@@ -305,6 +315,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
                     rcDifficulty = danielResult.estDiff;
                     rcNumericDifficulty = danielResult.numericDifficulty;
                     rcNumericDifficultyHint = danielResult.numericDifficultyHint;
+                    actualAlgorithm = "Daniel";
                 }
             }
         }
@@ -324,6 +335,7 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
         numericDifficulty,
         numericDifficultyHint,
         mixedCompanellaPlan: companellaPlan,
+        actualEstimatorAlgorithm: actualAlgorithm,
     };
 }
 

--- a/ManiaMapAnalyser by Leo_Black/js/pipeline/runAnalysisPipeline.js
+++ b/ManiaMapAnalyser by Leo_Black/js/pipeline/runAnalysisPipeline.js
@@ -159,6 +159,9 @@ export async function runAnalysisPipeline({ rawText, estimatorAlgorithm, options
             ? { ...options, precomputedSunnyResult: sharedSunnyResult }
             : options;
         selectedRework = runMixedEstimatorFromText(rawText, mixedOpts, parser);
+        // Mixed 自动路由到 Roxy/Azusa/Daniel/Companella/Sunny，
+        // 从结果读取实际命中的子算法（与 Azusa/Roxy 分支同语义）。
+        actualEstimatorAlgorithm = selectedRework?.actualEstimatorAlgorithm || actualEstimatorAlgorithm;
     } else if (estimatorAlgorithm === "Companella") {
         // Companella 本体在主线程异步追加（§7.5），此处跑 Sunny 打底。
         selectedRework = runSunnyEstimatorFromText(rawText, options, parser);
@@ -182,7 +185,7 @@ export async function runAnalysisPipeline({ rawText, estimatorAlgorithm, options
     let rework = selectedRework;
     let sunnyStar = null;
     let normalizationSunnyResult = null;
-    if (NORMALIZATION_ALGORITHMS.has(actualEstimatorAlgorithm)) {
+    if (NORMALIZATION_ALGORITHMS.has(actualEstimatorAlgorithm) || estimatorAlgorithm === "Mixed") {
         normalizationSunnyResult = sharedSunnyResult || runSunnyEstimatorFromText(rawText, options, parser);
         sunnyStar = Number(normalizationSunnyResult.star);
         rework = { ...selectedRework, star: sunnyStar };
@@ -198,7 +201,7 @@ export async function runAnalysisPipeline({ rawText, estimatorAlgorithm, options
     if (options.withPpMetrics === true) {
         try {
             let sunnySrc = null;
-            if (NORMALIZATION_ALGORITHMS.has(actualEstimatorAlgorithm)) {
+            if (NORMALIZATION_ALGORITHMS.has(actualEstimatorAlgorithm) || estimatorAlgorithm === "Mixed") {
                 sunnySrc = normalizationSunnyResult;
             } else if (estimatorAlgorithm === "Daniel") {
                 sunnySrc = runSunnyEstimatorFromText(rawText, { ...options, withPpMetrics: true }, parser);

--- a/backend/README.md
+++ b/backend/README.md
@@ -107,7 +107,7 @@ curl -d '{"id":"00000000-0000-4000-8000-000000000000","kind":"boot","version":"1
 }
 ```
 
-返回 `204 No Content`。请求体错误返回 `400`，方法错误返回 `405`，被限流返回 `429`。`data` 对象在服务端只保留以下键：`algorithm`、`actualAlgorithm`、`keycount`、`mods`、`speedRate`、`mode`、`star`、`lnRatio`、`typeBreakdown`、`durationMs`。
+返回 `204 No Content`。请求体错误返回 `400`，方法错误返回 `405`，被限流返回 `429`。`data` 对象在服务端只保留以下键：`algorithm`、`actualAlgorithm`、`keycount`、`mods`、`speedRate`、`mode`、`star`、`lnRatio`、`typeBreakdown`、`durationMs`、`numericDifficulty`（可选，标准数值化难度 .0=mid，见 `docs/features/telemetry.md`）。
 
 对 `POST`/`OPTIONS` 开放 CORS（插件运行在 `http://localhost:24050`）。
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -129,11 +129,11 @@ curl -d '{"id":"00000000-0000-4000-8000-000000000000","kind":"boot","version":"1
 
 ## 部署（Linux）
 
-在任何机器上交叉编译（无需 Docker、无 cgo）：
+在任何机器上交叉编译（无需 Docker、无 cgo）。`-X main.version=` 注入后端版本（`/api/v1/stats` 返回 `serverVersion`、看板 footer 显示、启动日志打印）；不注入则为 `dev`：
 
 ```bash
 cd backend
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o bin/telemetry-server ./cmd/server
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-X main.version=1.0.0 -s -w" -o bin/telemetry-server ./cmd/server
 ```
 
 在服务器上：

--- a/backend/README_EN.md
+++ b/backend/README_EN.md
@@ -107,7 +107,7 @@ Body (max 16 KB):
 }
 ```
 
-Returns `204 No Content`. `400` for a bad body, `405` for wrong method, `429` when rate limited. The `data` object is filtered server-side to these keys only: `algorithm`, `actualAlgorithm`, `keycount`, `mods`, `speedRate`, `mode`, `star`, `lnRatio`, `typeBreakdown`, `durationMs`.
+Returns `204 No Content`. `400` for a bad body, `405` for wrong method, `429` when rate limited. The `data` object is filtered server-side to these keys only: `algorithm`, `actualAlgorithm`, `keycount`, `mods`, `speedRate`, `mode`, `star`, `lnRatio`, `typeBreakdown`, `durationMs`, `numericDifficulty` (optional; standard numeric difficulty, .0 = mid, see `docs/features/telemetry.md`).
 
 CORS is enabled for `POST`/`OPTIONS` (the plugin runs on `http://localhost:24050`).
 

--- a/backend/README_EN.md
+++ b/backend/README_EN.md
@@ -129,11 +129,11 @@ A background loop deletes `events` older than `MMA_TELEMETRY_RETENTION_DAYS` (de
 
 ## Deployment (Linux)
 
-Cross-compile from any machine (no Docker, no cgo):
+Cross-compile from any machine (no Docker, no cgo). `-X main.version=` injects the backend version (returned as `serverVersion` in `/api/v1/stats`, shown in the dashboard footer and the startup log); without it the build reports `dev`:
 
 ```bash
 cd backend
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o bin/telemetry-server ./cmd/server
+CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-X main.version=1.0.0 -s -w" -o bin/telemetry-server ./cmd/server
 ```
 
 On the server:

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -16,6 +16,10 @@ import (
 	"osumania-telemetry/internal/web"
 )
 
+// version is injected at build time via
+// `-ldflags "-X main.version=<tag>"`; local/dev builds report "dev".
+var version = "dev"
+
 func main() {
 	cfg, err := config.Load()
 	if err != nil {
@@ -30,7 +34,7 @@ func main() {
 
 	limiter := ratelimit.New(cfg.RateLimitPerMin)
 	eventHandler := telemetry.NewHandler(st, limiter)
-	webHandler := web.NewHandler(st, cfg.OnlineWindowMin, cfg.StatsCacheSeconds)
+	webHandler := web.NewHandler(st, cfg.OnlineWindowMin, cfg.StatsCacheSeconds, version)
 
 	go retentionLoop(st, cfg.RetentionDays)
 
@@ -56,7 +60,7 @@ func main() {
 		IdleTimeout:       60 * time.Second,
 	}
 
-	log.Printf("osumania-telemetry listening on %s", cfg.Addr)
+	log.Printf("osumania-telemetry %s listening on %s", version, cfg.Addr)
 	if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		log.Fatalf("server: %v", err)
 	}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -63,6 +63,10 @@ func main() {
 }
 
 func retentionLoop(st *store.Store, retentionDays int) {
+	if retentionDays <= 0 {
+		log.Printf("retention: disabled (keep events forever)")
+		return
+	}
 	run := func() {
 		cutoff := time.Now().Add(-time.Duration(retentionDays) * 24 * time.Hour).UnixMilli()
 		if n, err := st.DeleteEventsBefore(cutoff); err != nil {

--- a/backend/internal/analytics/analytics.go
+++ b/backend/internal/analytics/analytics.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
 	"strings"
 	"time"
@@ -195,7 +196,10 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 	lns := map[float64]int64{}
 	var starSum, lnSum float64
 	var starN, lnN int64
-	var durations []int64
+	// Duration aggregate: exact sum/count plus a bounded reservoir for the
+	// percentiles, so memory/time stay O(1) as the event table grows.
+	var durSum, durN int64
+	var durSamples []int64
 
 	err := st.ScanAnalyzeData(since, func(dataJSON string) error {
 		var d analyzeData
@@ -236,7 +240,14 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 			lnN++
 		}
 		if d.DurationMs >= 0 {
-			durations = append(durations, int64(d.DurationMs))
+			v := int64(d.DurationMs)
+			durSum += v
+			durN++
+			if len(durSamples) < durationSampleCap {
+				durSamples = append(durSamples, v)
+			} else if j := rand.Int63n(durN); j < durationSampleCap {
+				durSamples[j] = v
+			}
 		}
 		return nil
 	})
@@ -264,7 +275,7 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 	if lnN > 0 {
 		s.AvgLnRatio = math.Round(lnSum/float64(lnN)*100) / 100
 	}
-	s.DurationStats = durationStats(durations)
+	s.DurationStats = durationStats(durSum, durN, durSamples)
 
 	return nil
 }
@@ -296,19 +307,25 @@ func histogram(m map[float64]int64, key func(float64) string) []Bucket {
 	return out
 }
 
-func durationStats(durations []int64) DurationStats {
-	if len(durations) == 0 {
+// durationSampleCap bounds the reservoir used for percentile estimation; the
+// average stays exact (sum/count over every event), only P50/P90 become
+// estimates — with 5000 random samples they converge within ~1-2% error even
+// at a million events.
+const durationSampleCap = 5000
+
+func durationStats(sum, n int64, samples []int64) DurationStats {
+	if n == 0 {
 		return DurationStats{}
 	}
-	sort.Slice(durations, func(i, j int) bool { return durations[i] < durations[j] })
-	var sum int64
-	for _, d := range durations {
-		sum += d
+	avg := sum / n
+	if len(samples) == 0 {
+		return DurationStats{AvgMs: avg}
 	}
+	sort.Slice(samples, func(i, j int) bool { return samples[i] < samples[j] })
 	return DurationStats{
-		AvgMs: sum / int64(len(durations)),
-		P50Ms: percentile(durations, 50),
-		P90Ms: percentile(durations, 90),
+		AvgMs: avg,
+		P50Ms: percentile(samples, 50),
+		P90Ms: percentile(samples, 90),
 	}
 }
 

--- a/backend/internal/analytics/analytics.go
+++ b/backend/internal/analytics/analytics.go
@@ -68,20 +68,22 @@ type Stats struct {
 	Versions         []KV          `json:"versions"`
 	StarHistogram    []Bucket      `json:"starHistogram"`
 	LnRatioHistogram []Bucket      `json:"lnRatioHistogram"`
+	NumericHistogram []Bucket      `json:"numericHistogram"`
 	DurationStats    DurationStats `json:"durationStats"`
 }
 
 type analyzeData struct {
-	Algorithm       string          `json:"algorithm"`
-	ActualAlgorithm string          `json:"actualAlgorithm"`
-	Keycount        int             `json:"keycount"`
-	Mods            []string        `json:"mods"`
-	SpeedRate       float64         `json:"speedRate"`
-	Mode            string          `json:"mode"`
-	Star            float64         `json:"star"`
-	LnRatio         float64         `json:"lnRatio"`
-	TypeBreakdown   json.RawMessage `json:"typeBreakdown"`
-	DurationMs      float64         `json:"durationMs"`
+	Algorithm         string          `json:"algorithm"`
+	ActualAlgorithm   string          `json:"actualAlgorithm"`
+	Keycount          int             `json:"keycount"`
+	Mods              []string        `json:"mods"`
+	SpeedRate         float64         `json:"speedRate"`
+	Mode              string          `json:"mode"`
+	Star              float64         `json:"star"`
+	LnRatio           float64         `json:"lnRatio"`
+	TypeBreakdown     json.RawMessage `json:"typeBreakdown"`
+	DurationMs        float64         `json:"durationMs"`
+	NumericDifficulty *float64        `json:"numericDifficulty"`
 }
 
 // Compute builds the full aggregate snapshot over the requested window.
@@ -194,6 +196,7 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 	modes := map[string]int64{}
 	stars := map[float64]int64{}
 	lns := map[float64]int64{}
+	numerics := map[float64]int64{}
 	var starSum, lnSum float64
 	var starN, lnN int64
 	// Duration aggregate: exact sum/count plus a bounded reservoir for the
@@ -239,6 +242,10 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 			lnSum += d.LnRatio
 			lnN++
 		}
+		if d.NumericDifficulty != nil && *d.NumericDifficulty >= -3 && *d.NumericDifficulty <= 30 {
+			// aggregate into 0.5 bins on the Reform numeric scale (.0 = mid)
+			numerics[math.Round(*d.NumericDifficulty*2)/2]++
+		}
 		if d.DurationMs >= 0 {
 			v := int64(d.DurationMs)
 			durSum += v
@@ -269,6 +276,7 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 
 	s.StarHistogram = histogram(stars, func(k float64) string { return fmt.Sprintf("%.1f", k) })
 	s.LnRatioHistogram = histogram(lns, func(k float64) string { return fmt.Sprintf("%.0f%%", k*100) })
+	s.NumericHistogram = histogram(numerics, func(k float64) string { return fmt.Sprintf("%.1f", k) })
 	if starN > 0 {
 		s.AvgStar = math.Round(starSum/float64(starN)*100) / 100
 	}

--- a/backend/internal/analytics/analytics.go
+++ b/backend/internal/analytics/analytics.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 	"time"
 
 	"osumania-telemetry/internal/store"
@@ -30,8 +31,9 @@ type TrendDay struct {
 }
 
 type Bucket struct {
-	Label string `json:"label"`
-	Count int64  `json:"count"`
+	Key   string  `json:"key"`
+	Value float64 `json:"value"`
+	Count int64   `json:"count"`
 }
 
 type DurationStats struct {
@@ -48,6 +50,13 @@ type Stats struct {
 	MonthActive      int64         `json:"monthActive"`
 	NewToday         int64         `json:"newToday"`
 	NewWeek          int64         `json:"newWeek"`
+	TotalEvents      int64         `json:"totalEvents"`
+	Analyze30d       int64         `json:"analyze30d"`
+	AvgStar          float64       `json:"avgStar"`
+	AvgLnRatio       float64       `json:"avgLnRatio"`
+	PeakOnline       int64         `json:"peakOnline"`
+	PeakOnlineHour   int           `json:"peakOnlineHour"`
+	AvgDailyActive   int64         `json:"avgDailyActive"`
 	OnlineByHour     [24]int64     `json:"onlineByHour"`
 	ActiveTrend      []TrendDay    `json:"activeTrend"`
 	Algorithms       []KV          `json:"algorithms"`
@@ -106,11 +115,30 @@ func Compute(st *store.Store, onlineWindowMin int) (*Stats, error) {
 	if s.NewWeek, err = st.CountInstallsNew(nowMs - 7*dayMs); err != nil {
 		return nil, err
 	}
+	if s.TotalEvents, err = st.CountEvents(); err != nil {
+		return nil, err
+	}
+	if s.Analyze30d, err = st.CountAnalyzeSince(since30d); err != nil {
+		return nil, err
+	}
 	if s.OnlineByHour, err = st.OnlineByHour(since30d); err != nil {
 		return nil, err
 	}
+	for h, c := range s.OnlineByHour {
+		if c > s.PeakOnline {
+			s.PeakOnline = c
+			s.PeakOnlineHour = h
+		}
+	}
 	if s.ActiveTrend, err = buildTrend(st); err != nil {
 		return nil, err
+	}
+	var activeSum int64
+	for _, d := range s.ActiveTrend {
+		activeSum += d.Active
+	}
+	if len(s.ActiveTrend) > 0 {
+		s.AvgDailyActive = activeSum / int64(len(s.ActiveTrend))
 	}
 	if err = buildDistributions(st, since30d, s); err != nil {
 		return nil, err
@@ -152,8 +180,10 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 	keys := map[string]int64{}
 	mods := map[string]int64{}
 	modes := map[string]int64{}
-	stars := map[int]int64{}
-	lns := map[int]int64{}
+	stars := map[float64]int64{}
+	lns := map[float64]int64{}
+	var starSum, lnSum float64
+	var starN, lnN int64
 	var durations []int64
 
 	err := st.ScanAnalyzeData(since, func(dataJSON string) error {
@@ -170,19 +200,20 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 		if d.Keycount > 0 {
 			keys[fmt.Sprintf("%dK", d.Keycount)]++
 		}
-		for _, m := range d.Mods {
-			if m != "" {
-				mods[m]++
-			}
-		}
+		mods[modCombo(d.Mods)]++
 		if d.Mode != "" {
 			modes[d.Mode]++
 		}
 		if d.Star > 0 {
-			stars[int(math.Round(d.Star))]++
+			// continuous: keep 2-decimal resolution
+			stars[math.Round(d.Star*100)/100]++
+			starSum += d.Star
+			starN++
 		}
 		if d.LnRatio >= 0 && d.LnRatio <= 1 {
-			lns[int(math.Round(d.LnRatio*100))]++
+			lns[math.Round(d.LnRatio*100)/100]++
+			lnSum += d.LnRatio
+			lnN++
 		}
 		if d.DurationMs >= 0 {
 			durations = append(durations, int64(d.DurationMs))
@@ -205,11 +236,32 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 	}
 	s.Versions = sortedKV(versionCounts)
 
-	s.StarHistogram = histogram(stars, func(k int) string { return fmt.Sprintf("%d★", k) })
-	s.LnRatioHistogram = histogram(lns, func(k int) string { return fmt.Sprintf("%d%%", k) })
+	s.StarHistogram = histogram(stars, func(k float64) string { return fmt.Sprintf("%.2f", k) })
+	s.LnRatioHistogram = histogram(lns, func(k float64) string { return fmt.Sprintf("%.2f", k) })
+	if starN > 0 {
+		s.AvgStar = math.Round(starSum/float64(starN)*100) / 100
+	}
+	if lnN > 0 {
+		s.AvgLnRatio = math.Round(lnSum/float64(lnN)*100) / 100
+	}
 	s.DurationStats = durationStats(durations)
 
 	return nil
+}
+
+// modCombo normalizes a mod array into a sorted combination key; no mods = NM.
+func modCombo(mods []string) string {
+	clean := make([]string, 0, len(mods))
+	for _, m := range mods {
+		if m = strings.TrimSpace(m); m != "" {
+			clean = append(clean, m)
+		}
+	}
+	if len(clean) == 0 {
+		return "NM"
+	}
+	sort.Strings(clean)
+	return strings.Join(clean, "+")
 }
 
 func sortedKV(m map[string]int64) []KV {
@@ -226,15 +278,15 @@ func sortedKV(m map[string]int64) []KV {
 	return out
 }
 
-func histogram(m map[int]int64, label func(int) string) []Bucket {
-	keys := make([]int, 0, len(m))
+func histogram(m map[float64]int64, key func(float64) string) []Bucket {
+	keys := make([]float64, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)
 	}
-	sort.Ints(keys)
+	sort.Float64s(keys)
 	out := make([]Bucket, 0, len(keys))
 	for _, k := range keys {
-		out = append(out, Bucket{Label: label(k), Count: m[k]})
+		out = append(out, Bucket{Key: key(k), Value: k, Count: m[k]})
 	}
 	return out
 }

--- a/backend/internal/analytics/analytics.go
+++ b/backend/internal/analytics/analytics.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	dayMs     = int64(24 * 60 * 60 * 1000)
-	trendDays = 30
+	dayMs = int64(24 * 60 * 60 * 1000)
 )
 
 type KV struct {
@@ -51,7 +50,7 @@ type Stats struct {
 	NewToday         int64         `json:"newToday"`
 	NewWeek          int64         `json:"newWeek"`
 	TotalEvents      int64         `json:"totalEvents"`
-	Analyze30d       int64         `json:"analyze30d"`
+	AnalyzeCount     int64         `json:"analyzeCount"`
 	AvgStar          float64       `json:"avgStar"`
 	AvgLnRatio       float64       `json:"avgLnRatio"`
 	PeakOnline       int64         `json:"peakOnline"`
@@ -83,13 +82,17 @@ type analyzeData struct {
 	DurationMs      float64         `json:"durationMs"`
 }
 
-// Compute builds the full aggregate snapshot over a 30-day analysis window.
-func Compute(st *store.Store, onlineWindowMin int) (*Stats, error) {
+// Compute builds the full aggregate snapshot over the requested window.
+// days <= 0 means "all time" (no lower bound); otherwise the last `days` days.
+func Compute(st *store.Store, onlineWindowMin, days int) (*Stats, error) {
 	now := time.Now().UTC()
 	nowMs := now.UnixMilli()
 	dayStart := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).UnixMilli()
 	windowMs := int64(onlineWindowMin) * 60 * 1000
-	since30d := nowMs - 30*dayMs
+	var since int64
+	if days > 0 {
+		since = nowMs - int64(days)*dayMs
+	}
 
 	s := &Stats{}
 	var err error
@@ -106,7 +109,7 @@ func Compute(st *store.Store, onlineWindowMin int) (*Stats, error) {
 	if s.WeekActive, err = st.CountActiveSince(nowMs - 7*dayMs); err != nil {
 		return nil, err
 	}
-	if s.MonthActive, err = st.CountActiveSince(since30d); err != nil {
+	if s.MonthActive, err = st.CountActiveSince(since); err != nil {
 		return nil, err
 	}
 	if s.NewToday, err = st.CountInstallsNew(dayStart); err != nil {
@@ -118,10 +121,10 @@ func Compute(st *store.Store, onlineWindowMin int) (*Stats, error) {
 	if s.TotalEvents, err = st.CountEvents(); err != nil {
 		return nil, err
 	}
-	if s.Analyze30d, err = st.CountAnalyzeSince(since30d); err != nil {
+	if s.AnalyzeCount, err = st.CountAnalyzeSince(since); err != nil {
 		return nil, err
 	}
-	if s.OnlineByHour, err = st.OnlineByHour(since30d); err != nil {
+	if s.OnlineByHour, err = st.OnlineByHour(since); err != nil {
 		return nil, err
 	}
 	for h, c := range s.OnlineByHour {
@@ -130,7 +133,7 @@ func Compute(st *store.Store, onlineWindowMin int) (*Stats, error) {
 			s.PeakOnlineHour = h
 		}
 	}
-	if s.ActiveTrend, err = buildTrend(st); err != nil {
+	if s.ActiveTrend, err = buildTrend(st, days); err != nil {
 		return nil, err
 	}
 	var activeSum int64
@@ -140,16 +143,23 @@ func Compute(st *store.Store, onlineWindowMin int) (*Stats, error) {
 	if len(s.ActiveTrend) > 0 {
 		s.AvgDailyActive = activeSum / int64(len(s.ActiveTrend))
 	}
-	if err = buildDistributions(st, since30d, s); err != nil {
+	if err = buildDistributions(st, since, s); err != nil {
 		return nil, err
 	}
 
 	return s, nil
 }
 
-func buildTrend(st *store.Store) ([]TrendDay, error) {
+func buildTrend(st *store.Store, days int) ([]TrendDay, error) {
+	n := days
+	if n <= 0 {
+		n = 90 // "all time" still shows a bounded recent window
+	}
+	if n > 366 {
+		n = 366
+	}
 	now := time.Now().UTC()
-	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -(trendDays - 1))
+	start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -(n - 1))
 	since := start.UnixMilli()
 
 	active, err := st.ActivePerDay(since)
@@ -161,8 +171,8 @@ func buildTrend(st *store.Store) ([]TrendDay, error) {
 		return nil, err
 	}
 
-	out := make([]TrendDay, 0, trendDays)
-	for i := 0; i < trendDays; i++ {
+	out := make([]TrendDay, 0, n)
+	for i := 0; i < n; i++ {
 		d := start.AddDate(0, 0, i)
 		dayEpoch := d.UnixMilli() / dayMs
 		out = append(out, TrendDay{
@@ -200,18 +210,27 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 		if d.Keycount > 0 {
 			keys[fmt.Sprintf("%dK", d.Keycount)]++
 		}
-		mods[modCombo(d.Mods)]++
+		if len(d.Mods) == 0 {
+			mods["NM"]++
+		} else {
+			for _, m := range d.Mods {
+				if m = strings.TrimSpace(m); m != "" {
+					mods[m]++
+				}
+			}
+		}
 		if d.Mode != "" {
 			modes[d.Mode]++
 		}
 		if d.Star > 0 {
-			// continuous: keep 2-decimal resolution
-			stars[math.Round(d.Star*100)/100]++
+			// aggregate into 0.5-star bins for the bar chart
+			stars[math.Round(d.Star*2)/2]++
 			starSum += d.Star
 			starN++
 		}
 		if d.LnRatio >= 0 && d.LnRatio <= 1 {
-			lns[math.Round(d.LnRatio*100)/100]++
+			// aggregate into 5% bins; labels are percentages
+			lns[math.Round(d.LnRatio*20)/20]++
 			lnSum += d.LnRatio
 			lnN++
 		}
@@ -236,8 +255,8 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 	}
 	s.Versions = sortedKV(versionCounts)
 
-	s.StarHistogram = histogram(stars, func(k float64) string { return fmt.Sprintf("%.2f", k) })
-	s.LnRatioHistogram = histogram(lns, func(k float64) string { return fmt.Sprintf("%.2f", k) })
+	s.StarHistogram = histogram(stars, func(k float64) string { return fmt.Sprintf("%.1f", k) })
+	s.LnRatioHistogram = histogram(lns, func(k float64) string { return fmt.Sprintf("%.0f%%", k*100) })
 	if starN > 0 {
 		s.AvgStar = math.Round(starSum/float64(starN)*100) / 100
 	}
@@ -247,21 +266,6 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 	s.DurationStats = durationStats(durations)
 
 	return nil
-}
-
-// modCombo normalizes a mod array into a sorted combination key; no mods = NM.
-func modCombo(mods []string) string {
-	clean := make([]string, 0, len(mods))
-	for _, m := range mods {
-		if m = strings.TrimSpace(m); m != "" {
-			clean = append(clean, m)
-		}
-	}
-	if len(clean) == 0 {
-		return "NM"
-	}
-	sort.Strings(clean)
-	return strings.Join(clean, "+")
 }
 
 func sortedKV(m map[string]int64) []KV {

--- a/backend/internal/analytics/analytics.go
+++ b/backend/internal/analytics/analytics.go
@@ -42,6 +42,7 @@ type DurationStats struct {
 }
 
 type Stats struct {
+	ServerVersion    string        `json:"serverVersion"`
 	TotalInstalls    int64         `json:"totalInstalls"`
 	OnlineNow        int64         `json:"onlineNow"`
 	TodayActive      int64         `json:"todayActive"`

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -58,9 +58,6 @@ func Load() (Config, error) {
 	if cfg.Addr == "" {
 		cfg.Addr = ":8080"
 	}
-	if cfg.RetentionDays <= 0 {
-		cfg.RetentionDays = 365
-	}
 	if cfg.OnlineWindowMin <= 0 {
 		cfg.OnlineWindowMin = 10
 	}

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -93,6 +93,18 @@ func (s *Store) CountActiveSince(since int64) (int64, error) {
 	return n, err
 }
 
+func (s *Store) CountEvents() (int64, error) {
+	var n int64
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM events`).Scan(&n)
+	return n, err
+}
+
+func (s *Store) CountAnalyzeSince(since int64) (int64, error) {
+	var n int64
+	err := s.db.QueryRow(`SELECT COUNT(*) FROM events WHERE kind='analyze' AND ts >= ?`, since).Scan(&n)
+	return n, err
+}
+
 // OnlineByHour returns, for each hour-of-day (0-23, UTC), how many distinct
 // installs had an event in that hour across the whole `since` window.
 func (s *Store) OnlineByHour(since int64) ([24]int64, error) {

--- a/backend/internal/telemetry/handler.go
+++ b/backend/internal/telemetry/handler.go
@@ -20,16 +20,17 @@ const maxBodyBytes = 16 * 1024
 // allowedDataKeys is the only data a client may contribute. Everything else is
 // dropped server-side so a modified client cannot smuggle extra fields.
 var allowedDataKeys = map[string]bool{
-	"algorithm":       true,
-	"actualAlgorithm": true,
-	"keycount":        true,
-	"mods":            true,
-	"speedRate":       true,
-	"mode":            true,
-	"star":            true,
-	"lnRatio":         true,
-	"typeBreakdown":   true,
-	"durationMs":      true,
+	"algorithm":         true,
+	"actualAlgorithm":   true,
+	"keycount":          true,
+	"mods":              true,
+	"speedRate":         true,
+	"mode":              true,
+	"star":              true,
+	"lnRatio":           true,
+	"typeBreakdown":     true,
+	"durationMs":        true,
+	"numericDifficulty": true,
 }
 
 type eventPayload struct {

--- a/backend/internal/web/dashboard.html
+++ b/backend/internal/web/dashboard.html
@@ -68,7 +68,6 @@
   .delta.flat { color: var(--muted); }
 
   .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 12px; margin-bottom: 12px; }
-  .grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; margin-bottom: 12px; }
   .grid4 { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 12px; }
   .panel {
     background: var(--panel);
@@ -164,20 +163,18 @@
     </section>
   </div>
 
-  <div class="grid3">
-    <section class="panel">
-      <h2>Star rating <small>0.5-star bins</small></h2>
-      <div class="body chart-wrap"><div id="starHistogram"></div></div>
-    </section>
-    <section class="panel">
-      <h2>LN ratio <small>5% bins</small></h2>
-      <div class="body chart-wrap"><div id="lnRatioHistogram"></div></div>
-    </section>
-    <section class="panel">
-      <h2>Numeric difficulty <small>0.5 bins · .0 = mid</small></h2>
-      <div class="body chart-wrap"><div id="numericHistogram"></div></div>
-    </section>
-  </div>
+  <section class="panel" style="margin-bottom:12px">
+    <h2>Star rating <small>0.5-star bins</small></h2>
+    <div class="body chart-wrap"><div id="starHistogram"></div></div>
+  </section>
+  <section class="panel" style="margin-bottom:12px">
+    <h2>LN ratio <small>5% bins</small></h2>
+    <div class="body chart-wrap"><div id="lnRatioHistogram"></div></div>
+  </section>
+  <section class="panel" style="margin-bottom:12px">
+    <h2>Numeric difficulty <small>0.5 bins · .0 = mid</small></h2>
+    <div class="body chart-wrap"><div id="numericHistogram"></div></div>
+  </section>
 
   <div class="grid4">
     <section class="panel"><h2>Key count</h2><div class="body" id="keycounts"></div></section>

--- a/backend/internal/web/dashboard.html
+++ b/backend/internal/web/dashboard.html
@@ -7,137 +7,167 @@
 <style>
   :root {
     --bg: #0d1117;
-    --panel: #161b27;
-    --panel-2: #1c2333;
-    --border: #232b3d;
+    --panel: #151b28;
+    --panel-2: #1b2334;
+    --border: #222c40;
     --fg: #e6edf7;
     --muted: #8b95ad;
     --accent: #4bb3fd;
     --accent-2: #8b5cf6;
     --ok: #3ddc97;
+    --warn: #fbbf24;
     --danger: #f87171;
     --track: #232b3d;
-    --radius: 14px;
+    --radius: 12px;
   }
   * { box-sizing: border-box; }
   html, body { margin: 0; padding: 0; }
   body {
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, "PingFang SC", "Microsoft YaHei", sans-serif;
     background:
-      radial-gradient(1200px 600px at 80% -10%, rgba(139, 92, 246, .14), transparent 60%),
-      radial-gradient(1000px 500px at -10% 0%, rgba(75, 179, 253, .12), transparent 55%),
+      radial-gradient(1100px 500px at 85% -10%, rgba(139, 92, 246, .13), transparent 60%),
+      radial-gradient(900px 450px at -10% 0%, rgba(75, 179, 253, .11), transparent 55%),
       var(--bg);
     color: var(--fg);
     min-height: 100vh;
   }
-  header { max-width: 1120px; margin: 0 auto; padding: 36px 24px 8px; }
-  header h1 { font-size: 24px; margin: 0; letter-spacing: .01em; }
+  header { max-width: 1180px; margin: 0 auto; padding: 28px 20px 6px; }
+  header h1 { font-size: 21px; margin: 0; letter-spacing: .01em; }
   header h1 .dot { color: var(--accent); }
-  .sub { color: var(--muted); font-size: 13.5px; margin: 6px 0 0; }
-  .meta { color: var(--muted); font-size: 12px; margin-top: 6px; display: flex; gap: 16px; flex-wrap: wrap; }
-  .meta .live { color: var(--ok); }
-  main { max-width: 1120px; margin: 0 auto; padding: 22px 24px 56px; }
+  .sub { color: var(--muted); font-size: 12.5px; margin: 5px 0 0; }
+  .meta { color: var(--muted); font-size: 11.5px; margin-top: 6px; display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
+  .live { color: var(--ok); display: inline-flex; align-items: center; gap: 5px; }
+  .live::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--ok); box-shadow: 0 0 8px var(--ok); }
+  main { max-width: 1180px; margin: 0 auto; padding: 16px 20px 44px; }
 
-  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 12px; margin-bottom: 18px; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(128px, 1fr)); gap: 10px; margin-bottom: 14px; }
   .card {
     background: linear-gradient(160deg, var(--panel-2), var(--panel));
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 16px 16px 14px;
+    padding: 12px 13px 11px;
     position: relative;
     overflow: hidden;
+    transition: transform .15s ease, border-color .15s ease;
+    cursor: default;
   }
-  .card::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 3px; background: var(--card-accent, var(--accent)); opacity: .8; }
-  .card .v { font-size: 30px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.02em; }
-  .card .k { font-size: 12px; color: var(--muted); margin-top: 6px; }
+  .card:hover { transform: translateY(-2px); border-color: var(--card-accent, var(--accent)); }
+  .card::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 2.5px; background: var(--card-accent, var(--accent)); opacity: .85; }
+  .card .v { font-size: 24px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.01em; display: flex; align-items: baseline; gap: 7px; }
+  .card .k { font-size: 11.5px; color: var(--muted); margin-top: 5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .delta { font-size: 11.5px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .delta.up { color: var(--ok); }
+  .delta.down { color: var(--danger); }
+  .delta.flat { color: var(--muted); }
 
-  .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(420px, 1fr)); gap: 16px; margin-bottom: 16px; }
-  .grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 16px; margin-bottom: 16px; }
+  .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 12px; margin-bottom: 12px; }
+  .grid4 { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 12px; }
   .panel {
     background: var(--panel);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    padding: 18px 18px 14px;
+    padding: 14px 14px 12px;
+    display: flex;
+    flex-direction: column;
   }
-  .panel h2 { font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); margin: 0 0 14px; }
-  .panel h2 small { text-transform: none; letter-spacing: 0; color: #6b7691; font-weight: 400; }
+  .panel h2 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 0 0 10px; display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
+  .panel h2 small { text-transform: none; letter-spacing: 0; color: #64708c; font-weight: 400; font-size: 11px; }
+  .panel .body { flex: 1; min-height: 0; }
 
-  .bars { display: flex; flex-direction: column; gap: 7px; }
-  .bar-row { display: flex; align-items: center; gap: 10px; font-size: 13px; }
-  .bar-label { flex: 0 0 110px; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .bar-track { flex: 1; background: var(--track); border-radius: 6px; height: 14px; overflow: hidden; }
-  .bar-fill { height: 100%; border-radius: 6px; background: linear-gradient(90deg, var(--accent), var(--accent-2)); min-width: 2px; }
-  .bar-count { flex: 0 0 76px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; font-size: 12px; }
+  .bars { display: flex; flex-direction: column; gap: 6px; max-height: 232px; overflow-y: auto; padding-right: 2px; }
+  .bars::-webkit-scrollbar { width: 6px; }
+  .bars::-webkit-scrollbar-thumb { background: #2b3650; border-radius: 3px; }
+  .bar-row { display: flex; align-items: center; gap: 9px; font-size: 12.5px; }
+  .bar-label { flex: 0 0 96px; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .bar-track { flex: 1; background: var(--track); border-radius: 5px; height: 13px; overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 5px; background: linear-gradient(90deg, var(--accent), var(--accent-2)); min-width: 2px; transition: filter .15s ease; }
+  .bar-row:hover .bar-fill { filter: brightness(1.25); }
+  .bar-count { flex: 0 0 72px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; font-size: 11.5px; white-space: nowrap; }
 
-  svg text { fill: var(--muted); font-size: 10px; }
+  .more-btn {
+    align-self: flex-start; margin-top: 4px;
+    background: var(--panel-2); color: var(--accent);
+    border: 1px solid var(--border); border-radius: 7px;
+    padding: 4px 10px; font-size: 11.5px; cursor: pointer;
+  }
+  .more-btn:hover { border-color: var(--accent); }
+
+  svg text { fill: var(--muted); font-size: 9.5px; }
   .chart-wrap { overflow-x: auto; }
+  .chart-wrap svg { display: block; }
 
-  .donut-wrap { display: flex; align-items: center; gap: 18px; flex-wrap: wrap; }
-  .legend { display: flex; flex-direction: column; gap: 6px; font-size: 13px; flex: 1; min-width: 120px; }
-  .legend-row { display: flex; align-items: center; gap: 8px; }
-  .legend-row .sw { width: 10px; height: 10px; border-radius: 3px; flex: none; }
-  .legend-row .lk { flex: 1; }
-  .legend-row .lv { color: var(--muted); font-variant-numeric: tabular-nums; }
+  .donut-wrap { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
+  .legend { display: flex; flex-direction: column; gap: 5px; font-size: 12px; flex: 1; min-width: 108px; }
+  .legend-row { display: flex; align-items: center; gap: 7px; }
+  .legend-row .sw { width: 9px; height: 9px; border-radius: 3px; flex: none; }
+  .legend-row .lk { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .legend-row .lv { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 11.5px; white-space: nowrap; }
 
-  .chips { display: flex; gap: 10px; flex-wrap: wrap; }
-  .chip { flex: 1; min-width: 90px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 12px; text-align: center; }
-  .chip .cv { font-size: 20px; font-weight: 700; font-variant-numeric: tabular-nums; }
-  .chip .ck { font-size: 11px; color: var(--muted); margin-top: 4px; }
+  .chips { display: flex; gap: 8px; flex-wrap: wrap; }
+  .chip { flex: 1; min-width: 104px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
+  .chip .cv { font-size: 17px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .chip .ck { font-size: 10.5px; color: var(--muted); margin-top: 3px; }
 
-  .empty { color: var(--muted); font-size: 13px; padding: 10px 0; }
-  .error { color: var(--danger); font-size: 13px; padding: 10px 0; }
-  footer { max-width: 1120px; margin: 0 auto; padding: 0 24px 40px; color: #6b7691; font-size: 12px; }
+  .empty { color: var(--muted); font-size: 12.5px; padding: 8px 0; }
+  .error { color: var(--danger); font-size: 12.5px; padding: 8px 0; }
+  footer { max-width: 1180px; margin: 0 auto; padding: 0 20px 36px; color: #5f6b88; font-size: 11.5px; }
 </style>
 </head>
 <body>
 <header>
   <h1>ManiaMapAnalyser <span class="dot">·</span> Usage Statistics</h1>
-  <p class="sub">Anonymous aggregate statistics. No usernames, no beatmap identity, and no IP addresses are collected or stored.</p>
-  <p class="meta"><span class="live">● live</span><span id="updated">loading…</span></p>
+  <p class="sub">Anonymous aggregate statistics — no usernames, no beatmap identity, no IP addresses.</p>
+  <p class="meta"><span class="live">live</span><span id="updated">loading…</span></p>
 </header>
 <main>
   <section id="overview" class="cards"></section>
 
   <div class="grid2">
     <section class="panel">
-      <h2>Online by hour <small>· UTC · last 30 days</small></h2>
-      <div class="chart-wrap"><div id="onlineByHour"></div></div>
+      <h2>Online by hour <small>UTC · 30d</small></h2>
+      <div class="body chart-wrap"><div id="onlineByHour"></div></div>
     </section>
     <section class="panel">
-      <h2>Active installs per day <small>· last 30 days</small></h2>
-      <div class="chart-wrap"><div id="trend"></div></div>
+      <h2>Active per day <small>30d</small></h2>
+      <div class="body chart-wrap"><div id="trend"></div></div>
     </section>
   </div>
 
   <div class="grid2">
-    <section class="panel"><h2>Selected algorithm</h2><div id="algorithms" class="bars"></div></section>
-    <section class="panel"><h2>Actual algorithm</h2><div id="actualAlgorithms" class="bars"></div></section>
+    <section class="panel">
+      <h2>Star rating <small>continuous · 0.01 bins</small></h2>
+      <div class="body chart-wrap"><div id="starHistogram"></div></div>
+    </section>
+    <section class="panel">
+      <h2>LN ratio <small>continuous · 0.01 bins</small></h2>
+      <div class="body chart-wrap"><div id="lnRatioHistogram"></div></div>
+    </section>
   </div>
 
-  <div class="grid3">
-    <section class="panel"><h2>Key count</h2><div id="keycounts"></div></section>
-    <section class="panel"><h2>Mode</h2><div id="modes"></div></section>
-    <section class="panel"><h2>Analysis duration</h2><div id="duration"></div></section>
+  <div class="grid4">
+    <section class="panel"><h2>Key count</h2><div class="body" id="keycounts"></div></section>
+    <section class="panel"><h2>Beatmap type <small>HB/RC/LN/Mix/SV</small></h2><div class="body" id="modes"></div></section>
+    <section class="panel"><h2>Mods <small>NM = no mod</small></h2><div class="body" id="mods"></div></section>
+    <section class="panel"><h2>Version</h2><div class="body" id="versions"></div></section>
   </div>
 
   <div class="grid2">
-    <section class="panel"><h2>Mods</h2><div id="mods" class="bars"></div></section>
-    <section class="panel"><h2>Version</h2><div id="versions" class="bars"></div></section>
+    <section class="panel"><h2>Selected algorithm</h2><div class="body" id="algorithms" class="bars"></div></section>
+    <section class="panel"><h2>Actual algorithm</h2><div class="body" id="actualAlgorithms" class="bars"></div></section>
   </div>
 
-  <div class="grid2">
-    <section class="panel"><h2>Star rating</h2><div id="starHistogram" class="bars"></div></section>
-    <section class="panel"><h2>LN ratio</h2><div id="lnRatioHistogram" class="bars"></div></section>
-  </div>
+  <section class="panel" style="margin-bottom:12px">
+    <h2>Analysis metrics</h2>
+    <div class="body"><div id="metrics" class="chips"></div></div>
+  </section>
 </main>
-<footer>Aggregate statistics · refreshed every 60 s · rendered with vanilla JS + SVG, no trackers.</footer>
+<footer>Aggregate statistics · refreshed every 60 s · vanilla JS + SVG, no trackers.</footer>
 
 <script>
 "use strict";
 
-// XSS policy: every client-controlled string (keys, versions, dates) is written
-// via textContent only. Numeric attributes are computed numbers — safe.
-const PALETTE = ["#4bb3fd", "#8b5cf6", "#3ddc97", "#fbbf24", "#f87171", "#f472b6", "#2dd4bf", "#a3b18a", "#60a5fa", "#c084fc"];
+// XSS policy: every client-controlled string is written via textContent only.
+const PALETTE = ["#4bb3fd", "#8b5cf6", "#3ddc97", "#fbbf24", "#f87171", "#f472b6", "#2dd4bf", "#60a5fa", "#c084fc", "#94a3b8"];
 
 function el(tag, cls, text) {
   const e = document.createElement(tag);
@@ -145,44 +175,92 @@ function el(tag, cls, text) {
   if (text != null) e.textContent = String(text);
   return e;
 }
-
 function svgEl(tag, attrs) {
   const e = document.createElementNS("http://www.w3.org/2000/svg", tag);
   for (const k in attrs) e.setAttribute(k, String(attrs[k]));
   return e;
 }
-
+function title(el_, text) {
+  const t = svgEl("title", {});
+  t.textContent = String(text);
+  el_.appendChild(t);
+}
 function emptyBox(host, msg) {
   host.textContent = "";
   host.appendChild(el("div", "empty", msg || "No data yet"));
 }
-
-function card(k, v, accent) {
+function fmtCompact(n) {
+  n = Number(n) || 0;
+  if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
+  if (n >= 1e4) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
+  return String(n);
+}
+function deltaSpan(delta) {
+  const s = el("span", "delta");
+  if (delta == null || !isFinite(delta)) { s.className = "delta flat"; s.textContent = "—"; return s; }
+  if (delta > 0) { s.className = "delta up"; s.textContent = "▲ " + fmtCompact(delta); }
+  else if (delta < 0) { s.className = "delta down"; s.textContent = "▼ " + fmtCompact(-delta); }
+  else { s.className = "delta flat"; s.textContent = "–"; }
+  return s;
+}
+function card(k, v, opts) {
   const d = el("div", "card");
-  if (accent) d.style.setProperty("--card-accent", accent);
-  d.appendChild(el("div", "v", v));
+  const accent = (opts && opts.accent) || "#4bb3fd";
+  d.style.setProperty("--card-accent", accent);
+  const vWrap = el("div", "v");
+  vWrap.appendChild(el("span", "", fmtCompact(v)));
+  if (opts && opts.delta != null) vWrap.appendChild(deltaSpan(opts.delta));
+  d.appendChild(vWrap);
   d.appendChild(el("div", "k", k));
   return d;
 }
 
-function renderBars(id, items) {
+function renderCards(s) {
+  const trend = s.activeTrend || [];
+  const t = trend[trend.length - 1], y = trend[trend.length - 2];
+  const todayDelta = (t && y) ? t.active - y.active : null;
+  const sum = (arr) => arr.reduce((a, b) => a + b, 0);
+  const last7 = trend.slice(-7), prev7 = trend.slice(-14, -7);
+  const weekDelta = (last7.length && prev7.length) ? sum(last7.map((d) => d.active)) - sum(prev7.map((d) => d.active)) : null;
+
+  const ov = document.getElementById("overview");
+  ov.textContent = "";
+  ov.appendChild(card("Total installs", s.totalInstalls, { accent: "#4bb3fd" }));
+  ov.appendChild(card("Online now", s.onlineNow, { accent: "#3ddc97" }));
+  ov.appendChild(card("Active today", s.todayActive, { accent: "#fbbf24", delta: todayDelta }));
+  ov.appendChild(card("Active 7d", s.weekActive, { accent: "#8b5cf6", delta: weekDelta }));
+  ov.appendChild(card("Active 30d", s.monthActive, { accent: "#f472b6" }));
+  ov.appendChild(card("New today", s.newToday, { accent: "#2dd4bf" }));
+  ov.appendChild(card("New 7d", s.newWeek, { accent: "#60a5fa" }));
+  ov.appendChild(card("Total events", s.totalEvents, { accent: "#c084fc" }));
+}
+
+function renderBars(id, items, cap) {
   const c = document.getElementById(id);
   c.textContent = "";
   if (!items.length) { emptyBox(c); return; }
+  const limit = (cap && items.length > cap) ? cap : items.length;
   let max = 1;
   for (const it of items) if (it.count > max) max = it.count;
-  for (const it of items) {
+  for (let i = 0; i < limit; i++) {
+    const it = items[i];
     const row = el("div", "bar-row");
     const label = el("span", "bar-label", it.key);
+    label.title = String(it.key);
     const track = el("div", "bar-track");
     const fill = el("div", "bar-fill");
     fill.style.width = Math.round((it.count / max) * 100) + "%";
+    fill.title = it.key + " — " + it.count + " (" + Math.round((it.count / max) * 100) + "%)";
     track.appendChild(fill);
-    const pct = Math.round((it.count / max) * 100);
     row.appendChild(label);
     row.appendChild(track);
-    row.appendChild(el("span", "bar-count", it.count + " · " + pct + "%"));
+    row.appendChild(el("span", "bar-count", fmtCompact(it.count) + " · " + Math.round((it.count / max) * 100) + "%"));
     c.appendChild(row);
+  }
+  if (items.length > limit) {
+    const btn = el("button", "more-btn", "Show all " + items.length);
+    btn.addEventListener("click", () => renderBars(id, items, 0));
+    c.appendChild(btn);
   }
 }
 
@@ -190,29 +268,25 @@ function renderHourBars(id, counts) {
   const c = document.getElementById(id);
   c.textContent = "";
   if (!counts || !counts.length) { emptyBox(c); return; }
-  const W = 560, H = 150, PAD = 6;
+  const W = 560, H = 132, PAD = 4;
   const max = Math.max.apply(null, counts.concat([1]));
   const bw = (W - PAD * 2) / counts.length;
-  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%", "max-width": "560px" });
-  const grad = svgEl("defs", {});
+  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
   const lg = svgEl("linearGradient", { id: "barGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
   lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#4bb3fd" }));
   lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#8b5cf6" }));
-  grad.appendChild(lg);
-  svg.appendChild(grad);
+  svg.appendChild(lg);
   for (let i = 0; i < counts.length; i++) {
     const v = counts[i] || 0;
     const h = Math.max(1, (v / max) * (H - PAD * 2 - 14));
     const x = PAD + i * bw + bw * 0.18;
     const w = bw * 0.64;
     const rect = svgEl("rect", { x: x.toFixed(1), y: (H - PAD - h).toFixed(1), width: w.toFixed(1), height: h.toFixed(1), rx: 2, fill: "url(#barGrad)" });
-    const t = svgEl("title", {});
-    t.textContent = String(i).padStart(2, "0") + ":00 — " + v + " installs";
-    rect.appendChild(t);
+    title(rect, String(i).padStart(2, "0") + ":00 UTC — " + v + " installs");
     svg.appendChild(rect);
     if (i % 4 === 0) {
-      const tx = svgEl("text", { x: (x + w / 2).toFixed(1), y: H - 2, "text-anchor": "middle" });
-      tx.textContent = String(i).padStart(2, "0") + "h";
+      const tx = svgEl("text", { x: (x + w / 2).toFixed(1), y: H - 1, "text-anchor": "middle" });
+      tx.textContent = String(i).padStart(2, "0");
       svg.appendChild(tx);
     }
   }
@@ -223,76 +297,120 @@ function renderTrend(id, trend) {
   const c = document.getElementById(id);
   c.textContent = "";
   if (!trend || !trend.length) { emptyBox(c); return; }
-  const W = 560, H = 150, PAD = 10;
+  const W = 560, H = 132, PAD = 8;
   const max = Math.max.apply(null, trend.map((d) => Math.max(d.active, d.new)).concat([1]));
   const n = trend.length;
   const x = (i) => PAD + (i * (W - PAD * 2)) / Math.max(n - 1, 1);
-  const y = (v) => H - PAD - (v / max) * (H - PAD * 2 - 14);
+  const y = (v) => H - PAD - (v / max) * (H - PAD * 2 - 12);
 
-  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%", "max-width": "560px" });
-  const grad = svgEl("defs", {});
+  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
   const lg = svgEl("linearGradient", { id: "areaGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
-  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#4bb3fd", "stop-opacity": "0.35" }));
+  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#4bb3fd", "stop-opacity": "0.3" }));
   lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#4bb3fd", "stop-opacity": "0" }));
-  grad.appendChild(lg);
-  svg.appendChild(grad);
+  svg.appendChild(lg);
 
   for (let g = 0; g < 3; g++) {
-    const gy = PAD + (g * (H - PAD * 2 - 14)) / 2;
+    const gy = PAD + (g * (H - PAD * 2 - 12)) / 2;
     svg.appendChild(svgEl("line", { x1: PAD, y1: gy.toFixed(1), x2: W - PAD, y2: gy.toFixed(1), stroke: "#232b3d", "stroke-width": 1 }));
   }
 
-  const activePts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.active).toFixed(1)).join(" ");
+  const actPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.active).toFixed(1)).join(" ");
   const newPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.new).toFixed(1)).join(" ");
-  const area = "M" + x(0).toFixed(1) + "," + y(trend[0].active).toFixed(1) + " L" + activePts.replace(/ /g, " L") + " L" + x(n - 1).toFixed(1) + "," + (H - PAD).toFixed(1) + " L" + x(0).toFixed(1) + "," + (H - PAD).toFixed(1) + " Z";
+  const area = "M" + x(0).toFixed(1) + "," + y(trend[0].active).toFixed(1) + " L" + actPts.replace(/ /g, " L") +
+    " L" + x(n - 1).toFixed(1) + "," + (H - PAD).toFixed(1) + " L" + x(0).toFixed(1) + "," + (H - PAD).toFixed(1) + " Z";
   svg.appendChild(svgEl("path", { d: area, fill: "url(#areaGrad)" }));
-  svg.appendChild(svgEl("polyline", { points: activePts, fill: "none", stroke: "#4bb3fd", "stroke-width": 2, "stroke-linejoin": "round" }));
-  svg.appendChild(svgEl("polyline", { points: newPts, fill: "none", stroke: "#3ddc97", "stroke-width": 1.5, "stroke-linejoin": "round", "stroke-dasharray": "3 3" }));
-
+  svg.appendChild(svgEl("polyline", { points: actPts, fill: "none", stroke: "#4bb3fd", "stroke-width": 2, "stroke-linejoin": "round" }));
+  svg.appendChild(svgEl("polyline", { points: newPts, fill: "none", stroke: "#3ddc97", "stroke-width": 1.3, "stroke-linejoin": "round", "stroke-dasharray": "3 3" }));
+  trend.forEach((d, i) => {
+    const dot = svgEl("circle", { cx: x(i).toFixed(1), cy: y(d.active).toFixed(1), r: 2, fill: "#4bb3fd" });
+    title(dot, d.date + " · active " + d.active + " · new " + d.new);
+    svg.appendChild(dot);
+  });
   const step = Math.ceil(n / 6);
   for (let i = 0; i < n; i += step) {
-    const tx = svgEl("text", { x: x(i).toFixed(1), y: H - 2, "text-anchor": "middle" });
+    const tx = svgEl("text", { x: x(i).toFixed(1), y: H - 1, "text-anchor": "middle" });
     tx.textContent = trend[i].date ? trend[i].date.slice(5) : "";
     svg.appendChild(tx);
   }
   c.appendChild(svg);
 }
 
-function renderDonut(id, items) {
+function renderValueLine(id, buckets) {
+  const c = document.getElementById(id);
+  c.textContent = "";
+  if (!buckets || !buckets.length) { emptyBox(c); return; }
+  const W = 560, H = 132, PAD = 8;
+  const v0 = buckets[0].value, v1 = buckets[buckets.length - 1].value;
+  const maxC = Math.max.apply(null, buckets.map((b) => b.count).concat([1]));
+  const x = (v) => PAD + ((v - v0) / ((v1 - v0) || 1)) * (W - PAD * 2);
+  const y = (cnt) => H - PAD - (cnt / maxC) * (H - PAD * 2 - 12);
+
+  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
+  const lg = svgEl("linearGradient", { id: "valGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
+  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#8b5cf6", "stop-opacity": "0.28" }));
+  lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#8b5cf6", "stop-opacity": "0" }));
+  svg.appendChild(lg);
+  for (let g = 0; g < 3; g++) {
+    const gy = PAD + (g * (H - PAD * 2 - 12)) / 2;
+    svg.appendChild(svgEl("line", { x1: PAD, y1: gy.toFixed(1), x2: W - PAD, y2: gy.toFixed(1), stroke: "#232b3d", "stroke-width": 1 }));
+  }
+
+  const pts = buckets.map((b) => x(b.value).toFixed(1) + "," + y(b.count).toFixed(1)).join(" ");
+  const area = "M" + x(v0).toFixed(1) + "," + y(0).toFixed(1) + " L" + pts.replace(/ /g, " L") + " L" + x(v1).toFixed(1) + "," + y(0).toFixed(1) + " Z";
+  svg.appendChild(svgEl("path", { d: area, fill: "url(#valGrad)" }));
+  svg.appendChild(svgEl("polyline", { points: pts, fill: "none", stroke: "#8b5cf6", "stroke-width": 2, "stroke-linejoin": "round" }));
+  buckets.forEach((b) => {
+    const dot = svgEl("circle", { cx: x(b.value).toFixed(1), cy: y(b.count).toFixed(1), r: 2.5, fill: "#8b5cf6" });
+    title(dot, b.key + " → " + b.count);
+    svg.appendChild(dot);
+  });
+  const mid = v0 + (v1 - v0) / 2;
+  [v0, mid, v1].forEach((v) => {
+    const tx = svgEl("text", { x: x(v).toFixed(1), y: H - 1, "text-anchor": "middle" });
+    tx.textContent = v.toFixed(2);
+    svg.appendChild(tx);
+  });
+  c.appendChild(svg);
+}
+
+function renderDonut(id, items, maxSlices) {
   const c = document.getElementById(id);
   c.textContent = "";
   if (!items.length) { emptyBox(c); return; }
-  const total = items.reduce((s, it) => s + it.count, 0) || 1;
-  const svg = svgEl("svg", { viewBox: "0 0 42 42", width: "120", height: "120" });
+  const MAX = maxSlices || 6;
+  let slices = items;
+  if (items.length > MAX) {
+    const top = items.slice(0, MAX - 1);
+    const other = items.slice(MAX - 1).reduce((s, it) => s + it.count, 0);
+    slices = top.concat([{ key: "Other", count: other }]);
+  }
+  const total = slices.reduce((s, it) => s + it.count, 0) || 1;
+  const svg = svgEl("svg", { viewBox: "0 0 42 42", width: "108", height: "108", "aria-hidden": "true" });
   let angle = 0;
-  items.forEach((it, i) => {
+  slices.forEach((it, i) => {
     const frac = it.count / total;
     const circle = svgEl("circle", {
-      cx: 21, cy: 21, r: 15.915,
-      fill: "none",
-      "stroke-width": 5,
+      cx: 21, cy: 21, r: 15.915, fill: "none", "stroke-width": 4.6,
       stroke: PALETTE[i % PALETTE.length],
       "stroke-dasharray": (frac * 100).toFixed(2) + " " + (100 - frac * 100).toFixed(2),
       "stroke-dashoffset": (-angle * 100).toFixed(2),
     });
-    const t = svgEl("title", {});
-    t.textContent = it.key + " — " + it.count;
-    circle.appendChild(t);
+    title(circle, it.key + " — " + it.count + " (" + Math.round((it.count / total) * 100) + "%)");
     svg.appendChild(circle);
     angle += frac;
   });
-  const center = svgEl("text", { x: 21, y: 23.5, "text-anchor": "middle", "font-size": "6.5", fill: "#e6edf7", "font-weight": "700" });
-  center.textContent = total;
+  const center = svgEl("text", { x: 21, y: 23, "text-anchor": "middle", "font-size": "6", fill: "#e6edf7", "font-weight": "700" });
+  center.textContent = fmtCompact(total);
   svg.appendChild(center);
 
   const legend = el("div", "legend");
-  items.forEach((it, i) => {
+  slices.forEach((it, i) => {
     const row = el("div", "legend-row");
     const sw = el("span", "sw");
     sw.style.background = PALETTE[i % PALETTE.length];
     row.appendChild(sw);
     row.appendChild(el("span", "lk", it.key));
-    row.appendChild(el("span", "lv", it.count + " · " + Math.round((it.count / total) * 100) + "%"));
+    row.appendChild(el("span", "lv", fmtCompact(it.count) + " · " + Math.round((it.count / total) * 100) + "%"));
     legend.appendChild(row);
   });
   const wrap = el("div", "donut-wrap");
@@ -301,18 +419,25 @@ function renderDonut(id, items) {
   c.appendChild(wrap);
 }
 
-function renderDuration(id, d) {
-  const c = document.getElementById(id);
+function renderMetrics(s) {
+  const c = document.getElementById("metrics");
   c.textContent = "";
-  if (!d || !d.avgMs) { emptyBox(c, "No data yet"); return; }
-  const chips = el("div", "chips");
-  for (const [k, v] of [["Average", d.avgMs], ["p50", d.p50Ms], ["p90", d.p90Ms]]) {
+  const items = [
+    ["Avg star", s.avgStar ? s.avgStar.toFixed(2) : "—"],
+    ["Avg LN ratio", s.avgLnRatio ? s.avgLnRatio.toFixed(2) : "—"],
+    ["Analyzes · 30d", fmtCompact(s.analyze30d)],
+    ["Peak online", s.peakOnline ? fmtCompact(s.peakOnline) + " @" + String(s.peakOnlineHour).padStart(2, "0") + ":00 UTC" : "—"],
+    ["Avg daily active", fmtCompact(s.avgDailyActive)],
+    ["Duration avg", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms"],
+    ["Duration p50", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms"],
+    ["Duration p90", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms"],
+  ];
+  for (const [k, v] of items) {
     const chip = el("div", "chip");
-    chip.appendChild(el("div", "cv", (v || 0) + " ms"));
+    chip.appendChild(el("div", "cv", v));
     chip.appendChild(el("div", "ck", k));
-    chips.appendChild(chip);
+    c.appendChild(chip);
   }
-  c.appendChild(chips);
 }
 
 fetch("/api/v1/stats")
@@ -322,27 +447,18 @@ fetch("/api/v1/stats")
   })
   .then((s) => {
     document.getElementById("updated").textContent = "updated " + new Date().toLocaleString();
-
-    const ov = document.getElementById("overview");
-    ov.appendChild(card("Total installs", s.totalInstalls, "#4bb3fd"));
-    ov.appendChild(card("Online now", s.onlineNow, "#3ddc97"));
-    ov.appendChild(card("Active today", s.todayActive, "#fbbf24"));
-    ov.appendChild(card("Active 7d", s.weekActive, "#8b5cf6"));
-    ov.appendChild(card("Active 30d", s.monthActive, "#f472b6"));
-    ov.appendChild(card("New today", s.newToday, "#2dd4bf"));
-    ov.appendChild(card("New 7d", s.newWeek, "#60a5fa"));
-
+    renderCards(s);
     renderHourBars("onlineByHour", s.onlineByHour || []);
     renderTrend("trend", s.activeTrend || []);
-    renderBars("algorithms", s.algorithms || []);
-    renderBars("actualAlgorithms", s.actualAlgorithms || []);
-    renderDonut("keycounts", s.keycounts || []);
+    renderValueLine("starHistogram", s.starHistogram || []);
+    renderValueLine("lnRatioHistogram", s.lnRatioHistogram || []);
+    renderBars("keycounts", s.keycounts || []);
     renderDonut("modes", s.modes || []);
-    renderDuration("duration", s.durationStats || {});
-    renderBars("mods", s.mods || []);
-    renderBars("versions", s.versions || []);
-    renderBars("starHistogram", s.starHistogram || []);
-    renderBars("lnRatioHistogram", s.lnRatioHistogram || []);
+    renderDonut("mods", s.mods || []);
+    renderDonut("versions", s.versions || []);
+    renderBars("algorithms", s.algorithms || [], 8);
+    renderBars("actualAlgorithms", s.actualAlgorithms || [], 8);
+    renderMetrics(s);
   })
   .catch((err) => {
     const ov = document.getElementById("overview");

--- a/backend/internal/web/dashboard.html
+++ b/backend/internal/web/dashboard.html
@@ -68,6 +68,7 @@
   .delta.flat { color: var(--muted); }
 
   .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 12px; margin-bottom: 12px; }
+  .grid3 { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 12px; margin-bottom: 12px; }
   .grid4 { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 12px; }
   .panel {
     background: var(--panel);
@@ -163,7 +164,7 @@
     </section>
   </div>
 
-  <div class="grid2">
+  <div class="grid3">
     <section class="panel">
       <h2>Star rating <small>0.5-star bins</small></h2>
       <div class="body chart-wrap"><div id="starHistogram"></div></div>
@@ -171,6 +172,10 @@
     <section class="panel">
       <h2>LN ratio <small>5% bins</small></h2>
       <div class="body chart-wrap"><div id="lnRatioHistogram"></div></div>
+    </section>
+    <section class="panel">
+      <h2>Numeric difficulty <small>0.5 bins · .0 = mid</small></h2>
+      <div class="body chart-wrap"><div id="numericHistogram"></div></div>
     </section>
   </div>
 
@@ -504,6 +509,7 @@ function load() {
       renderTrend("trend", s.activeTrend || []);
       renderValueBars("starHistogram", s.starHistogram || []);
       renderValueBars("lnRatioHistogram", s.lnRatioHistogram || []);
+      renderValueBars("numericHistogram", s.numericHistogram || []);
       renderHBar("keycounts", s.keycounts || []);
       renderDonut("modes", s.modes || []);
       renderDonut("mods", s.mods || []);

--- a/backend/internal/web/dashboard.html
+++ b/backend/internal/web/dashboard.html
@@ -15,9 +15,9 @@
     --accent: #4bb3fd;
     --accent-2: #8b5cf6;
     --ok: #3ddc97;
-    --warn: #fbbf24;
     --danger: #f87171;
     --track: #232b3d;
+    --grid: #202941;
     --radius: 12px;
   }
   * { box-sizing: border-box; }
@@ -31,16 +31,24 @@
     color: var(--fg);
     min-height: 100vh;
   }
-  header { max-width: 1180px; margin: 0 auto; padding: 28px 20px 6px; }
-  header h1 { font-size: 21px; margin: 0; letter-spacing: .01em; }
+  header { max-width: 1180px; margin: 0 auto; padding: 26px 20px 4px; }
+  header .top { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+  header h1 { font-size: 20px; margin: 0; letter-spacing: .01em; }
   header h1 .dot { color: var(--accent); }
   .sub { color: var(--muted); font-size: 12.5px; margin: 5px 0 0; }
   .meta { color: var(--muted); font-size: 11.5px; margin-top: 6px; display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
   .live { color: var(--ok); display: inline-flex; align-items: center; gap: 5px; }
   .live::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--ok); box-shadow: 0 0 8px var(--ok); }
+  .range { display: inline-flex; background: var(--panel); border: 1px solid var(--border); border-radius: 9px; overflow: hidden; }
+  .range button {
+    background: transparent; color: var(--muted); border: none; padding: 6px 14px;
+    font-size: 12px; cursor: pointer; transition: background .15s ease, color .15s ease;
+  }
+  .range button:hover { color: var(--fg); }
+  .range button.active { background: var(--accent); color: #081018; font-weight: 600; }
   main { max-width: 1180px; margin: 0 auto; padding: 16px 20px 44px; }
 
-  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(128px, 1fr)); gap: 10px; margin-bottom: 14px; }
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(126px, 1fr)); gap: 10px; margin-bottom: 14px; }
   .card {
     background: linear-gradient(160deg, var(--panel-2), var(--panel));
     border: 1px solid var(--border);
@@ -49,13 +57,12 @@
     position: relative;
     overflow: hidden;
     transition: transform .15s ease, border-color .15s ease;
-    cursor: default;
   }
   .card:hover { transform: translateY(-2px); border-color: var(--card-accent, var(--accent)); }
   .card::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 2.5px; background: var(--card-accent, var(--accent)); opacity: .85; }
-  .card .v { font-size: 24px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.01em; display: flex; align-items: baseline; gap: 7px; }
+  .card .v { font-size: 23px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.01em; display: flex; align-items: baseline; gap: 7px; }
   .card .k { font-size: 11.5px; color: var(--muted); margin-top: 5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .delta { font-size: 11.5px; font-weight: 600; font-variant-numeric: tabular-nums; }
+  .delta { font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; }
   .delta.up { color: var(--ok); }
   .delta.down { color: var(--danger); }
   .delta.flat { color: var(--muted); }
@@ -74,15 +81,16 @@
   .panel h2 small { text-transform: none; letter-spacing: 0; color: #64708c; font-weight: 400; font-size: 11px; }
   .panel .body { flex: 1; min-height: 0; }
 
-  .bars { display: flex; flex-direction: column; gap: 6px; max-height: 232px; overflow-y: auto; padding-right: 2px; }
+  .bars { display: flex; flex-direction: column; gap: 6px; max-height: 236px; overflow-y: auto; padding-right: 2px; }
   .bars::-webkit-scrollbar { width: 6px; }
   .bars::-webkit-scrollbar-thumb { background: #2b3650; border-radius: 3px; }
-  .bar-row { display: flex; align-items: center; gap: 9px; font-size: 12.5px; }
-  .bar-label { flex: 0 0 96px; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .bar-row { display: flex; align-items: center; gap: 8px; font-size: 12.5px; }
+  .bar-label { flex: 0 1 auto; min-width: 0; max-width: 34%; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .bar-track { flex: 1; background: var(--track); border-radius: 5px; height: 13px; overflow: hidden; }
-  .bar-fill { height: 100%; border-radius: 5px; background: linear-gradient(90deg, var(--accent), var(--accent-2)); min-width: 2px; transition: filter .15s ease; }
+  .bar-fill { height: 100%; border-radius: 5px; background: linear-gradient(90deg, var(--accent), var(--accent-2)); min-width: 2px; transition: filter .15s ease; transform-origin: left; animation: growX .5s cubic-bezier(.22,.61,.36,1) both; }
   .bar-row:hover .bar-fill { filter: brightness(1.25); }
-  .bar-count { flex: 0 0 72px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; font-size: 11.5px; white-space: nowrap; }
+  @keyframes growX { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+  .bar-count { flex: 0 0 70px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; font-size: 11.5px; white-space: nowrap; }
 
   .more-btn {
     align-self: flex-start; margin-top: 4px;
@@ -92,9 +100,15 @@
   }
   .more-btn:hover { border-color: var(--accent); }
 
-  svg text { fill: var(--muted); font-size: 9.5px; }
   .chart-wrap { overflow-x: auto; }
   .chart-wrap svg { display: block; }
+  svg text { fill: var(--muted); font-size: 9.5px; font-variant-numeric: tabular-nums; }
+  svg .grow { transform-box: fill-box; transform-origin: bottom; animation: growY .45s cubic-bezier(.22,.61,.36,1) both; }
+  @keyframes growY { from { transform: scaleY(0); } to { transform: scaleY(1); } }
+  svg .draw { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 1.1s ease forwards; }
+  @keyframes draw { to { stroke-dashoffset: 0; } }
+  svg .dotp { transition: r .1s ease; }
+  svg .dotp:hover { r: 4; }
 
   .donut-wrap { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
   .legend { display: flex; flex-direction: column; gap: 5px; font-size: 12px; flex: 1; min-width: 108px; }
@@ -104,19 +118,35 @@
   .legend-row .lv { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 11.5px; white-space: nowrap; }
 
   .chips { display: flex; gap: 8px; flex-wrap: wrap; }
-  .chip { flex: 1; min-width: 104px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
-  .chip .cv { font-size: 17px; font-weight: 700; font-variant-numeric: tabular-nums; }
+  .chip { flex: 1; min-width: 100px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
+  .chip .cv { font-size: 16px; font-weight: 700; font-variant-numeric: tabular-nums; }
   .chip .ck { font-size: 10.5px; color: var(--muted); margin-top: 3px; }
 
   .empty { color: var(--muted); font-size: 12.5px; padding: 8px 0; }
   .error { color: var(--danger); font-size: 12.5px; padding: 8px 0; }
-  footer { max-width: 1180px; margin: 0 auto; padding: 0 20px 36px; color: #5f6b88; font-size: 11.5px; }
+  #tip {
+    position: fixed; z-index: 99; display: none; pointer-events: none;
+    background: #10162a; border: 1px solid var(--border); border-radius: 8px;
+    padding: 6px 10px; font-size: 12px; max-width: 340px; line-height: 1.45;
+    box-shadow: 0 6px 20px rgba(0,0,0,.45);
+  }
+  footer { max-width: 1180px; margin: 0 auto; padding: 0 20px 34px; color: #5f6b88; font-size: 11.5px; }
 </style>
 </head>
 <body>
 <header>
-  <h1>ManiaMapAnalyser <span class="dot">·</span> Usage Statistics</h1>
-  <p class="sub">Anonymous aggregate statistics — no usernames, no beatmap identity, no IP addresses.</p>
+  <div class="top">
+    <div>
+      <h1>ManiaMapAnalyser <span class="dot">·</span> Usage Statistics</h1>
+      <p class="sub">Anonymous aggregate statistics — no usernames, no beatmap identity, no IP addresses.</p>
+    </div>
+    <div class="range" id="range" role="group" aria-label="Time range">
+      <button data-days="7">7d</button>
+      <button data-days="30" class="active">30d</button>
+      <button data-days="90">90d</button>
+      <button data-days="0">All</button>
+    </div>
+  </div>
   <p class="meta"><span class="live">live</span><span id="updated">loading…</span></p>
 </header>
 <main>
@@ -124,22 +154,22 @@
 
   <div class="grid2">
     <section class="panel">
-      <h2>Online by hour <small>UTC · 30d</small></h2>
+      <h2>Online by hour <small id="hourRange">UTC</small></h2>
       <div class="body chart-wrap"><div id="onlineByHour"></div></div>
     </section>
     <section class="panel">
-      <h2>Active per day <small>30d</small></h2>
+      <h2>Active per day</h2>
       <div class="body chart-wrap"><div id="trend"></div></div>
     </section>
   </div>
 
   <div class="grid2">
     <section class="panel">
-      <h2>Star rating <small>continuous · 0.01 bins</small></h2>
+      <h2>Star rating <small>0.5-star bins</small></h2>
       <div class="body chart-wrap"><div id="starHistogram"></div></div>
     </section>
     <section class="panel">
-      <h2>LN ratio <small>continuous · 0.01 bins</small></h2>
+      <h2>LN ratio <small>5% bins</small></h2>
       <div class="body chart-wrap"><div id="lnRatioHistogram"></div></div>
     </section>
   </div>
@@ -152,8 +182,8 @@
   </div>
 
   <div class="grid2">
-    <section class="panel"><h2>Selected algorithm</h2><div class="body" id="algorithms" class="bars"></div></section>
-    <section class="panel"><h2>Actual algorithm</h2><div class="body" id="actualAlgorithms" class="bars"></div></section>
+    <section class="panel"><h2>Selected algorithm</h2><div class="body" id="algorithms"></div></section>
+    <section class="panel"><h2>Actual algorithm</h2><div class="body" id="actualAlgorithms"></div></section>
   </div>
 
   <section class="panel" style="margin-bottom:12px">
@@ -161,6 +191,7 @@
     <div class="body"><div id="metrics" class="chips"></div></div>
   </section>
 </main>
+<div id="tip"></div>
 <footer>Aggregate statistics · refreshed every 60 s · vanilla JS + SVG, no trackers.</footer>
 
 <script>
@@ -168,6 +199,14 @@
 
 // XSS policy: every client-controlled string is written via textContent only.
 const PALETTE = ["#4bb3fd", "#8b5cf6", "#3ddc97", "#fbbf24", "#f87171", "#f472b6", "#2dd4bf", "#60a5fa", "#c084fc", "#94a3b8"];
+let currentDays = 30;
+
+const tip = document.getElementById("tip");
+function bindTip(node, text) {
+  node.addEventListener("mouseenter", () => { tip.textContent = String(text); tip.style.display = "block"; });
+  node.addEventListener("mousemove", (e) => { tip.style.left = (e.clientX + 14) + "px"; tip.style.top = (e.clientY + 14) + "px"; });
+  node.addEventListener("mouseleave", () => { tip.style.display = "none"; });
+}
 
 function el(tag, cls, text) {
   const e = document.createElement(tag);
@@ -179,11 +218,6 @@ function svgEl(tag, attrs) {
   const e = document.createElementNS("http://www.w3.org/2000/svg", tag);
   for (const k in attrs) e.setAttribute(k, String(attrs[k]));
   return e;
-}
-function title(el_, text) {
-  const t = svgEl("title", {});
-  t.textContent = String(text);
-  el_.appendChild(t);
 }
 function emptyBox(host, msg) {
   host.textContent = "";
@@ -201,14 +235,16 @@ function deltaSpan(delta) {
   if (delta > 0) { s.className = "delta up"; s.textContent = "▲ " + fmtCompact(delta); }
   else if (delta < 0) { s.className = "delta down"; s.textContent = "▼ " + fmtCompact(-delta); }
   else { s.className = "delta flat"; s.textContent = "–"; }
+  bindTip(s, String(delta));
   return s;
 }
 function card(k, v, opts) {
   const d = el("div", "card");
-  const accent = (opts && opts.accent) || "#4bb3fd";
-  d.style.setProperty("--card-accent", accent);
+  d.style.setProperty("--card-accent", (opts && opts.accent) || "#4bb3fd");
   const vWrap = el("div", "v");
-  vWrap.appendChild(el("span", "", fmtCompact(v)));
+  const vs = el("span", "", fmtCompact(v));
+  bindTip(vs, String(v));
+  vWrap.appendChild(vs);
   if (opts && opts.delta != null) vWrap.appendChild(deltaSpan(opts.delta));
   d.appendChild(vWrap);
   d.appendChild(el("div", "k", k));
@@ -229,13 +265,13 @@ function renderCards(s) {
   ov.appendChild(card("Online now", s.onlineNow, { accent: "#3ddc97" }));
   ov.appendChild(card("Active today", s.todayActive, { accent: "#fbbf24", delta: todayDelta }));
   ov.appendChild(card("Active 7d", s.weekActive, { accent: "#8b5cf6", delta: weekDelta }));
-  ov.appendChild(card("Active 30d", s.monthActive, { accent: "#f472b6" }));
+  ov.appendChild(card("Active " + (currentDays || 90) + "d", s.monthActive, { accent: "#f472b6" }));
   ov.appendChild(card("New today", s.newToday, { accent: "#2dd4bf" }));
   ov.appendChild(card("New 7d", s.newWeek, { accent: "#60a5fa" }));
   ov.appendChild(card("Total events", s.totalEvents, { accent: "#c084fc" }));
 }
 
-function renderBars(id, items, cap) {
+function renderHBar(id, items, cap) {
   const c = document.getElementById(id);
   c.textContent = "";
   if (!items.length) { emptyBox(c); return; }
@@ -246,62 +282,101 @@ function renderBars(id, items, cap) {
     const it = items[i];
     const row = el("div", "bar-row");
     const label = el("span", "bar-label", it.key);
-    label.title = String(it.key);
     const track = el("div", "bar-track");
     const fill = el("div", "bar-fill");
     fill.style.width = Math.round((it.count / max) * 100) + "%";
-    fill.title = it.key + " — " + it.count + " (" + Math.round((it.count / max) * 100) + "%)";
+    fill.style.animationDelay = (i * 30) + "ms";
+    bindTip(row, it.key + " — " + it.count + " (" + Math.round((it.count / max) * 100) + "%)");
     track.appendChild(fill);
     row.appendChild(label);
     row.appendChild(track);
-    row.appendChild(el("span", "bar-count", fmtCompact(it.count) + " · " + Math.round((it.count / max) * 100) + "%"));
+    const cnt = el("span", "bar-count", fmtCompact(it.count) + " · " + Math.round((it.count / max) * 100) + "%");
+    bindTip(cnt, String(it.count) + " · " + Math.round((it.count / max) * 100) + "%");
+    row.appendChild(cnt);
     c.appendChild(row);
   }
   if (items.length > limit) {
     const btn = el("button", "more-btn", "Show all " + items.length);
-    btn.addEventListener("click", () => renderBars(id, items, 0));
+    btn.addEventListener("click", () => renderHBar(id, items, 0));
     c.appendChild(btn);
   }
 }
 
-function renderHourBars(id, counts) {
+// Vertical bar chart with Y axis and X labels. items: [{label, count, tip}]
+function renderVChart(id, items, xEvery) {
   const c = document.getElementById(id);
   c.textContent = "";
-  if (!counts || !counts.length) { emptyBox(c); return; }
-  const W = 560, H = 132, PAD = 4;
-  const max = Math.max.apply(null, counts.concat([1]));
-  const bw = (W - PAD * 2) / counts.length;
+  if (!items.length) { emptyBox(c); return; }
+  const W = 560, H = 170, ML = 40, MB = 20, PAD = 6;
+  const max = Math.max.apply(null, items.map((i) => i.count).concat([1]));
+  const plotW = W - ML - PAD;
+  const plotH = H - MB - PAD;
+  const bw = plotW / items.length;
+  const step = xEvery || Math.max(1, Math.ceil(items.length / 12));
+
   const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
   const lg = svgEl("linearGradient", { id: "barGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
   lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#4bb3fd" }));
   lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#8b5cf6" }));
   svg.appendChild(lg);
-  for (let i = 0; i < counts.length; i++) {
-    const v = counts[i] || 0;
-    const h = Math.max(1, (v / max) * (H - PAD * 2 - 14));
-    const x = PAD + i * bw + bw * 0.18;
+
+  [0, 1 / 3, 2 / 3, 1].forEach((f) => {
+    const gy = (PAD + (1 - f) * plotH).toFixed(1);
+    svg.appendChild(svgEl("line", { x1: ML, y1: gy, x2: W - PAD, y2: gy, stroke: "#202941", "stroke-width": 1 }));
+    const tx = svgEl("text", { x: ML - 6, y: (parseFloat(gy) + 3).toFixed(1), "text-anchor": "end" });
+    tx.textContent = fmtCompact(Math.round(max * f));
+    bindTip(tx, String(Math.round(max * f)));
+    svg.appendChild(tx);
+  });
+
+  items.forEach((it, i) => {
+    const h = Math.max(1, (it.count / max) * plotH);
+    const x = ML + i * bw + bw * 0.18;
     const w = bw * 0.64;
-    const rect = svgEl("rect", { x: x.toFixed(1), y: (H - PAD - h).toFixed(1), width: w.toFixed(1), height: h.toFixed(1), rx: 2, fill: "url(#barGrad)" });
-    title(rect, String(i).padStart(2, "0") + ":00 UTC — " + v + " installs");
+    const rect = svgEl("rect", {
+      x: x.toFixed(1), y: (H - MB - h).toFixed(1),
+      width: w.toFixed(1), height: h.toFixed(1), rx: 2,
+      fill: "url(#barGrad)", class: "grow",
+    });
+    rect.style.animationDelay = (i * 18) + "ms";
+    bindTip(rect, it.tip || (it.label + " — " + it.count));
     svg.appendChild(rect);
-    if (i % 4 === 0) {
-      const tx = svgEl("text", { x: (x + w / 2).toFixed(1), y: H - 1, "text-anchor": "middle" });
-      tx.textContent = String(i).padStart(2, "0");
+    if (i % step === 0 || i === items.length - 1) {
+      const tx = svgEl("text", { x: (x + w / 2).toFixed(1), y: H - 6, "text-anchor": "middle" });
+      tx.textContent = it.label;
       svg.appendChild(tx);
     }
-  }
+  });
   c.appendChild(svg);
+}
+
+function renderHourBars(id, counts) {
+  const items = (counts || []).map((v, i) => ({
+    label: String(i).padStart(2, "0"),
+    count: v || 0,
+    tip: String(i).padStart(2, "0") + ":00 UTC — " + (v || 0) + " installs",
+  }));
+  renderVChart(id, items, 3);
+}
+
+function renderValueBars(id, buckets) {
+  const items = (buckets || []).map((b) => ({
+    label: b.key,
+    count: b.count,
+    tip: b.key + " → " + b.count,
+  }));
+  renderVChart(id, items, 0);
 }
 
 function renderTrend(id, trend) {
   const c = document.getElementById(id);
   c.textContent = "";
   if (!trend || !trend.length) { emptyBox(c); return; }
-  const W = 560, H = 132, PAD = 8;
+  const W = 560, H = 170, ML = 40, MB = 20, PAD = 6;
   const max = Math.max.apply(null, trend.map((d) => Math.max(d.active, d.new)).concat([1]));
   const n = trend.length;
-  const x = (i) => PAD + (i * (W - PAD * 2)) / Math.max(n - 1, 1);
-  const y = (v) => H - PAD - (v / max) * (H - PAD * 2 - 12);
+  const x = (i) => ML + (i * (W - ML - PAD)) / Math.max(n - 1, 1);
+  const y = (v) => PAD + (1 - v / max) * (H - MB - PAD);
 
   const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
   const lg = svgEl("linearGradient", { id: "areaGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
@@ -309,67 +384,33 @@ function renderTrend(id, trend) {
   lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#4bb3fd", "stop-opacity": "0" }));
   svg.appendChild(lg);
 
-  for (let g = 0; g < 3; g++) {
-    const gy = PAD + (g * (H - PAD * 2 - 12)) / 2;
-    svg.appendChild(svgEl("line", { x1: PAD, y1: gy.toFixed(1), x2: W - PAD, y2: gy.toFixed(1), stroke: "#232b3d", "stroke-width": 1 }));
-  }
+  [0, 1 / 3, 2 / 3, 1].forEach((f) => {
+    const gy = (PAD + (1 - f) * (H - MB - PAD)).toFixed(1);
+    svg.appendChild(svgEl("line", { x1: ML, y1: gy, x2: W - PAD, y2: gy, stroke: "#202941", "stroke-width": 1 }));
+    const tx = svgEl("text", { x: ML - 6, y: (parseFloat(gy) + 3).toFixed(1), "text-anchor": "end" });
+    tx.textContent = fmtCompact(Math.round(max * f));
+    bindTip(tx, String(Math.round(max * f)));
+    svg.appendChild(tx);
+  });
 
   const actPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.active).toFixed(1)).join(" ");
   const newPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.new).toFixed(1)).join(" ");
   const area = "M" + x(0).toFixed(1) + "," + y(trend[0].active).toFixed(1) + " L" + actPts.replace(/ /g, " L") +
-    " L" + x(n - 1).toFixed(1) + "," + (H - PAD).toFixed(1) + " L" + x(0).toFixed(1) + "," + (H - PAD).toFixed(1) + " Z";
+    " L" + x(n - 1).toFixed(1) + "," + (H - MB).toFixed(1) + " L" + x(0).toFixed(1) + "," + (H - MB).toFixed(1) + " Z";
   svg.appendChild(svgEl("path", { d: area, fill: "url(#areaGrad)" }));
-  svg.appendChild(svgEl("polyline", { points: actPts, fill: "none", stroke: "#4bb3fd", "stroke-width": 2, "stroke-linejoin": "round" }));
-  svg.appendChild(svgEl("polyline", { points: newPts, fill: "none", stroke: "#3ddc97", "stroke-width": 1.3, "stroke-linejoin": "round", "stroke-dasharray": "3 3" }));
+  svg.appendChild(svgEl("polyline", { points: actPts, fill: "none", stroke: "#4bb3fd", "stroke-width": 2, "stroke-linejoin": "round", class: "draw" }));
+  svg.appendChild(svgEl("polyline", { points: newPts, fill: "none", stroke: "#3ddc97", "stroke-width": 1.3, "stroke-linejoin": "round", "stroke-dasharray": "3 3", class: "draw" }));
   trend.forEach((d, i) => {
-    const dot = svgEl("circle", { cx: x(i).toFixed(1), cy: y(d.active).toFixed(1), r: 2, fill: "#4bb3fd" });
-    title(dot, d.date + " · active " + d.active + " · new " + d.new);
+    const dot = svgEl("circle", { cx: x(i).toFixed(1), cy: y(d.active).toFixed(1), r: 2.2, fill: "#4bb3fd", class: "dotp" });
+    bindTip(dot, d.date + " · active " + d.active + " · new " + d.new);
     svg.appendChild(dot);
   });
-  const step = Math.ceil(n / 6);
+  const step = Math.max(1, Math.ceil(n / 6));
   for (let i = 0; i < n; i += step) {
-    const tx = svgEl("text", { x: x(i).toFixed(1), y: H - 1, "text-anchor": "middle" });
+    const tx = svgEl("text", { x: x(i).toFixed(1), y: H - 6, "text-anchor": "middle" });
     tx.textContent = trend[i].date ? trend[i].date.slice(5) : "";
     svg.appendChild(tx);
   }
-  c.appendChild(svg);
-}
-
-function renderValueLine(id, buckets) {
-  const c = document.getElementById(id);
-  c.textContent = "";
-  if (!buckets || !buckets.length) { emptyBox(c); return; }
-  const W = 560, H = 132, PAD = 8;
-  const v0 = buckets[0].value, v1 = buckets[buckets.length - 1].value;
-  const maxC = Math.max.apply(null, buckets.map((b) => b.count).concat([1]));
-  const x = (v) => PAD + ((v - v0) / ((v1 - v0) || 1)) * (W - PAD * 2);
-  const y = (cnt) => H - PAD - (cnt / maxC) * (H - PAD * 2 - 12);
-
-  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
-  const lg = svgEl("linearGradient", { id: "valGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
-  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#8b5cf6", "stop-opacity": "0.28" }));
-  lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#8b5cf6", "stop-opacity": "0" }));
-  svg.appendChild(lg);
-  for (let g = 0; g < 3; g++) {
-    const gy = PAD + (g * (H - PAD * 2 - 12)) / 2;
-    svg.appendChild(svgEl("line", { x1: PAD, y1: gy.toFixed(1), x2: W - PAD, y2: gy.toFixed(1), stroke: "#232b3d", "stroke-width": 1 }));
-  }
-
-  const pts = buckets.map((b) => x(b.value).toFixed(1) + "," + y(b.count).toFixed(1)).join(" ");
-  const area = "M" + x(v0).toFixed(1) + "," + y(0).toFixed(1) + " L" + pts.replace(/ /g, " L") + " L" + x(v1).toFixed(1) + "," + y(0).toFixed(1) + " Z";
-  svg.appendChild(svgEl("path", { d: area, fill: "url(#valGrad)" }));
-  svg.appendChild(svgEl("polyline", { points: pts, fill: "none", stroke: "#8b5cf6", "stroke-width": 2, "stroke-linejoin": "round" }));
-  buckets.forEach((b) => {
-    const dot = svgEl("circle", { cx: x(b.value).toFixed(1), cy: y(b.count).toFixed(1), r: 2.5, fill: "#8b5cf6" });
-    title(dot, b.key + " → " + b.count);
-    svg.appendChild(dot);
-  });
-  const mid = v0 + (v1 - v0) / 2;
-  [v0, mid, v1].forEach((v) => {
-    const tx = svgEl("text", { x: x(v).toFixed(1), y: H - 1, "text-anchor": "middle" });
-    tx.textContent = v.toFixed(2);
-    svg.appendChild(tx);
-  });
   c.appendChild(svg);
 }
 
@@ -385,7 +426,7 @@ function renderDonut(id, items, maxSlices) {
     slices = top.concat([{ key: "Other", count: other }]);
   }
   const total = slices.reduce((s, it) => s + it.count, 0) || 1;
-  const svg = svgEl("svg", { viewBox: "0 0 42 42", width: "108", height: "108", "aria-hidden": "true" });
+  const svg = svgEl("svg", { viewBox: "0 0 42 42", width: "104", height: "104", "aria-hidden": "true" });
   let angle = 0;
   slices.forEach((it, i) => {
     const frac = it.count / total;
@@ -395,12 +436,13 @@ function renderDonut(id, items, maxSlices) {
       "stroke-dasharray": (frac * 100).toFixed(2) + " " + (100 - frac * 100).toFixed(2),
       "stroke-dashoffset": (-angle * 100).toFixed(2),
     });
-    title(circle, it.key + " — " + it.count + " (" + Math.round((it.count / total) * 100) + "%)");
+    bindTip(circle, it.key + " — " + it.count + " (" + Math.round((it.count / total) * 100) + "%)");
     svg.appendChild(circle);
     angle += frac;
   });
-  const center = svgEl("text", { x: 21, y: 23, "text-anchor": "middle", "font-size": "6", fill: "#e6edf7", "font-weight": "700" });
+  const center = svgEl("text", { x: 21, y: 23, "text-anchor": "middle", "font-size": "5.8", fill: "#e6edf7", "font-weight": "700" });
   center.textContent = fmtCompact(total);
+  bindTip(center, String(total));
   svg.appendChild(center);
 
   const legend = el("div", "legend");
@@ -410,7 +452,9 @@ function renderDonut(id, items, maxSlices) {
     sw.style.background = PALETTE[i % PALETTE.length];
     row.appendChild(sw);
     row.appendChild(el("span", "lk", it.key));
-    row.appendChild(el("span", "lv", fmtCompact(it.count) + " · " + Math.round((it.count / total) * 100) + "%"));
+    const lv = el("span", "lv", fmtCompact(it.count) + " · " + Math.round((it.count / total) * 100) + "%");
+    bindTip(lv, String(it.count) + " · " + Math.round((it.count / total) * 100) + "%");
+    row.appendChild(lv);
     legend.appendChild(row);
   });
   const wrap = el("div", "donut-wrap");
@@ -422,48 +466,67 @@ function renderDonut(id, items, maxSlices) {
 function renderMetrics(s) {
   const c = document.getElementById("metrics");
   c.textContent = "";
+  const windowLabel = currentDays ? currentDays + "d" : "all";
+  const hour = s.peakOnlineHour != null ? "@" + String(s.peakOnlineHour).padStart(2, "0") + ":00 UTC" : "";
   const items = [
-    ["Avg star", s.avgStar ? s.avgStar.toFixed(2) : "—"],
-    ["Avg LN ratio", s.avgLnRatio ? s.avgLnRatio.toFixed(2) : "—"],
-    ["Analyzes · 30d", fmtCompact(s.analyze30d)],
-    ["Peak online", s.peakOnline ? fmtCompact(s.peakOnline) + " @" + String(s.peakOnlineHour).padStart(2, "0") + ":00 UTC" : "—"],
-    ["Avg daily active", fmtCompact(s.avgDailyActive)],
-    ["Duration avg", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms"],
-    ["Duration p50", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms"],
-    ["Duration p90", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms"],
+    ["Avg star", s.avgStar ? s.avgStar.toFixed(2) : "—", s.avgStar ? s.avgStar.toFixed(2) : "—"],
+    ["Avg LN ratio", s.avgLnRatio ? (s.avgLnRatio * 100).toFixed(1) + "%" : "—", s.avgLnRatio ? (s.avgLnRatio * 100).toFixed(1) + "%" : "—"],
+    ["Analyzes · " + windowLabel, fmtCompact(s.analyzeCount), String(s.analyzeCount)],
+    ["Peak online", s.peakOnline ? fmtCompact(s.peakOnline) + " " + hour : "—", s.peakOnline ? String(s.peakOnline) + " " + hour : "—"],
+    ["Avg daily active", fmtCompact(s.avgDailyActive), String(s.avgDailyActive)],
+    ["Duration avg", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms"],
+    ["Duration p50", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms"],
+    ["Duration p90", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms"],
   ];
-  for (const [k, v] of items) {
+  for (const [k, v, raw] of items) {
     const chip = el("div", "chip");
-    chip.appendChild(el("div", "cv", v));
+    const cv = el("div", "cv", v);
+    if (raw !== v) bindTip(cv, raw);
+    chip.appendChild(cv);
     chip.appendChild(el("div", "ck", k));
     c.appendChild(chip);
   }
 }
 
-fetch("/api/v1/stats")
-  .then((r) => {
-    if (!r.ok) throw new Error("HTTP " + r.status);
-    return r.json();
-  })
-  .then((s) => {
-    document.getElementById("updated").textContent = "updated " + new Date().toLocaleString();
-    renderCards(s);
-    renderHourBars("onlineByHour", s.onlineByHour || []);
-    renderTrend("trend", s.activeTrend || []);
-    renderValueLine("starHistogram", s.starHistogram || []);
-    renderValueLine("lnRatioHistogram", s.lnRatioHistogram || []);
-    renderBars("keycounts", s.keycounts || []);
-    renderDonut("modes", s.modes || []);
-    renderDonut("mods", s.mods || []);
-    renderDonut("versions", s.versions || []);
-    renderBars("algorithms", s.algorithms || [], 8);
-    renderBars("actualAlgorithms", s.actualAlgorithms || [], 8);
-    renderMetrics(s);
-  })
-  .catch((err) => {
-    const ov = document.getElementById("overview");
-    ov.appendChild(el("div", "error", "Failed to load statistics: " + err.message));
-  });
+function load() {
+  document.getElementById("updated").textContent = "loading…";
+  fetch("/api/v1/stats?days=" + currentDays)
+    .then((r) => {
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      return r.json();
+    })
+    .then((s) => {
+      document.getElementById("updated").textContent = "updated " + new Date().toLocaleString();
+      document.getElementById("hourRange").textContent = "UTC · " + (currentDays ? currentDays + "d" : "all");
+      renderCards(s);
+      renderHourBars("onlineByHour", s.onlineByHour || []);
+      renderTrend("trend", s.activeTrend || []);
+      renderValueBars("starHistogram", s.starHistogram || []);
+      renderValueBars("lnRatioHistogram", s.lnRatioHistogram || []);
+      renderHBar("keycounts", s.keycounts || []);
+      renderDonut("modes", s.modes || []);
+      renderDonut("mods", s.mods || []);
+      renderDonut("versions", s.versions || []);
+      renderHBar("algorithms", s.algorithms || [], 8);
+      renderHBar("actualAlgorithms", s.actualAlgorithms || [], 8);
+      renderMetrics(s);
+    })
+    .catch((err) => {
+      const ov = document.getElementById("overview");
+      ov.textContent = "";
+      ov.appendChild(el("div", "error", "Failed to load statistics: " + err.message));
+    });
+}
+
+document.getElementById("range").addEventListener("click", (e) => {
+  const btn = e.target.closest("button[data-days]");
+  if (!btn) return;
+  currentDays = parseInt(btn.dataset.days, 10);
+  document.querySelectorAll("#range button").forEach((b) => b.classList.toggle("active", b === btn));
+  load();
+});
+
+load();
 </script>
 </body>
 </html>

--- a/backend/internal/web/dashboard.html
+++ b/backend/internal/web/dashboard.html
@@ -192,7 +192,7 @@
   </section>
 </main>
 <div id="tip"></div>
-<footer>Aggregate statistics · refreshed every 60 s · vanilla JS + SVG, no trackers.</footer>
+<footer>Aggregate statistics · refreshed every 60 s · server <span id="serverVer">–</span> · vanilla JS + SVG, no trackers.</footer>
 
 <script>
 "use strict";
@@ -497,6 +497,7 @@ function load() {
     })
     .then((s) => {
       document.getElementById("updated").textContent = "updated " + new Date().toLocaleString();
+      document.getElementById("serverVer").textContent = "v" + (s.serverVersion || "?");
       document.getElementById("hourRange").textContent = "UTC · " + (currentDays ? currentDays + "d" : "all");
       renderCards(s);
       renderHourBars("onlineByHour", s.onlineByHour || []);
@@ -527,6 +528,8 @@ document.getElementById("range").addEventListener("click", (e) => {
 });
 
 load();
+// Auto-refresh every 60 s (matches the server-side stats cache TTL).
+setInterval(load, 60000);
 </script>
 </body>
 </html>

--- a/backend/internal/web/dashboard.html
+++ b/backend/internal/web/dashboard.html
@@ -163,21 +163,26 @@
     </section>
   </div>
 
-  <section class="panel" style="margin-bottom:12px">
-    <h2>Star rating <small>0.5-star bins</small></h2>
-    <div class="body chart-wrap"><div id="starHistogram"></div></div>
-  </section>
-  <section class="panel" style="margin-bottom:12px">
-    <h2>LN ratio <small>5% bins</small></h2>
-    <div class="body chart-wrap"><div id="lnRatioHistogram"></div></div>
-  </section>
-  <section class="panel" style="margin-bottom:12px">
-    <h2>Numeric difficulty <small>0.5 bins · .0 = mid</small></h2>
-    <div class="body chart-wrap"><div id="numericHistogram"></div></div>
-  </section>
+  <div class="grid2">
+    <section class="panel">
+      <h2>Star rating <small>0.5-star bins</small></h2>
+      <div class="body chart-wrap"><div id="starHistogram"></div></div>
+    </section>
+    <section class="panel">
+      <h2>LN ratio <small>5% bins</small></h2>
+      <div class="body chart-wrap"><div id="lnRatioHistogram"></div></div>
+    </section>
+  </div>
+
+  <div class="grid2">
+    <section class="panel"><h2>Key count</h2><div class="body" id="keycounts"></div></section>
+    <section class="panel">
+      <h2>Numeric difficulty <small>0.5 bins · .0 = mid</small></h2>
+      <div class="body chart-wrap"><div id="numericHistogram"></div></div>
+    </section>
+  </div>
 
   <div class="grid4">
-    <section class="panel"><h2>Key count</h2><div class="body" id="keycounts"></div></section>
     <section class="panel"><h2>Beatmap type <small>HB/RC/LN/Mix/SV</small></h2><div class="body" id="modes"></div></section>
     <section class="panel"><h2>Mods <small>NM = no mod</small></h2><div class="body" id="mods"></div></section>
     <section class="panel"><h2>Version</h2><div class="body" id="versions"></div></section>

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -4,7 +4,9 @@ package web
 import (
 	_ "embed"
 	"encoding/json"
+	"log"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -15,14 +17,20 @@ import (
 //go:embed dashboard.html
 var dashboardHTML []byte
 
+const maxDays = 365
+
 type Handler struct {
 	store           *store.Store
 	onlineWindowMin int
 	statsCache      time.Duration
 
-	mu         sync.Mutex
-	cachedJSON []byte
-	cachedAt   time.Time
+	mu     sync.Mutex
+	cached map[int]cachedStats
+}
+
+type cachedStats struct {
+	json []byte
+	at   time.Time
 }
 
 func NewHandler(st *store.Store, onlineWindowMin, statsCacheSeconds int) *Handler {
@@ -30,6 +38,7 @@ func NewHandler(st *store.Store, onlineWindowMin, statsCacheSeconds int) *Handle
 		store:           st,
 		onlineWindowMin: onlineWindowMin,
 		statsCache:      time.Duration(statsCacheSeconds) * time.Second,
+		cached:          make(map[int]cachedStats),
 	}
 }
 
@@ -47,27 +56,50 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusMethodNotAllowed)
 			return
 		}
-		h.stats(w)
+		h.stats(w, r)
 	default:
 		w.WriteHeader(http.StatusNotFound)
 	}
 }
 
+// parseDays maps the ?days= query (or "all") to a window length in days.
+// 0 means "all time"; empty/invalid values default to 30.
+func parseDays(r *http.Request) int {
+	v := r.URL.Query().Get("days")
+	if v == "" {
+		return 30
+	}
+	if v == "all" {
+		return 0
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 30
+	}
+	if n > maxDays {
+		return maxDays
+	}
+	return n
+}
+
 // stats serves the cached aggregate JSON. The mutex is held across a stale
 // recompute so concurrent requests wait once instead of each hitting the DB
-// (a cheap stampede guard without extra dependencies).
-func (h *Handler) stats(w http.ResponseWriter) {
+// (a cheap stampede guard without extra dependencies). The cache is keyed by
+// the days window.
+func (h *Handler) stats(w http.ResponseWriter, r *http.Request) {
+	days := parseDays(r)
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if h.cachedJSON != nil && time.Since(h.cachedAt) < h.statsCache {
+	if e, ok := h.cached[days]; ok && time.Since(e.at) < h.statsCache {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
-		w.Write(h.cachedJSON)
+		w.Write(e.json)
 		return
 	}
 
-	stats, err := analytics.Compute(h.store, h.onlineWindowMin)
+	stats, err := analytics.Compute(h.store, h.onlineWindowMin, days)
 	if err != nil {
+		log.Printf("stats: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -77,8 +109,7 @@ func (h *Handler) stats(w http.ResponseWriter) {
 		return
 	}
 
-	h.cachedJSON = data
-	h.cachedAt = time.Now()
+	h.cached[days] = cachedStats{json: data, at: time.Now()}
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.Write(data)

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -23,6 +23,7 @@ type Handler struct {
 	store           *store.Store
 	onlineWindowMin int
 	statsCache      time.Duration
+	version         string
 
 	mu     sync.Mutex
 	cached map[int]cachedStats
@@ -33,11 +34,12 @@ type cachedStats struct {
 	at   time.Time
 }
 
-func NewHandler(st *store.Store, onlineWindowMin, statsCacheSeconds int) *Handler {
+func NewHandler(st *store.Store, onlineWindowMin, statsCacheSeconds int, version string) *Handler {
 	return &Handler{
 		store:           st,
 		onlineWindowMin: onlineWindowMin,
 		statsCache:      time.Duration(statsCacheSeconds) * time.Second,
+		version:         version,
 		cached:          make(map[int]cachedStats),
 	}
 }
@@ -103,6 +105,7 @@ func (h *Handler) stats(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	stats.ServerVersion = h.version
 	data, err := json.Marshal(stats)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -9,7 +9,7 @@
 | 事件 | 时机 | 载荷 |
 |---|---|---|
 | `boot` | 插件启动、且遥测开启且 endpoint 非空 | 仅 id/kind/version |
-| `heartbeat` | 每 **5 分钟**一次，且最近 30s 内收到 api_v2（游戏已连接） | 仅 id/kind/version |
+| `heartbeat` | 每 **10 分钟**一次，且最近 30s 内收到 api_v2（游戏已连接） | 仅 id/kind/version |
 | `analyze` | 每次成功分析后 | id/kind/version + `data` 字段 |
 
 ## 2. 隐私边界（硬约束）
@@ -28,7 +28,7 @@
 - `initTelemetry()` — 读配置，条件满足则发 `boot`。
 - `setTelemetryConfig()` — settings.js 运行时调用；开关由关→开且 endpoint 非空时补发 `boot`。
 - `noteTelemetryActivity()` — socketHandlers 每个 api_v2 包调用，更新 `lastActivityAt`。
-- `startTelemetryHeartbeat()` — `setInterval(5min)`；仅当 `enabled && endpoint && (now-lastActivityAt < 30s)` 发 `heartbeat`。
+- `startTelemetryHeartbeat()` — `setInterval(10min)`；仅当 `enabled && endpoint && (now-lastActivityAt < 30s)` 发 `heartbeat`。
 - `trackTelemetryAnalyze(data)` — 发 `analyze`（fire-and-forget）。
 
 发送用 `fetch(..., {keepalive:true})` + 5s `AbortController` 超时，`.catch` 静默——**遥测绝不阻塞/破坏插件功能**。

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -17,8 +17,9 @@
 - **匿名标识**：`crypto.randomUUID()`（或回退随机 hex）生成的随机 UUID，存 `localStorage` 键 `mma.telemetry.installId.v1`（失败回退 sessionStorage → 内存）。同一机器同一 tosu 数据目录多实例共享 → 天然去重；换机器/清数据才变。
 - **明确不采**：用户名、玩家 id、分数/acc、谱面 md5/标题、IP（后端不存，连哈希都不存）、UA/OS、时区。
 - **采集字段白名单**（`analyze.data`，与后端 `backend/internal/telemetry/handler.go` 的 `allowedDataKeys` 严格一致）：
-  `algorithm`、`actualAlgorithm`、`keycount`、`mods`、`speedRate`、`mode`、`star`、`lnRatio`、`typeBreakdown`、`durationMs`。
+  `algorithm`、`actualAlgorithm`、`keycount`、`mods`、`speedRate`、`mode`、`star`、`lnRatio`、`typeBreakdown`、`durationMs`、`numericDifficulty`。
   - `actualAlgorithm` 语义：Mixed 是自动路由算法，`analysis.js` 上报的是**路由后实际命中的子算法**（Roxy/Azusa/Daniel/Companella/Sunny，见 `js/estimator/mixedEstimator.js` 的 `actualEstimatorAlgorithm` 返回值与 `runAnalysisPipeline.js` Mixed 分支），不再是字面 "Mixed"；其余算法（Azusa/Roxy 无效回退）同样上报实际结果。
+  - `numericDifficulty` 语义：标准数值化难度（Reform 段位体系，**.0 = mid**）。Azusa/Roxy（含 Mixed 路由到它们）用原生连续值；其余算法（Sunny/Companella/Daniel）用 `rcLabelToNumeric(estDiff)` 从估计难度字符串**反向换算**——Daniel 原生值是 DP 尺度（比标准约高 0.5），故 Daniel 一律走反解。边界标签（`< Alpha Low`、`> Emik Zeta high`、`Unknown` 等）反解为 null → **不发送该字段**。
 - **开关**：设置项 `enableTelemetry`（Network 分组，默认开），用户可关；endpoint 为空时完全不发送（默认开启但未配置 = no-op）。
 
 ## 3. 模块设计

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -18,6 +18,7 @@
 - **明确不采**：用户名、玩家 id、分数/acc、谱面 md5/标题、IP（后端不存，连哈希都不存）、UA/OS、时区。
 - **采集字段白名单**（`analyze.data`，与后端 `backend/internal/telemetry/handler.go` 的 `allowedDataKeys` 严格一致）：
   `algorithm`、`actualAlgorithm`、`keycount`、`mods`、`speedRate`、`mode`、`star`、`lnRatio`、`typeBreakdown`、`durationMs`。
+  - `actualAlgorithm` 语义：Mixed 是自动路由算法，`analysis.js` 上报的是**路由后实际命中的子算法**（Roxy/Azusa/Daniel/Companella/Sunny，见 `js/estimator/mixedEstimator.js` 的 `actualEstimatorAlgorithm` 返回值与 `runAnalysisPipeline.js` Mixed 分支），不再是字面 "Mixed"；其余算法（Azusa/Roxy 无效回退）同样上报实际结果。
 - **开关**：设置项 `enableTelemetry`（Network 分组，默认开），用户可关；endpoint 为空时完全不发送（默认开启但未配置 = no-op）。
 
 ## 3. 模块设计


### PR DESCRIPTION
## 概述

匿名遥测后端（`backend/`）看板与数据管道的全面升级：看板重做、遥测字段扩展、查询性能优化、后端版本化。全部提交已实际部署（当前 v1.0.4）。

## 看板（前端）

- **时间筛选**：7d / 30d / 90d / All 范围切换（`?days=`），服务端按窗口缓存
- **紧凑数字悬停显示原始值**：所有卡片、条形计数、坐标轴刻度、环形图中心与图例（如 `2.3k` → 悬停显示 `2300`）
- **60s 自动刷新**：修复 footer 文案承诺但从未实现的刷新逻辑（与后端 60s 统计缓存 TTL 匹配）
- **图表布局**：连续折线（活跃趋势）、0.5 星分箱直方图、5% LN 分箱、0.5 数值化难度分箱；柱状图按行配对（Star/LN、Key count/Numeric），饼图每行三个
- **删除原始数据表**：`/api/v1/events` 端点与逐行数据展示已移除（隐私考虑），看板只暴露聚合数据

## 遥测字段

- **`actualAlgorithm` 语义修正**：Mixed 自动路由此前上报字面 "Mixed"，现上报实际命中的子算法（Roxy/Azusa/Daniel/Companella/Sunny）；星数归一化（Sunny sr 口径）行为保持不变
- **新增 `numericDifficulty`**（可选字段）：标准数值化难度（Reform 段位体系，`.0 = mid`）；Azusa/Roxy 用原生连续值，其余算法从 `estDiff` 标签反向换算（`rcLabelToNumeric`）；**Daniel 一律走反解**——其原生值是 DP 尺度（约高 0.5），直接上传会污染分布；边界标签（`< Alpha Low` 等）不可解析 → 不发送
- 服务端白名单同步 +1 字段，白名单外字段依旧丢弃

## 后端

- **版本化**：`-ldflags "-X main.version=…"` 注入（默认 `dev`），暴露于 `/api/v1/stats` 的 `serverVersion`、看板 footer 与启动日志
- **性能**：时长分位数改 5000 样本 reservoir sampling（`avgMs` 仍全量精确），内存/时间 O(1)，为数十万事件规模做准备
- **存储**：插件心跳间隔 5min → 10min，心跳行数减半（在线统计粒度仍足够）

## 隐私

延续既定边界：仅聚合属性，无用户名/谱面标识/IP/UA/OS/时区；`numericDifficulty` 为纯聚合数值，不引入任何身份信息。