### PR TITLE
backend: Split dashboard assets and refresh UI

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -6,5 +6,8 @@ telemetry.db-*
 # Build artifacts (compiled binaries).
 bin/
 
+# Local scratch (preview runs, downloaded DBs, screenshots).
+temp/
+
 # Private docs (teaching notes for the maintainer only).
 docs/

--- a/backend/internal/analytics/analytics.go
+++ b/backend/internal/analytics/analytics.go
@@ -243,8 +243,8 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 			lnN++
 		}
 		if d.NumericDifficulty != nil && *d.NumericDifficulty >= -3 && *d.NumericDifficulty <= 30 {
-			// aggregate into 0.5 bins on the Reform numeric scale (.0 = mid)
-			numerics[math.Round(*d.NumericDifficulty*2)/2]++
+			// aggregate into 0.25 bins on the Reform numeric scale (.0 = mid)
+			numerics[math.Round(*d.NumericDifficulty*4)/4]++
 		}
 		if d.DurationMs >= 0 {
 			v := int64(d.DurationMs)
@@ -276,7 +276,7 @@ func buildDistributions(st *store.Store, since int64, s *Stats) error {
 
 	s.StarHistogram = histogram(stars, func(k float64) string { return fmt.Sprintf("%.1f", k) })
 	s.LnRatioHistogram = histogram(lns, func(k float64) string { return fmt.Sprintf("%.0f%%", k*100) })
-	s.NumericHistogram = histogram(numerics, func(k float64) string { return fmt.Sprintf("%.1f", k) })
+	s.NumericHistogram = histogram(numerics, func(k float64) string { return fmt.Sprintf("%.2f", k) })
 	if starN > 0 {
 		s.AvgStar = math.Round(starSum/float64(starN)*100) / 100
 	}

--- a/backend/internal/web/dashboard.css
+++ b/backend/internal/web/dashboard.css
@@ -1,0 +1,383 @@
+/* ManiaMapAnalyser — Usage Statistics dashboard styles.
+   Loaded as a separate asset (go:embed) so the HTML stays small and the
+   stylesheet can be browser-cached independently. */
+
+/* ── Themes ────────────────────────────────────────── */
+:root {
+  /* light (default) */
+  --bg: #f6f9fc;
+  --panel: #ffffff;
+  --panel-2: #fafbfd;
+  --border: #e6e9ef;
+  --border-strong: #d1d6e0;
+  --fg: #0a2540;
+  --fg-dim: #425466;
+  --muted: #697386;
+  --accent: #635bff;
+  --accent-2: #7c75ff;
+  --accent-soft: rgba(99, 91, 255, .08);
+  --ok: #0d9c5f;
+  --danger: #cf1e3b;
+  --warm: #f5a623;
+  --track: #ebeef3;
+  --grid: #ebeef3;
+  --shadow: 0 1px 2px rgba(60, 66, 87, .04), 0 1px 3px rgba(60, 66, 87, .06);
+  --shadow-strong: 0 4px 12px rgba(60, 66, 87, .10);
+  --tip-bg: #1a1f36;
+  --tip-fg: #fff;
+  --font-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+}
+:root[data-theme="dark"] {
+  --bg: #0b1020;
+  --panel: #131a2c;
+  --panel-2: #0f1424;
+  --border: #1f2a40;
+  --border-strong: #2c3a55;
+  --fg: #e5e7eb;
+  --fg-dim: #b6bccb;
+  --muted: #7a8499;
+  --accent: #7c75ff;
+  --accent-2: #9b94ff;
+  --accent-soft: rgba(124, 117, 255, .12);
+  --ok: #34d399;
+  --danger: #f87171;
+  --warm: #fbbf24;
+  --track: #1a2238;
+  --grid: #232b40;       /* darker so gridlines stay subtle on dark panels */
+  --shadow: 0 1px 2px rgba(0, 0, 0, .3), 0 1px 3px rgba(0, 0, 0, .25);
+  --shadow-strong: 0 4px 12px rgba(0, 0, 0, .4);
+  --tip-bg: #1a1f36;
+  --tip-fg: #fff;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  transition: background-color .25s ease, color .25s ease;
+}
+.tabular { font-variant-numeric: tabular-nums; font-feature-settings: "tnum"; }
+
+/* ── Header ────────────────────────────────────────── */
+header {
+  max-width: 1180px; margin: 0 auto; padding: 36px 28px 24px;
+}
+header .top {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 24px; flex-wrap: wrap;
+}
+header h1 {
+  font-size: 22px; font-weight: 600; margin: 0; letter-spacing: -.015em;
+  color: var(--fg);
+}
+header h1 .dim { color: var(--muted); font-weight: 500; }
+header .sub {
+  color: var(--fg-dim); font-size: 13.5px; margin: 6px 0 0;
+}
+.meta {
+  color: var(--muted); font-size: 12.5px; margin-top: 18px;
+  display: flex; gap: 16px; flex-wrap: wrap; align-items: center;
+}
+.meta .live { color: var(--ok); display: inline-flex; align-items: center; gap: 6px; font-weight: 500; }
+.meta .live::before {
+  content: ""; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--ok); box-shadow: 0 0 0 3px rgba(52, 211, 153, .18);
+}
+:root:not([data-theme="dark"]) .meta .live::before {
+  box-shadow: 0 0 0 3px rgba(13, 156, 95, .15);
+}
+.meta .sep { color: var(--border-strong); }
+
+/* ── Controls (range + theme toggle) ─────────────────── */
+.controls { display: flex; align-items: center; gap: 10px; }
+.range {
+  display: inline-flex; background: var(--panel);
+  border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
+  box-shadow: var(--shadow);
+}
+.range button {
+  background: transparent; color: var(--fg-dim); border: none;
+  padding: 8px 18px; font-size: 13px; cursor: pointer;
+  transition: color .15s ease, background .15s ease;
+  border-right: 1px solid var(--border);
+  font-weight: 500;
+}
+.range button:last-child { border-right: none; }
+.range button:hover { color: var(--fg); background: var(--panel-2); }
+.range button.active { background: var(--accent); color: #fff; font-weight: 600; }
+.theme-btn {
+  width: 40px; height: 40px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  display: inline-flex; align-items: center; justify-content: center;
+  box-shadow: var(--shadow);
+  color: var(--fg-dim);
+  transition: color .15s ease, background .15s ease, border-color .15s ease;
+}
+.theme-btn:hover { color: var(--fg); border-color: var(--border-strong); }
+.theme-btn svg { width: 18px; height: 18px; }
+:root[data-theme="dark"] .theme-btn .icon-sun { display: inline; }
+:root[data-theme="dark"] .theme-btn .icon-moon { display: none; }
+:root:not([data-theme="dark"]) .theme-btn .icon-sun { display: none; }
+:root:not([data-theme="dark"]) .theme-btn .icon-moon { display: inline; }
+
+main { max-width: 1180px; margin: 0 auto; padding: 8px 28px 56px; }
+
+/* ── Cards (top stat row) — 8 cards, forced single row ── */
+.cards {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 12px;
+  margin-bottom: 24px;
+}
+@media (max-width: 1100px) { .cards { grid-template-columns: repeat(4, 1fr); } }
+@media (max-width: 560px) { .cards { grid-template-columns: repeat(2, 1fr); } }
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 14px 12px;
+  box-shadow: var(--shadow);
+  transition: border-color .15s ease, background-color .25s ease;
+}
+.card:hover { border-color: var(--border-strong); }
+.card .v {
+  font-family: var(--font-mono);
+  font-size: 22px; font-weight: 600;
+  letter-spacing: -.015em;
+  color: var(--fg);
+  line-height: 1.15;
+}
+.card .v .delta {
+  font-family: var(--font-sans);
+  font-size: 11.5px; font-weight: 600; margin-left: 6px;
+  vertical-align: 2px;
+}
+.delta.up { color: var(--ok); }
+.delta.down { color: var(--danger); }
+.delta.flat { color: var(--muted); }
+.card .k {
+  font-size: 12px; color: var(--muted);
+  margin-top: 6px;
+  font-weight: 500;
+}
+
+/* ── Grids ─────────────────────────────────────────── */
+.grid2, .grid3 { gap: 14px; margin-bottom: 14px; display: grid; align-items: stretch; }
+.grid2 { grid-template-columns: repeat(2, 1fr); }
+.grid3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 900px) { .grid2, .grid3 { grid-template-columns: 1fr; } }
+
+.full { display: block; margin-bottom: 14px; }
+
+/* ── Panels ────────────────────────────────────────── */
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 18px 20px 16px;
+  display: flex; flex-direction: column;
+  min-width: 0;
+  box-shadow: var(--shadow);
+  transition: background-color .25s ease, border-color .25s ease;
+}
+.panel h2 {
+  font-size: 13px; font-weight: 600;
+  color: var(--fg);
+  margin: 0 0 16px;
+  display: flex; justify-content: space-between; align-items: baseline; gap: 10px;
+}
+.panel h2 small {
+  color: var(--muted); font-weight: 400; font-size: 12px;
+}
+.panel .body { flex: 1; min-height: 0; min-width: 0; display: flex; flex-direction: column; }
+
+/* ── Horizontal bar rows ───────────────────────────── */
+.bars {
+  display: flex; flex-direction: column;
+  justify-content: space-around;
+  gap: 10px;
+  flex: 1;
+  min-height: 170px;
+  padding-right: 4px;
+}
+.bar-row {
+  display: grid;
+  grid-template-columns: 76px 1fr 100px;
+  align-items: center;
+  gap: 12px;
+  font-size: 13px;
+}
+.bar-label {
+  color: var(--fg);
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 500;
+}
+.bar-track {
+  background: var(--track);
+  border-radius: 4px;
+  height: 14px;
+  overflow: hidden;
+}
+.bar-fill {
+  height: 100%; border-radius: 4px;
+  background: var(--accent);
+  min-width: 2px;
+  transform-origin: left;
+  animation: growX .5s cubic-bezier(.22,.61,.36,1) both;
+}
+.bar-row:hover .bar-fill { background: var(--accent-2); }
+@keyframes growX { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+.bar-count {
+  text-align: left;
+  color: var(--fg-dim);
+  font-size: 12px;
+  white-space: nowrap;
+  font-weight: 500;
+}
+.bar-count .num { font-family: var(--font-mono); font-weight: 500; }
+.bar-count .pct { color: var(--muted); margin-left: 6px; font-size: 11px; font-weight: 400; font-family: var(--font-mono); }
+
+.more-btn {
+  align-self: flex-start; margin-top: 10px;
+  background: var(--panel); color: var(--accent);
+  border: 1px solid var(--border); border-radius: 6px;
+  padding: 5px 12px; font-size: 12px; cursor: pointer;
+  font-weight: 500;
+  transition: border-color .15s ease;
+}
+.more-btn:hover { border-color: var(--accent); }
+
+/* ── Chart wrapper & svg ───────────────────────────── */
+.chart-wrap { overflow-x: auto; }
+.chart-wrap svg { display: block; }
+svg text {
+  fill: var(--muted);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+}
+svg line.grid { stroke: var(--grid); stroke-width: 1; }
+svg .grow {
+  transform-box: fill-box; transform-origin: bottom;
+  animation: growY .45s cubic-bezier(.22,.61,.36,1) both;
+}
+@keyframes growY { from { transform: scaleY(0); } to { transform: scaleY(1); } }
+svg .draw {
+  stroke-dasharray: 2000; stroke-dashoffset: 2000;
+  animation: draw 1.1s ease forwards;
+}
+@keyframes draw { to { stroke-dashoffset: 0; } }
+svg .hover-guide { stroke: var(--accent); stroke-width: 1; stroke-dasharray: 3 3; opacity: .55; }
+svg .hover-halo { fill: var(--accent); stroke: var(--panel); stroke-width: 2; opacity: .25; }
+svg .hover-dot { fill: var(--accent); stroke: var(--panel); stroke-width: 2; }
+
+/* Numeric difficulty chart uses slightly larger labels (per design). */
+.numeric-chart svg text { font-size: 5.5px; }
+
+/* Key count: split into two visual columns inside one panel (shared max). */
+.bars-split .bars {
+  display: block; /* override flex so CSS columns work */
+  min-height: auto;
+  overflow: visible;
+  columns: 2;
+  column-gap: 28px;
+}
+.bars-split .bar-row { break-inside: avoid; margin-bottom: 2px; }
+@media (max-width: 600px) { .bars-split .bars { columns: 1; } }
+
+/* ── Donut & legend ────────────────────────────────── */
+.donut-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.donut-wrap svg {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+}
+.legend {
+  display: flex; flex-direction: column; gap: 8px;
+  font-size: 12.5px; min-width: 0;
+  margin-left: 124px;
+  max-height: 100%;
+  overflow-y: auto;
+}
+.legend-row {
+  display: grid;
+  grid-template-columns: 10px auto 80px;
+  align-items: center;
+  gap: 6px 10px;
+}
+.legend-row .lv { text-align: right; }
+.legend-row .sw { width: 9px; height: 9px; border-radius: 2px; }
+.legend-row .lk {
+  color: var(--fg);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  font-weight: 500;
+}
+.legend-row .lv { color: var(--fg-dim); font-size: 12px; white-space: nowrap; font-weight: 500; }
+.legend-row .lv .num { font-family: var(--font-mono); }
+.legend-row .lv .pct { color: var(--muted); margin-left: 4px; font-size: 11px; font-weight: 400; font-family: var(--font-mono); }
+
+/* ── Metric chips (single row, 8 cols) ─────────────── */
+.chips {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+@media (max-width: 1100px) { .chips { grid-template-columns: repeat(4, 1fr); } }
+@media (max-width: 600px) { .chips { grid-template-columns: repeat(2, 1fr); } }
+.chip {
+  background: var(--panel);
+  padding: 12px 14px;
+  display: flex; flex-direction: column; gap: 4px;
+  min-width: 0;
+}
+.chip .cv { font-family: var(--font-mono); font-size: 15px; font-weight: 600; color: var(--fg); letter-spacing: -.01em; word-break: break-word; }
+.chip .ck { font-size: 11px; color: var(--muted); font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+
+/* ── Empty / error states ──────────────────────────── */
+.empty { color: var(--muted); font-size: 12.5px; padding: 24px 0; text-align: center; }
+.error { color: var(--danger); font-size: 12.5px; padding: 24px 0; text-align: center; }
+
+/* ── Tooltip ───────────────────────────────────────── */
+#tip {
+  position: fixed; z-index: 99; display: none; pointer-events: none;
+  background: var(--tip-bg); color: var(--tip-fg);
+  border-radius: 6px;
+  padding: 8px 12px; font-size: 12.5px; max-width: 340px; line-height: 1.45;
+  box-shadow: var(--shadow-strong);
+  font-family: var(--font-sans);
+}
+#tip .tt-date { color: rgba(255,255,255,.6); font-size: 11px; margin-bottom: 4px; font-family: var(--font-mono); }
+#tip .tt-row { display: flex; gap: 8px; align-items: center; }
+#tip .tt-row .sw { width: 8px; height: 8px; border-radius: 2px; }
+#tip .tt-row .lbl { color: rgba(255,255,255,.7); }
+#tip .tt-row .v { font-family: var(--font-mono); }
+
+footer {
+  max-width: 1180px; margin: 0 auto; padding: 16px 28px 40px;
+  color: var(--muted); font-size: 12px;
+  display: flex; gap: 14px; flex-wrap: wrap;
+}
+footer .sep { color: var(--border-strong); }

--- a/backend/internal/web/dashboard.html
+++ b/backend/internal/web/dashboard.html
@@ -4,150 +4,44 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>ManiaMapAnalyser — Usage Statistics</title>
-<style>
-  :root {
-    --bg: #0d1117;
-    --panel: #151b28;
-    --panel-2: #1b2334;
-    --border: #222c40;
-    --fg: #e6edf7;
-    --muted: #8b95ad;
-    --accent: #4bb3fd;
-    --accent-2: #8b5cf6;
-    --ok: #3ddc97;
-    --danger: #f87171;
-    --track: #232b3d;
-    --grid: #202941;
-    --radius: 12px;
-  }
-  * { box-sizing: border-box; }
-  html, body { margin: 0; padding: 0; }
-  body {
-    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "PingFang SC", "Microsoft YaHei", sans-serif;
-    background:
-      radial-gradient(1100px 500px at 85% -10%, rgba(139, 92, 246, .13), transparent 60%),
-      radial-gradient(900px 450px at -10% 0%, rgba(75, 179, 253, .11), transparent 55%),
-      var(--bg);
-    color: var(--fg);
-    min-height: 100vh;
-  }
-  header { max-width: 1180px; margin: 0 auto; padding: 26px 20px 4px; }
-  header .top { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
-  header h1 { font-size: 20px; margin: 0; letter-spacing: .01em; }
-  header h1 .dot { color: var(--accent); }
-  .sub { color: var(--muted); font-size: 12.5px; margin: 5px 0 0; }
-  .meta { color: var(--muted); font-size: 11.5px; margin-top: 6px; display: flex; gap: 14px; flex-wrap: wrap; align-items: center; }
-  .live { color: var(--ok); display: inline-flex; align-items: center; gap: 5px; }
-  .live::before { content: ""; width: 7px; height: 7px; border-radius: 50%; background: var(--ok); box-shadow: 0 0 8px var(--ok); }
-  .range { display: inline-flex; background: var(--panel); border: 1px solid var(--border); border-radius: 9px; overflow: hidden; }
-  .range button {
-    background: transparent; color: var(--muted); border: none; padding: 6px 14px;
-    font-size: 12px; cursor: pointer; transition: background .15s ease, color .15s ease;
-  }
-  .range button:hover { color: var(--fg); }
-  .range button.active { background: var(--accent); color: #081018; font-weight: 600; }
-  main { max-width: 1180px; margin: 0 auto; padding: 16px 20px 44px; }
-
-  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(126px, 1fr)); gap: 10px; margin-bottom: 14px; }
-  .card {
-    background: linear-gradient(160deg, var(--panel-2), var(--panel));
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 12px 13px 11px;
-    position: relative;
-    overflow: hidden;
-    transition: transform .15s ease, border-color .15s ease;
-  }
-  .card:hover { transform: translateY(-2px); border-color: var(--card-accent, var(--accent)); }
-  .card::before { content: ""; position: absolute; inset: 0 0 auto 0; height: 2.5px; background: var(--card-accent, var(--accent)); opacity: .85; }
-  .card .v { font-size: 23px; font-weight: 700; font-variant-numeric: tabular-nums; letter-spacing: -.01em; display: flex; align-items: baseline; gap: 7px; }
-  .card .k { font-size: 11.5px; color: var(--muted); margin-top: 5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .delta { font-size: 11px; font-weight: 600; font-variant-numeric: tabular-nums; }
-  .delta.up { color: var(--ok); }
-  .delta.down { color: var(--danger); }
-  .delta.flat { color: var(--muted); }
-
-  .grid2 { display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 12px; margin-bottom: 12px; }
-  .grid4 { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; margin-bottom: 12px; }
-  .panel {
-    background: var(--panel);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 14px 14px 12px;
-    display: flex;
-    flex-direction: column;
-  }
-  .panel h2 { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin: 0 0 10px; display: flex; justify-content: space-between; align-items: baseline; gap: 8px; }
-  .panel h2 small { text-transform: none; letter-spacing: 0; color: #64708c; font-weight: 400; font-size: 11px; }
-  .panel .body { flex: 1; min-height: 0; }
-
-  .bars { display: flex; flex-direction: column; gap: 6px; max-height: 236px; overflow-y: auto; padding-right: 2px; }
-  .bars::-webkit-scrollbar { width: 6px; }
-  .bars::-webkit-scrollbar-thumb { background: #2b3650; border-radius: 3px; }
-  .bar-row { display: flex; align-items: center; gap: 8px; font-size: 12.5px; }
-  .bar-label { flex: 0 1 auto; min-width: 0; max-width: 34%; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .bar-track { flex: 1; background: var(--track); border-radius: 5px; height: 13px; overflow: hidden; }
-  .bar-fill { height: 100%; border-radius: 5px; background: linear-gradient(90deg, var(--accent), var(--accent-2)); min-width: 2px; transition: filter .15s ease; transform-origin: left; animation: growX .5s cubic-bezier(.22,.61,.36,1) both; }
-  .bar-row:hover .bar-fill { filter: brightness(1.25); }
-  @keyframes growX { from { transform: scaleX(0); } to { transform: scaleX(1); } }
-  .bar-count { flex: 0 0 70px; text-align: right; color: var(--muted); font-variant-numeric: tabular-nums; font-size: 11.5px; white-space: nowrap; }
-
-  .more-btn {
-    align-self: flex-start; margin-top: 4px;
-    background: var(--panel-2); color: var(--accent);
-    border: 1px solid var(--border); border-radius: 7px;
-    padding: 4px 10px; font-size: 11.5px; cursor: pointer;
-  }
-  .more-btn:hover { border-color: var(--accent); }
-
-  .chart-wrap { overflow-x: auto; }
-  .chart-wrap svg { display: block; }
-  svg text { fill: var(--muted); font-size: 9.5px; font-variant-numeric: tabular-nums; }
-  svg .grow { transform-box: fill-box; transform-origin: bottom; animation: growY .45s cubic-bezier(.22,.61,.36,1) both; }
-  @keyframes growY { from { transform: scaleY(0); } to { transform: scaleY(1); } }
-  svg .draw { stroke-dasharray: 2000; stroke-dashoffset: 2000; animation: draw 1.1s ease forwards; }
-  @keyframes draw { to { stroke-dashoffset: 0; } }
-  svg .dotp { transition: r .1s ease; }
-  svg .dotp:hover { r: 4; }
-
-  .donut-wrap { display: flex; align-items: center; gap: 14px; flex-wrap: wrap; }
-  .legend { display: flex; flex-direction: column; gap: 5px; font-size: 12px; flex: 1; min-width: 108px; }
-  .legend-row { display: flex; align-items: center; gap: 7px; }
-  .legend-row .sw { width: 9px; height: 9px; border-radius: 3px; flex: none; }
-  .legend-row .lk { flex: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  .legend-row .lv { color: var(--muted); font-variant-numeric: tabular-nums; font-size: 11.5px; white-space: nowrap; }
-
-  .chips { display: flex; gap: 8px; flex-wrap: wrap; }
-  .chip { flex: 1; min-width: 100px; background: var(--panel-2); border: 1px solid var(--border); border-radius: 10px; padding: 10px 12px; }
-  .chip .cv { font-size: 16px; font-weight: 700; font-variant-numeric: tabular-nums; }
-  .chip .ck { font-size: 10.5px; color: var(--muted); margin-top: 3px; }
-
-  .empty { color: var(--muted); font-size: 12.5px; padding: 8px 0; }
-  .error { color: var(--danger); font-size: 12.5px; padding: 8px 0; }
-  #tip {
-    position: fixed; z-index: 99; display: none; pointer-events: none;
-    background: #10162a; border: 1px solid var(--border); border-radius: 8px;
-    padding: 6px 10px; font-size: 12px; max-width: 340px; line-height: 1.45;
-    box-shadow: 0 6px 20px rgba(0,0,0,.45);
-  }
-  footer { max-width: 1180px; margin: 0 auto; padding: 0 20px 34px; color: #5f6b88; font-size: 11.5px; }
-</style>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/dashboard.css">
 </head>
 <body>
 <header>
   <div class="top">
     <div>
-      <h1>ManiaMapAnalyser <span class="dot">·</span> Usage Statistics</h1>
-      <p class="sub">Anonymous aggregate statistics — no usernames, no beatmap identity, no IP addresses.</p>
+      <h1>ManiaMapAnalyser <span class="dim">· Usage Statistics</span></h1>
+      <p class="sub">Anonymous aggregate statistics from the osu!mania overlay plugin. No usernames, no beatmap identity, no IP.</p>
     </div>
-    <div class="range" id="range" role="group" aria-label="Time range">
-      <button data-days="7">7d</button>
-      <button data-days="30" class="active">30d</button>
-      <button data-days="90">90d</button>
-      <button data-days="0">All</button>
+    <div class="controls">
+      <div class="range" id="range" role="group" aria-label="Time range">
+        <button data-days="7">7d</button>
+        <button data-days="30" class="active">30d</button>
+        <button data-days="90">90d</button>
+        <button data-days="0">All</button>
+      </div>
+      <button class="theme-btn" id="themeBtn" type="button" aria-label="Toggle theme">
+        <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="12" cy="12" r="4"></circle>
+          <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
+        </svg>
+        <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+        </svg>
+      </button>
     </div>
   </div>
-  <p class="meta"><span class="live">live</span><span id="updated">loading…</span></p>
+  <p class="meta">
+    <span class="live">live</span>
+    <span id="updated">loading…</span>
+    <span class="sep">·</span>
+    <span>server <strong id="serverVer">–</strong></span>
+    <span class="sep">·</span>
+    <span>auto-refresh 60s</span>
+  </p>
 </header>
 <main>
   <section id="overview" class="cards"></section>
@@ -158,14 +52,14 @@
       <div class="body chart-wrap"><div id="onlineByHour"></div></div>
     </section>
     <section class="panel">
-      <h2>Active per day</h2>
+      <h2>Active per day <small>active · new</small></h2>
       <div class="body chart-wrap"><div id="trend"></div></div>
     </section>
   </div>
 
   <div class="grid2">
     <section class="panel">
-      <h2>Star rating <small>0.5-star bins</small></h2>
+      <h2>Star rating <small>0.5★ bins</small></h2>
       <div class="body chart-wrap"><div id="starHistogram"></div></div>
     </section>
     <section class="panel">
@@ -174,370 +68,44 @@
     </section>
   </div>
 
-  <div class="grid2">
-    <section class="panel"><h2>Key count</h2><div class="body" id="keycounts"></div></section>
-    <section class="panel">
-      <h2>Numeric difficulty <small>0.5 bins · .0 = mid</small></h2>
-      <div class="body chart-wrap"><div id="numericHistogram"></div></div>
-    </section>
-  </div>
+  <section class="panel full">
+    <h2>Key count</h2>
+    <div class="body"><div id="keycounts" class="bars-split"></div></div>
+  </section>
 
-  <div class="grid4">
-    <section class="panel"><h2>Beatmap type <small>HB/RC/LN/Mix/SV</small></h2><div class="body" id="modes"></div></section>
+  <section class="panel full">
+    <h2>Numeric difficulty <small>0.25 bins · .0 = mid</small></h2>
+    <div class="body chart-wrap numeric-chart"><div id="numericHistogram"></div></div>
+  </section>
+
+  <div class="grid3">
+    <section class="panel"><h2>Beatmap type <small>HB / RC / LN / Mix / SV</small></h2><div class="body" id="modes"></div></section>
     <section class="panel"><h2>Mods <small>NM = no mod</small></h2><div class="body" id="mods"></div></section>
     <section class="panel"><h2>Version</h2><div class="body" id="versions"></div></section>
   </div>
 
   <div class="grid2">
-    <section class="panel"><h2>Selected algorithm</h2><div class="body" id="algorithms"></div></section>
-    <section class="panel"><h2>Actual algorithm</h2><div class="body" id="actualAlgorithms"></div></section>
+    <section class="panel">
+      <h2>Selected algorithm <small>user choice</small></h2>
+      <div class="body" id="algorithms"></div>
+    </section>
+    <section class="panel">
+      <h2>Called algorithm <small>each analyze · once</small></h2>
+      <div class="body" id="actualAlgorithms"></div>
+    </section>
   </div>
 
-  <section class="panel" style="margin-bottom:12px">
-    <h2>Analysis metrics</h2>
+  <section class="panel" style="margin-bottom:14px">
+    <h2>Analysis metrics <small id="windowLabel">30d</small></h2>
     <div class="body"><div id="metrics" class="chips"></div></div>
   </section>
 </main>
 <div id="tip"></div>
-<footer>Aggregate statistics · refreshed every 60 s · server <span id="serverVer">–</span> · vanilla JS + SVG, no trackers.</footer>
-
-<script>
-"use strict";
-
-// XSS policy: every client-controlled string is written via textContent only.
-const PALETTE = ["#4bb3fd", "#8b5cf6", "#3ddc97", "#fbbf24", "#f87171", "#f472b6", "#2dd4bf", "#60a5fa", "#c084fc", "#94a3b8"];
-let currentDays = 30;
-
-const tip = document.getElementById("tip");
-function bindTip(node, text) {
-  node.addEventListener("mouseenter", () => { tip.textContent = String(text); tip.style.display = "block"; });
-  node.addEventListener("mousemove", (e) => { tip.style.left = (e.clientX + 14) + "px"; tip.style.top = (e.clientY + 14) + "px"; });
-  node.addEventListener("mouseleave", () => { tip.style.display = "none"; });
-}
-
-function el(tag, cls, text) {
-  const e = document.createElement(tag);
-  if (cls) e.className = cls;
-  if (text != null) e.textContent = String(text);
-  return e;
-}
-function svgEl(tag, attrs) {
-  const e = document.createElementNS("http://www.w3.org/2000/svg", tag);
-  for (const k in attrs) e.setAttribute(k, String(attrs[k]));
-  return e;
-}
-function emptyBox(host, msg) {
-  host.textContent = "";
-  host.appendChild(el("div", "empty", msg || "No data yet"));
-}
-function fmtCompact(n) {
-  n = Number(n) || 0;
-  if (n >= 1e6) return (n / 1e6).toFixed(1).replace(/\.0$/, "") + "M";
-  if (n >= 1e4) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
-  return String(n);
-}
-function deltaSpan(delta) {
-  const s = el("span", "delta");
-  if (delta == null || !isFinite(delta)) { s.className = "delta flat"; s.textContent = "—"; return s; }
-  if (delta > 0) { s.className = "delta up"; s.textContent = "▲ " + fmtCompact(delta); }
-  else if (delta < 0) { s.className = "delta down"; s.textContent = "▼ " + fmtCompact(-delta); }
-  else { s.className = "delta flat"; s.textContent = "–"; }
-  bindTip(s, String(delta));
-  return s;
-}
-function card(k, v, opts) {
-  const d = el("div", "card");
-  d.style.setProperty("--card-accent", (opts && opts.accent) || "#4bb3fd");
-  const vWrap = el("div", "v");
-  const vs = el("span", "", fmtCompact(v));
-  bindTip(vs, String(v));
-  vWrap.appendChild(vs);
-  if (opts && opts.delta != null) vWrap.appendChild(deltaSpan(opts.delta));
-  d.appendChild(vWrap);
-  d.appendChild(el("div", "k", k));
-  return d;
-}
-
-function renderCards(s) {
-  const trend = s.activeTrend || [];
-  const t = trend[trend.length - 1], y = trend[trend.length - 2];
-  const todayDelta = (t && y) ? t.active - y.active : null;
-  const sum = (arr) => arr.reduce((a, b) => a + b, 0);
-  const last7 = trend.slice(-7), prev7 = trend.slice(-14, -7);
-  const weekDelta = (last7.length && prev7.length) ? sum(last7.map((d) => d.active)) - sum(prev7.map((d) => d.active)) : null;
-
-  const ov = document.getElementById("overview");
-  ov.textContent = "";
-  ov.appendChild(card("Total installs", s.totalInstalls, { accent: "#4bb3fd" }));
-  ov.appendChild(card("Online now", s.onlineNow, { accent: "#3ddc97" }));
-  ov.appendChild(card("Active today", s.todayActive, { accent: "#fbbf24", delta: todayDelta }));
-  ov.appendChild(card("Active 7d", s.weekActive, { accent: "#8b5cf6", delta: weekDelta }));
-  ov.appendChild(card("Active " + (currentDays || 90) + "d", s.monthActive, { accent: "#f472b6" }));
-  ov.appendChild(card("New today", s.newToday, { accent: "#2dd4bf" }));
-  ov.appendChild(card("New 7d", s.newWeek, { accent: "#60a5fa" }));
-  ov.appendChild(card("Total events", s.totalEvents, { accent: "#c084fc" }));
-}
-
-function renderHBar(id, items, cap) {
-  const c = document.getElementById(id);
-  c.textContent = "";
-  if (!items.length) { emptyBox(c); return; }
-  const limit = (cap && items.length > cap) ? cap : items.length;
-  let max = 1;
-  for (const it of items) if (it.count > max) max = it.count;
-  for (let i = 0; i < limit; i++) {
-    const it = items[i];
-    const row = el("div", "bar-row");
-    const label = el("span", "bar-label", it.key);
-    const track = el("div", "bar-track");
-    const fill = el("div", "bar-fill");
-    fill.style.width = Math.round((it.count / max) * 100) + "%";
-    fill.style.animationDelay = (i * 30) + "ms";
-    bindTip(row, it.key + " — " + it.count + " (" + Math.round((it.count / max) * 100) + "%)");
-    track.appendChild(fill);
-    row.appendChild(label);
-    row.appendChild(track);
-    const cnt = el("span", "bar-count", fmtCompact(it.count) + " · " + Math.round((it.count / max) * 100) + "%");
-    bindTip(cnt, String(it.count) + " · " + Math.round((it.count / max) * 100) + "%");
-    row.appendChild(cnt);
-    c.appendChild(row);
-  }
-  if (items.length > limit) {
-    const btn = el("button", "more-btn", "Show all " + items.length);
-    btn.addEventListener("click", () => renderHBar(id, items, 0));
-    c.appendChild(btn);
-  }
-}
-
-// Vertical bar chart with Y axis and X labels. items: [{label, count, tip}]
-function renderVChart(id, items, xEvery) {
-  const c = document.getElementById(id);
-  c.textContent = "";
-  if (!items.length) { emptyBox(c); return; }
-  const W = 560, H = 170, ML = 40, MB = 20, PAD = 6;
-  const max = Math.max.apply(null, items.map((i) => i.count).concat([1]));
-  const plotW = W - ML - PAD;
-  const plotH = H - MB - PAD;
-  const bw = plotW / items.length;
-  const step = xEvery || Math.max(1, Math.ceil(items.length / 12));
-
-  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
-  const lg = svgEl("linearGradient", { id: "barGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
-  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#4bb3fd" }));
-  lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#8b5cf6" }));
-  svg.appendChild(lg);
-
-  [0, 1 / 3, 2 / 3, 1].forEach((f) => {
-    const gy = (PAD + (1 - f) * plotH).toFixed(1);
-    svg.appendChild(svgEl("line", { x1: ML, y1: gy, x2: W - PAD, y2: gy, stroke: "#202941", "stroke-width": 1 }));
-    const tx = svgEl("text", { x: ML - 6, y: (parseFloat(gy) + 3).toFixed(1), "text-anchor": "end" });
-    tx.textContent = fmtCompact(Math.round(max * f));
-    bindTip(tx, String(Math.round(max * f)));
-    svg.appendChild(tx);
-  });
-
-  items.forEach((it, i) => {
-    const h = Math.max(1, (it.count / max) * plotH);
-    const x = ML + i * bw + bw * 0.18;
-    const w = bw * 0.64;
-    const rect = svgEl("rect", {
-      x: x.toFixed(1), y: (H - MB - h).toFixed(1),
-      width: w.toFixed(1), height: h.toFixed(1), rx: 2,
-      fill: "url(#barGrad)", class: "grow",
-    });
-    rect.style.animationDelay = (i * 18) + "ms";
-    bindTip(rect, it.tip || (it.label + " — " + it.count));
-    svg.appendChild(rect);
-    if (i % step === 0 || i === items.length - 1) {
-      const tx = svgEl("text", { x: (x + w / 2).toFixed(1), y: H - 6, "text-anchor": "middle" });
-      tx.textContent = it.label;
-      svg.appendChild(tx);
-    }
-  });
-  c.appendChild(svg);
-}
-
-function renderHourBars(id, counts) {
-  const items = (counts || []).map((v, i) => ({
-    label: String(i).padStart(2, "0"),
-    count: v || 0,
-    tip: String(i).padStart(2, "0") + ":00 UTC — " + (v || 0) + " installs",
-  }));
-  renderVChart(id, items, 3);
-}
-
-function renderValueBars(id, buckets) {
-  const items = (buckets || []).map((b) => ({
-    label: b.key,
-    count: b.count,
-    tip: b.key + " → " + b.count,
-  }));
-  renderVChart(id, items, 0);
-}
-
-function renderTrend(id, trend) {
-  const c = document.getElementById(id);
-  c.textContent = "";
-  if (!trend || !trend.length) { emptyBox(c); return; }
-  const W = 560, H = 170, ML = 40, MB = 20, PAD = 6;
-  const max = Math.max.apply(null, trend.map((d) => Math.max(d.active, d.new)).concat([1]));
-  const n = trend.length;
-  const x = (i) => ML + (i * (W - ML - PAD)) / Math.max(n - 1, 1);
-  const y = (v) => PAD + (1 - v / max) * (H - MB - PAD);
-
-  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
-  const lg = svgEl("linearGradient", { id: "areaGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
-  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#4bb3fd", "stop-opacity": "0.3" }));
-  lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#4bb3fd", "stop-opacity": "0" }));
-  svg.appendChild(lg);
-
-  [0, 1 / 3, 2 / 3, 1].forEach((f) => {
-    const gy = (PAD + (1 - f) * (H - MB - PAD)).toFixed(1);
-    svg.appendChild(svgEl("line", { x1: ML, y1: gy, x2: W - PAD, y2: gy, stroke: "#202941", "stroke-width": 1 }));
-    const tx = svgEl("text", { x: ML - 6, y: (parseFloat(gy) + 3).toFixed(1), "text-anchor": "end" });
-    tx.textContent = fmtCompact(Math.round(max * f));
-    bindTip(tx, String(Math.round(max * f)));
-    svg.appendChild(tx);
-  });
-
-  const actPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.active).toFixed(1)).join(" ");
-  const newPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.new).toFixed(1)).join(" ");
-  const area = "M" + x(0).toFixed(1) + "," + y(trend[0].active).toFixed(1) + " L" + actPts.replace(/ /g, " L") +
-    " L" + x(n - 1).toFixed(1) + "," + (H - MB).toFixed(1) + " L" + x(0).toFixed(1) + "," + (H - MB).toFixed(1) + " Z";
-  svg.appendChild(svgEl("path", { d: area, fill: "url(#areaGrad)" }));
-  svg.appendChild(svgEl("polyline", { points: actPts, fill: "none", stroke: "#4bb3fd", "stroke-width": 2, "stroke-linejoin": "round", class: "draw" }));
-  svg.appendChild(svgEl("polyline", { points: newPts, fill: "none", stroke: "#3ddc97", "stroke-width": 1.3, "stroke-linejoin": "round", "stroke-dasharray": "3 3", class: "draw" }));
-  trend.forEach((d, i) => {
-    const dot = svgEl("circle", { cx: x(i).toFixed(1), cy: y(d.active).toFixed(1), r: 2.2, fill: "#4bb3fd", class: "dotp" });
-    bindTip(dot, d.date + " · active " + d.active + " · new " + d.new);
-    svg.appendChild(dot);
-  });
-  const step = Math.max(1, Math.ceil(n / 6));
-  for (let i = 0; i < n; i += step) {
-    const tx = svgEl("text", { x: x(i).toFixed(1), y: H - 6, "text-anchor": "middle" });
-    tx.textContent = trend[i].date ? trend[i].date.slice(5) : "";
-    svg.appendChild(tx);
-  }
-  c.appendChild(svg);
-}
-
-function renderDonut(id, items, maxSlices) {
-  const c = document.getElementById(id);
-  c.textContent = "";
-  if (!items.length) { emptyBox(c); return; }
-  const MAX = maxSlices || 6;
-  let slices = items;
-  if (items.length > MAX) {
-    const top = items.slice(0, MAX - 1);
-    const other = items.slice(MAX - 1).reduce((s, it) => s + it.count, 0);
-    slices = top.concat([{ key: "Other", count: other }]);
-  }
-  const total = slices.reduce((s, it) => s + it.count, 0) || 1;
-  const svg = svgEl("svg", { viewBox: "0 0 42 42", width: "104", height: "104", "aria-hidden": "true" });
-  let angle = 0;
-  slices.forEach((it, i) => {
-    const frac = it.count / total;
-    const circle = svgEl("circle", {
-      cx: 21, cy: 21, r: 15.915, fill: "none", "stroke-width": 4.6,
-      stroke: PALETTE[i % PALETTE.length],
-      "stroke-dasharray": (frac * 100).toFixed(2) + " " + (100 - frac * 100).toFixed(2),
-      "stroke-dashoffset": (-angle * 100).toFixed(2),
-    });
-    bindTip(circle, it.key + " — " + it.count + " (" + Math.round((it.count / total) * 100) + "%)");
-    svg.appendChild(circle);
-    angle += frac;
-  });
-  const center = svgEl("text", { x: 21, y: 23, "text-anchor": "middle", "font-size": "5.8", fill: "#e6edf7", "font-weight": "700" });
-  center.textContent = fmtCompact(total);
-  bindTip(center, String(total));
-  svg.appendChild(center);
-
-  const legend = el("div", "legend");
-  slices.forEach((it, i) => {
-    const row = el("div", "legend-row");
-    const sw = el("span", "sw");
-    sw.style.background = PALETTE[i % PALETTE.length];
-    row.appendChild(sw);
-    row.appendChild(el("span", "lk", it.key));
-    const lv = el("span", "lv", fmtCompact(it.count) + " · " + Math.round((it.count / total) * 100) + "%");
-    bindTip(lv, String(it.count) + " · " + Math.round((it.count / total) * 100) + "%");
-    row.appendChild(lv);
-    legend.appendChild(row);
-  });
-  const wrap = el("div", "donut-wrap");
-  wrap.appendChild(svg);
-  wrap.appendChild(legend);
-  c.appendChild(wrap);
-}
-
-function renderMetrics(s) {
-  const c = document.getElementById("metrics");
-  c.textContent = "";
-  const windowLabel = currentDays ? currentDays + "d" : "all";
-  const hour = s.peakOnlineHour != null ? "@" + String(s.peakOnlineHour).padStart(2, "0") + ":00 UTC" : "";
-  const items = [
-    ["Avg star", s.avgStar ? s.avgStar.toFixed(2) : "—", s.avgStar ? s.avgStar.toFixed(2) : "—"],
-    ["Avg LN ratio", s.avgLnRatio ? (s.avgLnRatio * 100).toFixed(1) + "%" : "—", s.avgLnRatio ? (s.avgLnRatio * 100).toFixed(1) + "%" : "—"],
-    ["Analyzes · " + windowLabel, fmtCompact(s.analyzeCount), String(s.analyzeCount)],
-    ["Peak online", s.peakOnline ? fmtCompact(s.peakOnline) + " " + hour : "—", s.peakOnline ? String(s.peakOnline) + " " + hour : "—"],
-    ["Avg daily active", fmtCompact(s.avgDailyActive), String(s.avgDailyActive)],
-    ["Duration avg", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms"],
-    ["Duration p50", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms"],
-    ["Duration p90", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms"],
-  ];
-  for (const [k, v, raw] of items) {
-    const chip = el("div", "chip");
-    const cv = el("div", "cv", v);
-    if (raw !== v) bindTip(cv, raw);
-    chip.appendChild(cv);
-    chip.appendChild(el("div", "ck", k));
-    c.appendChild(chip);
-  }
-}
-
-function load() {
-  document.getElementById("updated").textContent = "loading…";
-  fetch("/api/v1/stats?days=" + currentDays)
-    .then((r) => {
-      if (!r.ok) throw new Error("HTTP " + r.status);
-      return r.json();
-    })
-    .then((s) => {
-      document.getElementById("updated").textContent = "updated " + new Date().toLocaleString();
-      document.getElementById("serverVer").textContent = "v" + (s.serverVersion || "?");
-      document.getElementById("hourRange").textContent = "UTC · " + (currentDays ? currentDays + "d" : "all");
-      renderCards(s);
-      renderHourBars("onlineByHour", s.onlineByHour || []);
-      renderTrend("trend", s.activeTrend || []);
-      renderValueBars("starHistogram", s.starHistogram || []);
-      renderValueBars("lnRatioHistogram", s.lnRatioHistogram || []);
-      renderValueBars("numericHistogram", s.numericHistogram || []);
-      renderHBar("keycounts", s.keycounts || []);
-      renderDonut("modes", s.modes || []);
-      renderDonut("mods", s.mods || []);
-      renderDonut("versions", s.versions || []);
-      renderHBar("algorithms", s.algorithms || [], 8);
-      renderHBar("actualAlgorithms", s.actualAlgorithms || [], 8);
-      renderMetrics(s);
-    })
-    .catch((err) => {
-      const ov = document.getElementById("overview");
-      ov.textContent = "";
-      ov.appendChild(el("div", "error", "Failed to load statistics: " + err.message));
-    });
-}
-
-document.getElementById("range").addEventListener("click", (e) => {
-  const btn = e.target.closest("button[data-days]");
-  if (!btn) return;
-  currentDays = parseInt(btn.dataset.days, 10);
-  document.querySelectorAll("#range button").forEach((b) => b.classList.toggle("active", b === btn));
-  load();
-});
-
-load();
-// Auto-refresh every 60 s (matches the server-side stats cache TTL).
-setInterval(load, 60000);
-</script>
+<footer>
+  <span>aggregate statistics only</span>
+  <span class="sep">·</span>
+  <span>vanilla JS + SVG, no trackers</span>
+</footer>
+<script src="/dashboard.js" defer></script>
 </body>
 </html>

--- a/backend/internal/web/dashboard.js
+++ b/backend/internal/web/dashboard.js
@@ -1,0 +1,520 @@
+// ManiaMapAnalyser — Usage Statistics dashboard logic.
+// Loaded as a separate asset (go:embed).
+
+"use strict";
+
+// XSS policy: every client-controlled string is written via textContent only.
+const PALETTE = ["#635bff", "#0d9c5f", "#f5a623", "#cf1e3b", "#06b6d4", "#a855f7", "#ec4899", "#0ea5e9"];
+let currentDays = 30;
+
+// ── Theme: default to system preference, persist choice. ──
+(function initTheme() {
+  let saved = null;
+  try { saved = localStorage.getItem("mma-theme"); } catch {}
+  const sysDark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+  const theme = saved || (sysDark ? "dark" : "light");
+  document.documentElement.setAttribute("data-theme", theme);
+})();
+document.getElementById("themeBtn").addEventListener("click", () => {
+  const cur = document.documentElement.getAttribute("data-theme") || "light";
+  const next = cur === "dark" ? "light" : "dark";
+  document.documentElement.setAttribute("data-theme", next);
+  try { localStorage.setItem("mma-theme", next); } catch {}
+});
+
+// ── Tooltip ─────────────────────────────────────────
+const tip = document.getElementById("tip");
+function bindTip(node, text) {
+  node.addEventListener("mouseenter", () => { tip.textContent = String(text); tip.style.display = "block"; });
+  node.addEventListener("mousemove", (e) => { tip.style.left = (e.clientX + 14) + "px"; tip.style.top = (e.clientY + 14) + "px"; });
+  node.addEventListener("mouseleave", () => { tip.style.display = "none"; });
+}
+
+// ── DOM helpers ─────────────────────────────────────
+function el(tag, cls, text) {
+  const e = document.createElement(tag);
+  if (cls) e.className = cls;
+  if (text != null) e.textContent = String(text);
+  return e;
+}
+function svgEl(tag, attrs) {
+  const e = document.createElementNS("http://www.w3.org/2000/svg", tag);
+  for (const k in attrs) e.setAttribute(k, String(attrs[k]));
+  return e;
+}
+function emptyBox(host, msg) {
+  host.textContent = "";
+  host.appendChild(el("div", "empty", msg || "No data yet"));
+}
+
+// ── Compact number formatter ────────────────────────
+function fmtCompact(n) {
+  n = Number(n) || 0;
+  if (n >= 1e9) return (n / 1e9).toFixed(1).replace(/\.0$/, "") + "B";
+  if (n >= 1e6) return Math.round(n / 1e5) / 10 + "M";
+  if (n >= 1e4) return Math.round(n / 1e3) + "k";
+  return String(n);
+}
+
+// ── Delta arrow ─────────────────────────────────────
+function deltaSpan(delta) {
+  const s = el("span", "delta");
+  if (delta == null || !isFinite(delta)) { s.className = "delta flat"; s.textContent = "—"; return s; }
+  if (delta > 0) { s.className = "delta up"; s.textContent = "▲" + fmtCompact(delta); }
+  else if (delta < 0) { s.className = "delta down"; s.textContent = "▼" + fmtCompact(-delta); }
+  else { s.className = "delta flat"; s.textContent = "–"; }
+  bindTip(s, String(delta));
+  return s;
+}
+
+// ── Stat card ────────────────────────────────────────
+function card(k, v, opts) {
+  const d = el("div", "card");
+  const vWrap = el("div", "v");
+  const vs = el("span", "", fmtCompact(v));
+  bindTip(vs, String(v));
+  vWrap.appendChild(vs);
+  if (opts && opts.delta != null) vWrap.appendChild(deltaSpan(opts.delta));
+  d.appendChild(vWrap);
+  d.appendChild(el("div", "k", k));
+  return d;
+}
+
+function renderCards(s) {
+  const trend = s.activeTrend || [];
+  const t = trend[trend.length - 1], y = trend[trend.length - 2];
+  const todayDelta = (t && y) ? t.active - y.active : null;
+  const sum = (arr) => arr.reduce((a, b) => a + b, 0);
+  const last7 = trend.slice(-7), prev7 = trend.slice(-14, -7);
+  const weekDelta = (last7.length && prev7.length) ? sum(last7.map((d) => d.active)) - sum(prev7.map((d) => d.active)) : null;
+
+  const ov = document.getElementById("overview");
+  ov.textContent = "";
+  ov.appendChild(card("Installs", s.totalInstalls));
+  ov.appendChild(card("Online now", s.onlineNow));
+  ov.appendChild(card("Active today", s.todayActive, { delta: todayDelta }));
+  ov.appendChild(card("Active 7d", s.weekActive, { delta: weekDelta }));
+  ov.appendChild(card("New today", s.newToday));
+  ov.appendChild(card("New 7d", s.newWeek));
+  ov.appendChild(card("Active 30d", s.monthActive));
+  ov.appendChild(card("Events", s.totalEvents));
+}
+
+// ── Horizontal bar list ──────────────────────────────
+function renderHBar(id, items, cap) {
+  const c = document.getElementById(id);
+  c.textContent = "";
+  if (!items.length) { emptyBox(c); return; }
+  const limit = (cap && items.length > cap) ? cap : items.length;
+  let max = 1;
+  for (const it of items) if (it.count > max) max = it.count;
+  const bars = el("div", "bars");
+  for (let i = 0; i < limit; i++) {
+    const it = items[i];
+    const row = el("div", "bar-row");
+    const label = el("span", "bar-label", it.key);
+    const track = el("div", "bar-track");
+    const fill = el("div", "bar-fill");
+    fill.style.width = Math.round((it.count / max) * 100) + "%";
+    fill.style.animationDelay = (i * 30) + "ms";
+    bindTip(row, it.key + " — " + it.count + " (" + Math.round((it.count / max) * 100) + "%)");
+    track.appendChild(fill);
+    row.appendChild(label);
+    row.appendChild(track);
+    const cnt = el("span", "bar-count");
+    const cntNum = el("span", "num", fmtCompact(it.count));
+    bindTip(cntNum, String(it.count));
+    cnt.appendChild(cntNum);
+    cnt.appendChild(el("span", "pct", Math.round((it.count / max) * 100) + "%"));
+    row.appendChild(cnt);
+    bars.appendChild(row);
+  }
+  c.appendChild(bars);
+  if (items.length > limit) {
+    const btn = el("button", "more-btn", "Show all " + items.length);
+    btn.addEventListener("click", () => {
+      bars.textContent = "";
+      for (let i = 0; i < items.length; i++) {
+        const it = items[i];
+        const row = el("div", "bar-row");
+        const label = el("span", "bar-label", it.key);
+        const track = el("div", "bar-track");
+        const fill = el("div", "bar-fill");
+        fill.style.width = Math.round((it.count / max) * 100) + "%";
+        bindTip(row, it.key + " — " + it.count);
+        track.appendChild(fill);
+        row.appendChild(label);
+        row.appendChild(track);
+        const cnt = el("span", "bar-count");
+        cnt.appendChild(el("span", "num", fmtCompact(it.count)));
+        row.appendChild(cnt);
+        bars.appendChild(row);
+      }
+      btn.remove();
+    });
+    c.appendChild(btn);
+  }
+}
+
+// ── Vertical bar chart with Y-axis ticks ─────────────
+function renderVChart(id, items, xEvery) {
+  const c = document.getElementById(id);
+  c.textContent = "";
+  if (!items.length) { emptyBox(c); return; }
+  const W = 560, H = 170, ML = 40, MB = 22, PAD = 6;
+  const max = Math.max.apply(null, items.map((i) => i.count).concat([1]));
+  const plotW = W - ML - PAD;
+  const plotH = H - MB - PAD;
+  const bw = plotW / items.length;
+  const step = xEvery || Math.max(1, Math.ceil(items.length / 12));
+
+  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
+
+  [0, 1 / 3, 2 / 3, 1].forEach((f) => {
+    const gy = (PAD + (1 - f) * plotH).toFixed(1);
+    svg.appendChild(svgEl("line", { x1: ML, y1: gy, x2: W - PAD, y2: gy, class: "grid" }));
+    const tx = svgEl("text", { x: ML - 6, y: (parseFloat(gy) + 3).toFixed(1), "text-anchor": "end" });
+    tx.textContent = fmtCompact(Math.round(max * f));
+    bindTip(tx, String(Math.round(max * f)));
+    svg.appendChild(tx);
+  });
+
+  items.forEach((it, i) => {
+    const h = Math.max(1, (it.count / max) * plotH);
+    const x = ML + i * bw + bw * 0.2;
+    const w = bw * 0.6;
+    const rect = svgEl("rect", {
+      x: x.toFixed(1), y: (H - MB - h).toFixed(1),
+      width: w.toFixed(1), height: h.toFixed(1), rx: 1.5,
+      fill: "#635bff", class: "grow",
+    });
+    rect.style.animationDelay = (i * 18) + "ms";
+    bindTip(rect, it.tip || (it.label + " — " + it.count));
+    svg.appendChild(rect);
+    if (i % step === 0 || i === items.length - 1) {
+      const tx = svgEl("text", { x: (x + w / 2).toFixed(1), y: H - 6, "text-anchor": "middle" });
+      tx.textContent = it.label;
+      svg.appendChild(tx);
+    }
+  });
+  c.appendChild(svg);
+}
+
+// ── Single-series line chart with crosshair snap-hover ─────────────
+// items: [{label, count}] — same as renderVChart input format.
+function renderLine(id, items) {
+  const c = document.getElementById(id);
+  c.textContent = "";
+  if (!items.length) { emptyBox(c); return; }
+  const W = 560, H = 170, ML = 40, MB = 22, PAD = 6;
+  const max = Math.max.apply(null, items.map((i) => i.count).concat([1]));
+  const n = items.length;
+  const x = (i) => ML + (i * (W - ML - PAD)) / Math.max(n - 1, 1);
+  const y = (v) => PAD + (1 - v / max) * (H - MB - PAD);
+
+  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
+  const lg = svgEl("linearGradient", { id: "lineAreaGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
+  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#635bff", "stop-opacity": "0.18" }));
+  lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#635bff", "stop-opacity": "0" }));
+  svg.appendChild(lg);
+
+  // Y-axis gridlines
+  [0, 1 / 3, 2 / 3, 1].forEach((f) => {
+    const gy = (PAD + (1 - f) * (H - MB - PAD)).toFixed(1);
+    svg.appendChild(svgEl("line", { x1: ML, y1: gy, x2: W - PAD, y2: gy, class: "grid" }));
+    const tx = svgEl("text", { x: ML - 6, y: (parseFloat(gy) + 3).toFixed(1), "text-anchor": "end" });
+    tx.textContent = fmtCompact(Math.round(max * f));
+    bindTip(tx, String(Math.round(max * f)));
+    svg.appendChild(tx);
+  });
+
+  // Area fill + line
+  const pts = items.map((it, i) => x(i).toFixed(1) + "," + y(it.count).toFixed(1)).join(" ");
+  const area = "M" + x(0).toFixed(1) + "," + y(items[0].count).toFixed(1) + " L" + pts.replace(/ /g, " L") +
+    " L" + x(n - 1).toFixed(1) + "," + (H - MB).toFixed(1) + " L" + x(0).toFixed(1) + "," + (H - MB).toFixed(1) + " Z";
+  svg.appendChild(svgEl("path", { d: area, fill: "url(#lineAreaGrad)" }));
+  svg.appendChild(svgEl("polyline", { points: pts, fill: "none", stroke: "#635bff", "stroke-width": 1.8, "stroke-linejoin": "round", class: "draw" }));
+
+  // Crosshair hover overlay
+  const hover = svgEl("g", { display: "none" });
+  const guide = svgEl("line", { class: "hover-guide" });
+  guide.setAttribute("y1", PAD); guide.setAttribute("y2", H - MB);
+  const halo = svgEl("circle", { class: "hover-halo", r: 10 });
+  const dot = svgEl("circle", { class: "hover-dot", r: 4 });
+  hover.appendChild(guide); hover.appendChild(halo); hover.appendChild(dot);
+  svg.appendChild(hover);
+
+  function snap(clientX) {
+    const rect = svg.getBoundingClientRect();
+    const sx = (clientX - rect.left) / rect.width * W;
+    let best = 0, bestD = Infinity;
+    for (let i = 0; i < n; i++) {
+      const d = Math.abs(x(i) - sx);
+      if (d < bestD) { bestD = d; best = i; }
+    }
+    return best;
+  }
+  function showHover(idx, clientX, clientY) {
+    const it = items[idx];
+    const xi = x(idx), yi = y(it.count);
+    guide.setAttribute("x1", xi); guide.setAttribute("x2", xi);
+    halo.setAttribute("cx", xi); halo.setAttribute("cy", yi);
+    dot.setAttribute("cx", xi); dot.setAttribute("cy", yi);
+    hover.setAttribute("display", "block");
+    tip.textContent = it.tip;
+    tip.style.display = "block";
+    tip.style.left = (clientX + 14) + "px";
+    tip.style.top = (clientY + 14) + "px";
+  }
+  function hideHover() { hover.setAttribute("display", "none"); tip.style.display = "none"; }
+
+  svg.addEventListener("mousemove", (e) => showHover(snap(e.clientX), e.clientX, e.clientY));
+  svg.addEventListener("mouseleave", hideHover);
+
+  // X-axis labels
+  const step = Math.max(1, Math.ceil(n / 12));
+  for (let i = 0; i < n; i += step) {
+    const tx = svgEl("text", { x: x(i).toFixed(1), y: H - 6, "text-anchor": "middle" });
+    tx.textContent = items[i].label;
+    svg.appendChild(tx);
+  }
+  c.appendChild(svg);
+}
+
+function renderHourBars(id, counts) {
+  const items = (counts || []).map((v, i) => ({
+    label: String(i).padStart(2, "0"),
+    count: v || 0,
+    tip: String(i).padStart(2, "0") + ":00 UTC — " + (v || 0) + " installs",
+  }));
+  renderLine(id, items);
+}
+
+function renderValueBars(id, buckets) {
+  const items = (buckets || []).map((b) => ({
+    label: b.key,
+    count: b.count,
+    tip: b.key + " → " + b.count,
+  }));
+  renderVChart(id, items, 0);
+}
+
+// ── Line chart with crosshair snap-hover ─────────────
+function renderTrend(id, trend) {
+  const c = document.getElementById(id);
+  c.textContent = "";
+  if (!trend || !trend.length) { emptyBox(c); return; }
+  const W = 560, H = 170, ML = 40, MB = 22, PAD = 6;
+  const max = Math.max.apply(null, trend.map((d) => Math.max(d.active, d.new)).concat([1]));
+  const n = trend.length;
+  const x = (i) => ML + (i * (W - ML - PAD)) / Math.max(n - 1, 1);
+  const y = (v) => PAD + (1 - v / max) * (H - MB - PAD);
+
+  const svg = svgEl("svg", { viewBox: "0 0 " + W + " " + H, width: "100%" });
+  const lg = svgEl("linearGradient", { id: "areaGrad", x1: "0", y1: "0", x2: "0", y2: "1" });
+  lg.appendChild(svgEl("stop", { offset: "0%", "stop-color": "#635bff", "stop-opacity": "0.12" }));
+  lg.appendChild(svgEl("stop", { offset: "100%", "stop-color": "#635bff", "stop-opacity": "0" }));
+  svg.appendChild(lg);
+
+  [0, 1 / 3, 2 / 3, 1].forEach((f) => {
+    const gy = (PAD + (1 - f) * (H - MB - PAD)).toFixed(1);
+    svg.appendChild(svgEl("line", { x1: ML, y1: gy, x2: W - PAD, y2: gy, class: "grid" }));
+    const tx = svgEl("text", { x: ML - 6, y: (parseFloat(gy) + 3).toFixed(1), "text-anchor": "end" });
+    tx.textContent = fmtCompact(Math.round(max * f));
+    bindTip(tx, String(Math.round(max * f)));
+    svg.appendChild(tx);
+  });
+
+  const actPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.active).toFixed(1)).join(" ");
+  const newPts = trend.map((d, i) => x(i).toFixed(1) + "," + y(d.new).toFixed(1)).join(" ");
+  const area = "M" + x(0).toFixed(1) + "," + y(trend[0].active).toFixed(1) + " L" + actPts.replace(/ /g, " L") +
+    " L" + x(n - 1).toFixed(1) + "," + (H - MB).toFixed(1) + " L" + x(0).toFixed(1) + "," + (H - MB).toFixed(1) + " Z";
+  svg.appendChild(svgEl("path", { d: area, fill: "url(#areaGrad)" }));
+  svg.appendChild(svgEl("polyline", { points: actPts, fill: "none", stroke: "#635bff", "stroke-width": 1.8, "stroke-linejoin": "round", class: "draw" }));
+  svg.appendChild(svgEl("polyline", { points: newPts, fill: "none", stroke: "#f5a623", "stroke-width": 1.2, "stroke-linejoin": "round", "stroke-dasharray": "3 3", class: "draw" }));
+
+  const hover = svgEl("g", { display: "none" });
+  const guide = svgEl("line", { class: "hover-guide" });
+  guide.setAttribute("y1", PAD); guide.setAttribute("y2", H - MB);
+  const halo = svgEl("circle", { class: "hover-halo", r: 10 });
+  const dot = svgEl("circle", { class: "hover-dot", r: 4 });
+  hover.appendChild(guide); hover.appendChild(halo); hover.appendChild(dot);
+  svg.appendChild(hover);
+
+  function snap(clientX) {
+    const rect = svg.getBoundingClientRect();
+    const sx = (clientX - rect.left) / rect.width * W;
+    let best = 0, bestD = Infinity;
+    for (let i = 0; i < n; i++) {
+      const d = Math.abs(x(i) - sx);
+      if (d < bestD) { bestD = d; best = i; }
+    }
+    return best;
+  }
+  function showHover(idx, clientX, clientY) {
+    const d = trend[idx];
+    const xi = x(idx), yi = y(d.active);
+    guide.setAttribute("x1", xi); guide.setAttribute("x2", xi);
+    halo.setAttribute("cx", xi); halo.setAttribute("cy", yi);
+    dot.setAttribute("cx", xi); dot.setAttribute("cy", yi);
+    hover.setAttribute("display", "block");
+    tip.innerHTML = "";
+    const date = el("div", "tt-date", d.date || "");
+    if (date.textContent) tip.appendChild(date);
+    const r1 = el("div", "tt-row");
+    r1.appendChild(el("span", "sw")); r1.firstChild.style.background = "#635bff";
+    r1.appendChild(el("span", "lbl", "active"));
+    r1.appendChild(el("span", "v", String(d.active)));
+    tip.appendChild(r1);
+    const r2 = el("div", "tt-row");
+    r2.appendChild(el("span", "sw")); r2.firstChild.style.background = "#f5a623";
+    r2.appendChild(el("span", "lbl", "new"));
+    r2.appendChild(el("span", "v", String(d.new)));
+    tip.appendChild(r2);
+    tip.style.display = "block";
+    tip.style.left = (clientX + 14) + "px";
+    tip.style.top = (clientY + 14) + "px";
+  }
+  function hideHover() { hover.setAttribute("display", "none"); tip.style.display = "none"; }
+
+  svg.addEventListener("mousemove", (e) => showHover(snap(e.clientX), e.clientX, e.clientY));
+  svg.addEventListener("mouseleave", hideHover);
+
+  const step = Math.max(1, Math.ceil(n / 6));
+  for (let i = 0; i < n; i += step) {
+    const tx = svgEl("text", { x: x(i).toFixed(1), y: H - 6, "text-anchor": "middle" });
+    tx.textContent = trend[i].date ? trend[i].date.slice(5) : "";
+    svg.appendChild(tx);
+  }
+  c.appendChild(svg);
+}
+
+// ── Donut + legend ───────────────────────────────────
+function renderDonut(id, items, maxSlices) {
+  const c = document.getElementById(id);
+  c.textContent = "";
+  if (!items.length) { emptyBox(c); return; }
+  const MAX = maxSlices || 6;
+  let slices = items;
+  if (items.length > MAX) {
+    const top = items.slice(0, MAX - 1);
+    const other = items.slice(MAX - 1).reduce((s, it) => s + it.count, 0);
+    slices = top.concat([{ key: "Other", count: other }]);
+  }
+  const total = slices.reduce((s, it) => s + it.count, 0) || 1;
+  const svg = svgEl("svg", { viewBox: "0 0 42 42", width: "108", height: "108", "aria-hidden": "true" });
+  let angle = 0;
+  slices.forEach((it, i) => {
+    const frac = it.count / total;
+    const circle = svgEl("circle", {
+      cx: 21, cy: 21, r: 15.915, fill: "none", "stroke-width": 4,
+      stroke: PALETTE[i % PALETTE.length],
+      "stroke-dasharray": (frac * 100).toFixed(2) + " " + (100 - frac * 100).toFixed(2),
+      "stroke-dashoffset": (-angle * 100).toFixed(2),
+    });
+    bindTip(circle, it.key + " — " + it.count + " (" + Math.round((it.count / total) * 100) + "%)");
+    svg.appendChild(circle);
+    angle += frac;
+  });
+  const center = svgEl("text", {
+    x: 21, y: 21, "text-anchor": "middle", "dominant-baseline": "central",
+    "font-size": "5.4", fill: "#0a2540", "font-weight": "600",
+  });
+  center.textContent = fmtCompact(total);
+  bindTip(center, String(total));
+  svg.appendChild(center);
+
+  const legend = el("div", "legend");
+  slices.forEach((it, i) => {
+    const row = el("div", "legend-row");
+    const sw = el("span", "sw");
+    sw.style.background = PALETTE[i % PALETTE.length];
+    row.appendChild(sw);
+    row.appendChild(el("span", "lk", it.key));
+    const lv = el("span", "lv");
+    const lvNum = el("span", "num", fmtCompact(it.count));
+    bindTip(lvNum, String(it.count));
+    lv.appendChild(lvNum);
+    lv.appendChild(el("span", "pct", Math.round((it.count / total) * 100) + "%"));
+    row.appendChild(lv);
+    legend.appendChild(row);
+  });
+  const wrap = el("div", "donut-wrap");
+  wrap.appendChild(svg);
+  wrap.appendChild(legend);
+  c.appendChild(wrap);
+}
+
+// ── Bottom metric chips ──────────────────────────────
+function renderMetrics(s) {
+  const c = document.getElementById("metrics");
+  c.textContent = "";
+  const windowLabel = currentDays ? currentDays + "d" : "all";
+  const wEl = document.getElementById("windowLabel");
+  if (wEl) wEl.textContent = windowLabel;
+  const hour = s.peakOnlineHour != null ? " · " + String(s.peakOnlineHour).padStart(2, "0") + ":00 UTC" : "";
+  const items = [
+    ["Avg ★", s.avgStar ? s.avgStar.toFixed(2) : "—", s.avgStar ? s.avgStar.toFixed(2) : "—"],
+    ["Avg LN%", s.avgLnRatio ? (s.avgLnRatio * 100).toFixed(1) + "%" : "—", s.avgLnRatio ? (s.avgLnRatio * 100).toFixed(1) + "%" : "—"],
+    ["Peak online", s.peakOnline ? fmtCompact(s.peakOnline) + hour : "—", s.peakOnline ? String(s.peakOnline) + hour : "—"],
+    ["Avg daily", fmtCompact(s.avgDailyActive), String(s.avgDailyActive)],
+    ["Analyzes", fmtCompact(s.analyzeCount), String(s.analyzeCount)],
+    ["Dur. avg", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms", (s.durationStats && s.durationStats.avgMs ? s.durationStats.avgMs : 0) + " ms"],
+    ["Dur. p50", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms", (s.durationStats ? s.durationStats.p50Ms : 0) + " ms"],
+    ["Dur. p90", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms", (s.durationStats ? s.durationStats.p90Ms : 0) + " ms"],
+  ];
+  for (const [k, v, raw] of items) {
+    const chip = el("div", "chip");
+    const cv = el("div", "cv", v);
+    if (raw !== v) bindTip(cv, raw);
+    chip.appendChild(cv);
+    chip.appendChild(el("div", "ck", k));
+    c.appendChild(chip);
+  }
+}
+
+// ── Fetch + dispatch ─────────────────────────────────
+function load() {
+  document.getElementById("updated").textContent = "loading…";
+  fetch("/api/v1/stats?days=" + currentDays)
+    .then((r) => {
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      return r.json();
+    })
+    .then((s) => {
+      document.getElementById("updated").textContent = "updated " + new Date().toLocaleString();
+      document.getElementById("serverVer").textContent = "v" + (s.serverVersion || "?");
+      document.getElementById("hourRange").textContent = "UTC · " + (currentDays ? currentDays + "d" : "all");
+      renderCards(s);
+      renderHourBars("onlineByHour", s.onlineByHour || []);
+      renderTrend("trend", s.activeTrend || []);
+      renderValueBars("starHistogram", s.starHistogram || []);
+      renderValueBars("lnRatioHistogram", s.lnRatioHistogram || []);
+      renderValueBars("numericHistogram", s.numericHistogram || [], "numeric");
+      renderHBar("keycounts", s.keycounts || []);
+      renderDonut("modes", s.modes || []);
+      renderDonut("mods", s.mods || []);
+      renderDonut("versions", s.versions || []);
+      renderHBar("algorithms", s.algorithms || [], 8);
+      renderHBar("actualAlgorithms", s.actualAlgorithms || [], 8);
+      renderMetrics(s);
+    })
+    .catch((err) => {
+      const ov = document.getElementById("overview");
+      ov.textContent = "";
+      ov.appendChild(el("div", "error", "Failed to load statistics: " + err.message));
+    });
+}
+
+// ── Bindings ─────────────────────────────────────────
+document.getElementById("range").addEventListener("click", (e) => {
+  const btn = e.target.closest("button[data-days]");
+  if (!btn) return;
+  currentDays = parseInt(btn.dataset.days, 10);
+  document.querySelectorAll("#range button").forEach((b) => b.classList.toggle("active", b === btn));
+  load();
+});
+
+load();
+// Auto-refresh every 60 s (matches the server-side stats cache TTL).
+setInterval(load, 60000);

--- a/backend/internal/web/web.go
+++ b/backend/internal/web/web.go
@@ -17,6 +17,12 @@ import (
 //go:embed dashboard.html
 var dashboardHTML []byte
 
+//go:embed dashboard.css
+var dashboardCSS []byte
+
+//go:embed dashboard.js
+var dashboardJS []byte
+
 const maxDays = 365
 
 type Handler struct {
@@ -52,7 +58,24 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
 		w.Write(dashboardHTML)
+	case "/dashboard.css":
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "text/css; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Write(dashboardCSS)
+	case "/dashboard.js":
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Write(dashboardJS)
 	case "/api/v1/stats":
 		if r.Method != http.MethodGet {
 			w.WriteHeader(http.StatusMethodNotAllowed)


### PR DESCRIPTION
Refactors the analytics dashboard by moving inline CSS/JS out of `dashboard.html` into embedded `dashboard.css` and `dashboard.js`, then serves them from new `/dashboard.css` and `/dashboard.js` routes in `web.go` with explicit content types and no-cache headers. The dashboard UI was redesigned (theme toggle, updated layout/labels, improved charts/legend/cards styling, and cleaner footer/meta presentation). Analytics aggregation now uses finer numeric-difficulty buckets (0.25 instead of 0.5) and formats numeric histogram labels to 2 decimals to match. Also ignores `backend/temp/` for local preview/scratch artifacts.