### PR TITLE
fix: prevent memory leaks in long-running overlay

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -437,6 +437,7 @@ export async function fetchBeatmapFile(reason) {
                 parsedInfo = pipelineResult.parsedSummary;
                 applyContentBarOverride(parsedInfo.columnCount);
             } catch (error) {
+                if (isStaleRequest()) return;
                 resetReworkDisplay();
                 if (state.diffText === "Graph" || contentBarShows("Graph")) {
                     showDiffGraphError("Graph unavailable");

--- a/ManiaMapAnalyser by Leo_Black/js/app/coverTheme.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/coverTheme.js
@@ -99,14 +99,24 @@ function loadImage(url) {
     return new Promise((resolve, reject) => {
         const image = new Image();
         image.crossOrigin = "anonymous";
+
+        const cleanup = () => {
+            image.onload = null;
+            image.onerror = null;
+        };
+
         image.onload = () => {
+            cleanup();
             if (image.naturalWidth > 0 && image.naturalHeight > 0) {
                 resolve(image);
             } else {
                 reject(new Error("Empty image"));
             }
         };
-        image.onerror = () => reject(new Error("Image load failed"));
+        image.onerror = () => {
+            cleanup();
+            reject(new Error("Image load failed"));
+        };
         image.src = url;
     });
 }

--- a/ManiaMapAnalyser by Leo_Black/js/app/graph.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/graph.js
@@ -371,6 +371,8 @@ export function clearDiffGraph() {
 
         clearPauseMarkersDom(view);
     });
+
+    syncGraphAnimationLoop();
 }
 
 export function setGraphCursorVisible(visible) {
@@ -520,21 +522,35 @@ export function updateGraphCursor(explicitTimeMs = null) {
     setGraphCursorVisible(true);
 }
 
-export function startGraphAnimationLoop() {
-    if (state.graphAnimationStarted) {
-        return;
+let graphAnimationFrameId = 0;
+
+function graphAnimationTick() {
+    graphAnimationFrameId = 0;
+    if (hasAnyGraphModeEnabled()) {
+        updateGraphCursor();
+        graphAnimationFrameId = requestAnimationFrame(graphAnimationTick);
+    } else {
+        state.graphAnimationStarted = false;
     }
+}
 
-    state.graphAnimationStarted = true;
-
-    const tick = () => {
-        if (hasAnyGraphModeEnabled()) {
-            updateGraphCursor();
+export function syncGraphAnimationLoop() {
+    if (hasAnyGraphModeEnabled()) {
+        if (!state.graphAnimationStarted) {
+            state.graphAnimationStarted = true;
+            graphAnimationFrameId = requestAnimationFrame(graphAnimationTick);
         }
-        requestAnimationFrame(tick);
-    };
+    } else {
+        if (graphAnimationFrameId) {
+            cancelAnimationFrame(graphAnimationFrameId);
+            graphAnimationFrameId = 0;
+        }
+        state.graphAnimationStarted = false;
+    }
+}
 
-    requestAnimationFrame(tick);
+export function startGraphAnimationLoop() {
+    syncGraphAnimationLoop();
 }
 
 // toFixed(1) is sufficient for a 260px-wide viewBox — saves ~20% string length vs (2)
@@ -706,6 +722,8 @@ export function updateDiffTextVisibility() {
     } else {
         setGraphCursorVisible(false);
     }
+
+    syncGraphAnimationLoop();
 
     if (!showRightCapsule && reworkRightCapsuleEl) {
         reworkRightCapsuleEl.textContent = "-";

--- a/ManiaMapAnalyser by Leo_Black/js/app/settings.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/settings.js
@@ -63,6 +63,7 @@ import {
     clearDiffGraph,
     redrawPauseMarkers,
     setGraphCursorVisible,
+    syncGraphAnimationLoop,
     updateDiffTextVisibility,
 } from "./graph.js";
 import {
@@ -429,6 +430,7 @@ export function setRuntimeContentBar(contentBar) {
     } else {
         setGraphCursorVisible(false);
     }
+    syncGraphAnimationLoop();
     return changed;
 }
 
@@ -453,6 +455,7 @@ export function setEffectiveContentBarForMap(contentBarOrNull) {
     } else {
         setGraphCursorVisible(false);
     }
+    syncGraphAnimationLoop();
 
     return changed;
 }

--- a/ManiaMapAnalyser by Leo_Black/js/app/telemetry.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/telemetry.js
@@ -157,6 +157,7 @@ export function initTelemetry() {
 // Called by settings.js whenever telemetry settings change at runtime.
 export function setTelemetryConfig() {
     readConfig();
+    syncTelemetryHeartbeat();
     maybeBoot();
 }
 
@@ -166,20 +167,35 @@ export function noteTelemetryActivity() {
     lastActivityAt = Date.now();
 }
 
-export function startTelemetryHeartbeat() {
+export function stopTelemetryHeartbeat() {
     if (heartbeatTimerId) {
-        return;
+        clearInterval(heartbeatTimerId);
+        heartbeatTimerId = 0;
     }
+}
 
-    heartbeatTimerId = window.setInterval(() => {
-        if (!isActive()) {
+function syncTelemetryHeartbeat() {
+    if (isActive()) {
+        if (heartbeatTimerId) {
             return;
         }
-        if (Date.now() - lastActivityAt > ACTIVITY_WINDOW_MS) {
-            return;
-        }
-        send("heartbeat");
-    }, HEARTBEAT_INTERVAL_MS);
+
+        heartbeatTimerId = window.setInterval(() => {
+            if (!isActive()) {
+                return;
+            }
+            if (Date.now() - lastActivityAt > ACTIVITY_WINDOW_MS) {
+                return;
+            }
+            send("heartbeat");
+        }, HEARTBEAT_INTERVAL_MS);
+    } else {
+        stopTelemetryHeartbeat();
+    }
+}
+
+export function startTelemetryHeartbeat() {
+    syncTelemetryHeartbeat();
 }
 
 export function trackTelemetryAnalyze(data) {

--- a/ManiaMapAnalyser by Leo_Black/js/app/updateChecker.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/updateChecker.js
@@ -183,10 +183,11 @@ async function runUpdateCheckIfDueInternal({ enabled, currentVersion, onResult, 
         return;
     }
 
+    let timeoutId = 0;
     try {
         const hasAbortController = typeof AbortController !== "undefined";
         const controller = hasAbortController ? new AbortController() : null;
-        const timeoutId = setTimeout(() => {
+        timeoutId = setTimeout(() => {
             if (controller) {
                 controller.abort();
             }
@@ -202,6 +203,7 @@ async function runUpdateCheckIfDueInternal({ enabled, currentVersion, onResult, 
         });
         const response = await inFlightCheckPromise;
         clearTimeout(timeoutId);
+        timeoutId = 0;
 
         if (!response.ok) {
             throw new Error(`latest release request failed: ${response.status}`);
@@ -232,6 +234,9 @@ async function runUpdateCheckIfDueInternal({ enabled, currentVersion, onResult, 
 
         emitResult(onResult, false, "", "");
     } finally {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
         inFlightCheckPromise = null;
     }
 }

--- a/ManiaMapAnalyser by Leo_Black/js/app/worker/manager.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/worker/manager.js
@@ -10,7 +10,8 @@
 
 let worker = null;
 let nextId = 0;
-let latestId = null;
+let messageHandlerAttached = false;
+const pendingRequests = new Map();
 
 function ensureWorker() {
     if (worker) return worker;
@@ -20,8 +21,23 @@ function ensureWorker() {
             { type: "module" },
         );
         worker = w;
+        messageHandlerAttached = false;
+
+        w.addEventListener("error", () => {
+            rejectAllPending(new Error("Worker crashed"));
+            if (worker === w) {
+                try {
+                    w.terminate();
+                } catch {
+                    // Ignore terminate errors during cleanup.
+                }
+                worker = null;
+                messageHandlerAttached = false;
+            }
+        });
     } catch (_) {
         worker = null;
+        messageHandlerAttached = false;
     }
     return worker;
 }
@@ -29,6 +45,33 @@ function ensureWorker() {
 function generateId() {
     nextId += 1;
     return `req-${nextId}-${Date.now()}`;
+}
+
+function rejectAllPending(reason) {
+    for (const entry of pendingRequests.values()) {
+        clearTimeout(entry.timeoutId);
+        entry.reject(reason);
+    }
+    pendingRequests.clear();
+}
+
+function attachMessageHandler(w) {
+    if (messageHandlerAttached) return;
+    messageHandlerAttached = true;
+
+    w.addEventListener("message", (event) => {
+        const { id, result, error } = event.data || {};
+        const entry = pendingRequests.get(id);
+        if (!entry) return;
+
+        pendingRequests.delete(id);
+        clearTimeout(entry.timeoutId);
+        if (error) {
+            entry.reject(new Error(error));
+        } else {
+            entry.resolve(result);
+        }
+    });
 }
 
 /**
@@ -41,35 +84,42 @@ export function runInWorker(input) {
     const w = ensureWorker();
     if (!w) return null; // caller should fall back to sync
 
-    // Cancel all previous pending requests by advancing latestId
+    // A new request supersedes every pending one: settle their promises and
+    // drop their listeners so stale work cannot accumulate in memory.
+    rejectAllPending(new Error("Worker request superseded"));
+
     const id = generateId();
-    latestId = id;
+    attachMessageHandler(w);
 
     return new Promise((resolve, reject) => {
-        const handler = (event) => {
-            const { id: respId, result, error } = event.data || {};
-
-            // Discard responses from stale requests
-            if (respId !== latestId) return;
-
-            w.removeEventListener("message", handler);
-            if (error) {
-                reject(new Error(error));
-            } else {
-                resolve(result);
-            }
-        };
-
-        w.addEventListener("message", handler);
-        w.postMessage({ id, type: "pipeline", input });
-
-        // Safety timeout (30s) to prevent hanging
-        setTimeout(() => {
-            if (id === latestId) {
-                w.removeEventListener("message", handler);
-                reject(new Error("Worker timeout"));
-            }
+        const timeoutId = setTimeout(() => {
+            const entry = pendingRequests.get(id);
+            if (!entry) return;
+            pendingRequests.delete(id);
+            reject(new Error("Worker timeout"));
         }, 30000);
+
+        pendingRequests.set(id, { resolve, reject, timeoutId });
+
+        try {
+            w.postMessage({ id, type: "pipeline", input });
+        } catch (error) {
+            const entry = pendingRequests.get(id);
+            if (entry) {
+                pendingRequests.delete(id);
+                clearTimeout(entry.timeoutId);
+            }
+            if (worker === w) {
+                try {
+                    w.terminate();
+                } catch {
+                    // Ignore terminate errors during cleanup.
+                }
+                worker = null;
+                messageHandlerAttached = false;
+            }
+            reject(error);
+        }
     });
 }
 

--- a/docs/features/difficulty-estimation.md
+++ b/docs/features/difficulty-estimation.md
@@ -80,8 +80,8 @@ const effectiveWeights = (options?.classicMod === true ? CArr : CArrV2).map((c, 
 `js/app/worker/manager.js` 管理 Worker 生命周期：
 
 - `manager.js:41 runInWorker`：创建 Worker 失败（不支持或构造异常，`manager.js:15-27 ensureWorker`）时返回 `null`（`manager.js:43`），调用方回退到主线程同步执行；
-- `manager.js:80 isWorkerAvailable`：查询 Worker 是否可用；
-- `manager.js:49-74`：只接受最新请求的结果（`latestId` 匹配），并带 30 秒超时兜底。
+- `manager.js:129 isWorkerAvailable`：查询 Worker 是否可用；
+- `manager.js:83-124 runInWorker`：新请求先取消全部在途请求（`pendingRequests` Map），共享 `message` 监听按 id 匹配响应，并带 30 秒超时兜底。
 
 `analysis.js` 中所有 worker 估算器的调用均采用 `wp ? await wp : runXxxEstimatorFromText(...)` 模式：
 

--- a/docs/features/graph-visualization.md
+++ b/docs/features/graph-visualization.md
@@ -102,7 +102,7 @@ graph.js 中通过 `view.svgEl` / `view.fillEl` / `view.fillPlayEl` / `view.play
 
 - `graph.js:515-517`：`view.playClipRectEl.setAttribute("width", x.toFixed(2))`，其中 `x` 是当前播放时间插值出的 viewBox 横坐标（`graph.js:495`）。注释（`graph.js:514`）说明：clip 宽度 = 已玩边界，暂停时 x 冻结、回退时 x 收缩，自动跟随。
 - 游标更新在 `graph.js:460 updateGraphCursor(explicitTimeMs)`：播放时间经 `graph.js:70 getInterpolatedPlaybackTime()` 获取（基于 WebSocket 时间戳 + `performance.now()` 插值，暂停时返回冻结值 `state.frozenInterpMs`）；时间限定在 `[songStartMs, songEndMs]`（`graph.js:482-484`）再 clamp 到系列范围；y 值经 `interpolateSeriesValue` + 归一化得出（`graph.js:496-498`）。
-- 动画循环：`graph.js:523 startGraphAnimationLoop()` 用 `requestAnimationFrame` 每帧调用 `updateGraphCursor()`（`graph.js:530-537`）。
+- 动画循环：`graph.js:537 syncGraphAnimationLoop()` 只在**存在任一图表模式**时用 `requestAnimationFrame` 每帧调用 `updateGraphCursor()`（`graph.js:530-536`）；无图表模式时 `cancelAnimationFrame` 停掉循环，避免常驻空转。`startGraphAnimationLoop()`（`graph.js:552`）在初始化时调用，`updateDiffTextVisibility`/`setRuntimeContentBar`/`setEffectiveContentBarForMap` 在模式切换时同步启停。
 
 ### 5.2 resetPlayedFill 调用点（共 6 处，清空/加载/错误路径）
 

--- a/docs/features/telemetry.md
+++ b/docs/features/telemetry.md
@@ -29,7 +29,7 @@
 - `initTelemetry()` — 读配置，条件满足则发 `boot`。
 - `setTelemetryConfig()` — settings.js 运行时调用；开关由关→开且 endpoint 非空时补发 `boot`。
 - `noteTelemetryActivity()` — socketHandlers 每个 api_v2 包调用，更新 `lastActivityAt`。
-- `startTelemetryHeartbeat()` — `setInterval(10min)`；仅当 `enabled && endpoint && (now-lastActivityAt < 30s)` 发 `heartbeat`。
+- `startTelemetryHeartbeat()` / `stopTelemetryHeartbeat()` — 遥测激活时才启动 `setInterval(10min)`；`setTelemetryConfig()` 在关闭遥测时同步停止 interval，避免禁用后定时器常驻。心跳仅在 `enabled && endpoint && (now-lastActivityAt < 30s)` 时发送。
 - `trackTelemetryAnalyze(data)` — 发 `analyze`（fire-and-forget）。
 
 发送用 `fetch(..., {keepalive:true})` + 5s `AbortController` 超时，`.catch` 静默——**遥测绝不阻塞/破坏插件功能**。

--- a/docs/pipeline/analysis-pipeline.md
+++ b/docs/pipeline/analysis-pipeline.md
@@ -162,7 +162,7 @@ const isStaleRequest = () => requestSeq !== state.analysisRequestSeq;
 - 每次 `fetchBeatmapFile` 开始时自增全局序号（appContext.js:149 `analysisRequestSeq`），闭包捕获本次的 `requestSeq`。
 - 之后任何时刻（每个 await 之后）调用 `isStaleRequest()` 比对：一旦期间又发起了新分析（序号被推进），本次请求即过期，**立即 return 放弃渲染**，防止过期请求的结果覆盖新结果。
 - 检查点遍布异步边界：fetch 响应后（:337、:344）、估算后（:515）、Interlude（:591）、Etterna（:651）、Companella（:701、:715）、异常路径（:919）、finally（:935）。
-- worker 内部还有**同等的过期丢弃**：`manager.js:47 latestId` 只接受最新请求的响应（:54），30s 超时保护（:68-73）。
+- worker 内部还有**同等的过期丢弃**：`manager.js` 用 `pendingRequests` Map + 共享 `message` 监听按 id 匹配；新请求先 `rejectAllPending` 取消旧在途请求，过期/已取消响应直接忽略，30s 超时保护（manager.js:95-100）。
 
 ## 7. fetchBeatmapFile 主流程
 
@@ -215,9 +215,9 @@ const response = await fetch(getEndpoint(), { method: "GET", cache: "no-store" }
 
 - **附属段开关**：`withPattern/withEtterna/withInterlude` 取自 needComputed（fetch 前的保守值，与缓存覆盖检查同源，analysis.js:365-368）。默认 false——仅请求需要的段，避免 worker 白算（5K 等非支持键数谱面被 override 强制 Pattern 的边界：主线程消费段有回退分支，见下）。
 - **软失败通道**：附属段各自 try/catch，失败置空字段（`patternReport=null` / `ettResult=null` / `interludeStar=NaN`）并填独立错误文本（`patternError/ettError/interludeError/companellaEttError`），**不并入 errors[]**——旧代码的 errors.push 带展示条件（`shouldReportEtternaError`/`isKeycountError` 过滤、need* 门控）依赖主线程状态，由 analysis.js 按旧条件决定是否并入，保证逐字一致。
-- **worker 往返**：manager 发 `{id, type:"pipeline", input}`，compute.worker.js 的 `"pipeline"` 消息分支**异步**调 `runAnalysisPipeline(input)` 经 then/catch 回传（原 4 估算器消息保留不动）；latestId + 30s 超时语义不变。
+- **worker 往返**：manager 发 `{id, type:"pipeline", input}`，compute.worker.js 的 `"pipeline"` 消息分支**异步**调 `runAnalysisPipeline(input)` 经 then/catch 回传（原 4 估算器消息保留不动）；`pendingRequests` 取消 + 30s 超时语义保持 worker 防挂起。
 - **归一化星数复用决策**（仅影响性能，不改数值）：Mixed 与 Azusa(`forceSunnyReferenceHo=false`) 的内部 Sunny 与归一化调用使用相同 options → 预计算一份 Sunny 结果经 `precomputedSunnyResult` 喂给估算器并复用其 star；Azusa(`forceSunnyReferenceHo=true`) 内部用 `cvtFlag:"HO"`、Roxy 内部用 canonicalized 文本 → 独立计算（决策表见 worker.md §4.5）。
-- **估算失败**：pipeline 不吞估算器/SunnyWindow 抛错——直接向上传播，analysis.js 外层 catch（:377-399）`resetReworkDisplay()` + `errors.push("Rework failed: ...")` + 失败路径回退元信息解析（pipeline 抛错时 parsedSummary 未返回，catch 内用最小 OsuFileParser 补齐 parsedInfo 供渲染降级，与旧 parseMetadataFromBeatmap 行为一致）；`errors[]` 恒为空（预留软失败通道），合并与写门条件不变。
+- **估算失败**：pipeline 不吞估算器/SunnyWindow 抛错——直接向上传播，analysis.js 估算块 catch 先做 `isStaleRequest()` 守卫（过期请求因新请求取消而 reject 时直接 return，不做失败 UI），非过期才 `resetReworkDisplay()` + `errors.push("Rework failed: ...")` + 失败路径回退元信息解析（pipeline 抛错时 parsedSummary 未返回，catch 内用最小 OsuFileParser 补齐 parsedInfo 供渲染降级，与旧 parseMetadataFromBeatmap 行为一致）；`errors[]` 恒为空（预留软失败通道），合并与写门条件不变。
 - **SunnyWindow 合并留在 analysis.js**（:483-496）：`sunnyWindow.estDiff` 的 LN 段替换 `resolvedEstDiff`、`typePercentageData`、`lnStar`、`pendingMixedCompanellaContext.lnDifficulty` 等展示/缓存逻辑仍在原处，逐行未变。
 - **graph 去留决策**（实测记录）：graph 数组占 pipeline 消息体 ~99%（withGraph 时），但 structuredClone 耗时仅 0.6–3.2ms（3.6 万点马拉松谱面）vs 主线程重算估算器 30–400ms——graph 留在 pipeline（worker）内，不搬主线程。
 
@@ -300,7 +300,7 @@ const response = await fetch(getEndpoint(), { method: "GET", cache: "no-store" }
 | --- | --- | --- | --- |
 | `socketRecalcLazyDelayMs` | 200ms | config.js:70 `APP_CONFIG.timing.socketRecalcLazyDelayMs` → appContext.js:175 `SOCKET_RECALC_LAZY_DELAY_MS` | scheduler.js:22-23 `scheduleRecompute` 防抖窗口（socketHandlers.js:305、settings.js:859 传入 `useLazyDelay=true`） |
 | `settingsCommandTimeoutMs` | 1500ms | config.js:71 `APP_CONFIG.timing.settingsCommandTimeoutMs` → appContext.js:176 `SETTINGS_COMMAND_TIMEOUT_MS`（settings.js:50 导入） | settings.js:871 `waitForInitialSettingsFromCommand(timeoutMs)` 的 getSettings 响应超时（超时 reject "getSettings timeout"），详见 settings-pipeline.md §9 |
-| worker 安全超时 | 30s | manager.js:68-73 硬编码 | `runInWorker` 防挂起，超时 reject "Worker timeout" |
+| worker 安全超时 | 30s | manager.js:95-100 硬编码 | `runInWorker` 防挂起，超时 reject "Worker timeout" |
 | 重连间隔 | 1s | socket.js:43 | WebSocket 断开重连 |
 | `sendCommand` 重试 | 100ms/1s，至多 3 次 | socket.js:71-76/:82-87 | 命令通道未就绪/发送失败 |
 
@@ -309,7 +309,7 @@ const response = await fetch(getEndpoint(), { method: "GET", cache: "no-store" }
 - **stale 请求不写缓存**：写门含 `!isStaleRequest()`（analysis.js:745）与代数守卫 `genAtStart === resultCacheGeneration()`（:746）双保险——前者防"过期分析结果覆盖新结果"（含缓存），后者防"clear 之后旧分析写回"（result-cache.md §7）。
 - **meta 降级 identity 不缓存**：`analysis.js:776` `put(cacheKey, {...}, { skip: isMetaDegraded })`——meta: 身份只读不写，碰撞风险下宁可每张图重算（result-cache.md §8）。
 - **分析失败路径**：估算块 catch → `analysis.js:551 resetReworkDisplay()`（定义 :215-246）——重置 actualEstimatorAlgorithm、数值/胶囊/图/meta 全清、mode tag 回 "Mix"、SV 标签隐藏、必要时显示 "Graph unavailable"；外层 catch（:918-933，fetch/解析失败）同样调用并在 overlay 显示 "Load failed"。
-- **worker 失败不阻塞主线程**：`runInWorker` 返回 null 即同步回退（analysis.js:458），Worker 构造失败（manager.js:23-25）与 30s 超时（manager.js:68-73）都不会让分析中断——代价是主线程计算可能卡顿，这是"可用性优先"的取舍。
+- **worker 失败不阻塞主线程**：`runInWorker` 返回 null 即同步回退（analysis.js:458），Worker 构造失败（manager.js:38-41）与 30s 超时（manager.js:95-100）都不会让分析中断——代价是主线程计算可能卡顿，这是"可用性优先"的取舍。
 - **缓存键不含显示类设置**：`display6kLevel`、`forceSunnyWindow`、etterna 版本等不进键，正确性依赖 settings.js 失效列表——任何新计算影响设置漏加失效 = 静默过期结果（result-cache.md §9）。
 - **needComputed 是保守值**：fetch 前用上一张图的 effectiveContentBar 推导（analysis.js:284-286 注释），仅供覆盖检查；实际 shows*/need* 在 override 后重算（:362-365）——修改 needComputed 推导时注意保持两处一致。
 - **changeKind 只消费一次**：`analysis.js:262` 取用后即清空 `state.pendingChangeKind`——后续纯设置 recompute 拿到的都是 undefined，按 difficulty 轻量过渡处理（:258-261），避免换歌动画重复播放。

--- a/docs/pipeline/worker.md
+++ b/docs/pipeline/worker.md
@@ -21,38 +21,39 @@ Node 回归脚本（computeOutput）直接 await runAnalysisPipeline（第三端
 
 ## 2. Worker 生命周期（manager.js）
 
-`js/app/worker/manager.js` 是 worker 的唯一持有者，模块级闭包变量 `worker / nextId / latestId`（manager.js:11-13）。
+`js/app/worker/manager.js` 是 worker 的唯一持有者，模块级闭包变量 `worker / nextId / pendingRequests / messageHandlerAttached`（manager.js:11-16）。
 
 ### 2.1 创建与复用
 
-- `ensureWorker()`（manager.js:15-27）：`worker` 已存在直接返回（**单例复用**）；不存在则 `new Worker(new URL("./compute.worker.js", import.meta.url), { type: "module" })`（manager.js:18-21，`import.meta.url` 相对**模块文件**解析：`new URL` 模式，勿改相对字符串，见 module-conventions.md §3）。
-- **构造失败**（不支持 Worker 的环境，如部分 WebView/禁用 worker 的浏览器）：`catch` 置 `worker = null`（manager.js:23-25），**不抛错**，由调用方走同步回退。
-- 崩溃恢复：worker 运行时崩溃后 `worker` 引用仍指向已死的实例，下一次请求时 `postMessage` 会抛错 → `runInWorker` 的 Promise reject → analysis.js 外层 catch 按失败路径处理；重新创建发生在下一次 `ensureWorker()` 前需要显式重建的场景（当前实现不自动重建，失败路径不依赖 worker 恢复）。
+- `ensureWorker()`（manager.js:16-43）：`worker` 已存在直接返回（**单例复用**）；不存在则 `new Worker(new URL("./compute.worker.js", import.meta.url), { type: "module" })`（manager.js:19-22，`import.meta.url` 相对**模块文件**解析：`new URL` 模式，勿改相对字符串，见 module-conventions.md §3）。
+- **构造失败**（不支持 Worker 的环境，如部分 WebView/禁用 worker 的浏览器）：`catch` 置 `worker = null`（manager.js:38-41），**不抛错**，由调用方走同步回退。
+- 崩溃恢复：`ensureWorker()` 为新建 worker 注册 `error` 监听；worker 运行时崩溃会**拒绝全部在途请求、`terminate()` 已死实例并置 `worker = null`**，下一次请求自动重建。这同时避免崩溃后 pending promise/listener 永久滞留。
 
-### 2.2 latestId 过期机制
+### 2.2 请求取消与响应匹配
 
-`runInWorker(input)`（manager.js:40-74）：
+`runInWorker(input)`（manager.js:83-124）：
 
-- `generateId()`（manager.js:29-32）自增 `nextId` 生成 `req-<n>-<ts>`。
-- `latestId = id`（manager.js:46），**每次新请求直接推进 latestId，旧的在途请求立即作废**（相当于取消）。
-- 响应回调（manager.js:49-61）：`event.data` 解构 `{ id, result, error }`；`respId !== latestId` 的响应**直接丢弃**（manager.js:53），旧请求的迟到响应永远不会污染新请求。
-- 正常完成后 `removeEventListener` 解绑（manager.js:55），错误 reject `new Error(error)`（:57），成功 resolve result（:59）。
+- `generateId()`（manager.js:45-48）自增 `nextId` 生成 `req-<n>-<ts>`。
+- 每次新请求先 `rejectAllPending(new Error("Worker request superseded"))`（manager.js:50-56）：**旧的在途请求立即 settle，不再保留 listener/promise**，避免快速换歌/改设置时累积泄漏。
+- 响应匹配改为**单一共享 `message` 监听**（`attachMessageHandler`，manager.js:58-75）：按 `event.data.id` 查 `pendingRequests` Map；查得到才 resolve/reject 并清理超时，查不到（已过期/已取消）直接忽略。因此旧请求的迟到响应永远不会污染新请求，也不需要逐请求 `removeEventListener`。
+- 正常完成或错误时 `pendingRequests.delete(id)` + `clearTimeout(timeoutId)`；错误 reject `new Error(error)`，成功 resolve result。
 
 ### 2.3 30s 超时
 
-- `setTimeout`（manager.js:67-72）：30s 内未收到响应（且该请求仍是 latestId）→ 解绑并 `reject(new Error("Worker timeout"))`。
+- 每个请求的 `setTimeout`（manager.js:95-100）：30s 内未收到响应 → 从 `pendingRequests` 删除并 `reject(new Error("Worker timeout"))`。
+- `postMessage` 同步抛错时也会清理该请求并 reject。
 - **stale 粒度差异**（详见 §7）：pipeline 单次往返消息在 worker 内**不可中断**，30s 超时是唯一的最坏情况保护；旧 4 估算器消息时代可以在每个 runX 边界丢弃过期请求，粒度更细。
 
 ### 2.4 同步回退链
 
 ```
-runInWorker 返回 null（Worker 构造失败，manager.js:23-25）
+runInWorker 返回 null（Worker 构造失败，manager.js:38-41）
   → analysis.js:375 走 await runAnalysisPipeline(pipelineInput)
   → 同一函数、同一输入，逐位相同输出
   → 仅有的代价：估算在主线程同步执行（可能卡顿）
 ```
 
-`isWorkerAvailable()`（manager.js:79-81）暴露可用性查询（当前仅 debug 面板使用）。
+`isWorkerAvailable()`（manager.js:129-131）暴露可用性查询（当前仅 debug 面板使用）。
 
 ## 3. 消息协议
 
@@ -226,8 +227,8 @@ graph 数组占 withGraph 消息体 ~99%，但 **structuredClone 耗时 0.6~3.2m
 | 层 | 粒度 | 机制 |
 | --- | --- | --- |
 | 主线程请求序号 | 每次 `fetchBeatmapFile`（analysis.js:231-233 `analysisRequestSeq`） | 每个 await 后 `isStaleRequest()` 检查（:325/:332/:495/:576/:676/:732/:747），过期立即 return |
-| worker latestId | 每次 `runInWorker`（manager.js:46） | 响应按 `respId !== latestId` 丢弃（manager.js:53） |
-| pipeline 消息内部 | **一次往返，不可中断** | worker 内 `runAnalysisPipeline` 一旦开始就跑到结束；30s 超时（manager.js:67-72）是最坏情况保护 |
+| worker pendingRequests | 每次 `runInWorker` | 新请求先 `rejectAllPending`；共享 `message` 监听按 id 匹配 `pendingRequests`，过期/已取消响应直接忽略 |
+| pipeline 消息内部 | **一次往返，不可中断** | worker 内 `runAnalysisPipeline` 一旦开始就跑到结束；30s 超时（manager.js:95-100）是最坏情况保护 |
 | 旧 4 估算器消息 | **每次 runX 可中止** | 旧消息时代主线程可在估算器之间丢弃过期响应（粒度更细，现已无调用方） |
 
 **pipeline 单次往返的取舍**：一次性带回全部产物（含二次 Ett、pattern、graph），代价是 worker 内无法在中途放弃，30s 超时兜底。对典型谱面（总耗时 <1s）无实际影响。


### PR DESCRIPTION
- worker manager: replace per-request message listeners with a single pendingRequests Map; superseding requests now settle stale promises and drop listeners, and worker crashes reject/cleanup pending work
- graph: stop requestAnimationFrame loop when no graph mode is active
- telemetry: only run heartbeat interval while telemetry is enabled
- update checker: clear abort timeout on fetch rejection as well
- cover theme: detach image load/error handlers after settle
- analysis: ignore superseded worker rejections before resetting UI
- docs: sync worker/graph/telemetry behavior