### PR TITLE
fix: card auto-grows with content instead of clipping (issue #57)

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -69,6 +69,7 @@ import {
     updateDiffTextVisibility,
 } from "./graph.js";
 import {
+    animateCardHeightTransition,
     currentEstimatorAlgorithm,
     isAutoDisplayEnabledNow,
     refreshAutoDisplayProfile,
@@ -476,6 +477,12 @@ export async function fetchBeatmapFile(reason) {
             renderContentSkeleton();
             bodyRenderDelayPromise = waitForMainCardResizeTransition();
         }
+
+        // 主体渲染前快照卡片高度（骨架路径下为骨架撑起的高度）。卡片高度现在是
+        // height:auto（随内容生长），内容渲染后的高度变化是瞬时布局——渲染完成
+        // 后用它补一次 height 过渡，恢复平滑伸长（与 setRuntimeContentBar 的
+        // animateCardHeightTransition 用法一致）。
+        const heightBeforeBodyRender = mainCardEl ? (Number(mainCardEl.getBoundingClientRect().height) || 0) : 0;
 
         const waitForBodyRenderReady = async () => {
             if (!bodyRenderDelayPromise) {
@@ -1031,6 +1038,10 @@ export async function fetchBeatmapFile(reason) {
         if (isVibroMap && state.diffText === "Difficulty") {
             setEstimateDifficultyText("VIBRO");
         }
+
+        // 主体渲染完成：auto 高度下内容撑开是瞬时的，这里从渲染前高度补过渡动画。
+        // 放在 refreshAutoDisplayProfile 之后，避免 profile 切换已触发的动画被打断重播。
+        animateCardHeightTransition(heightBeforeBodyRender);
 
         const metadataLine = formatMetadataStatus(parsedInfo.metadata);
         const metadataErrors = errors.filter((entry) => {

--- a/ManiaMapAnalyser by Leo_Black/js/app/settings.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/settings.js
@@ -146,7 +146,7 @@ function clearCardHeightTransitionState() {
     mainCardEl.style.removeProperty("height");
 }
 
-function animateCardHeightTransition(previousHeight) {
+export function animateCardHeightTransition(previousHeight) {
     if (!mainCardEl) {
         clearCardHeightTransitionState();
         return;

--- a/ManiaMapAnalyser by Leo_Black/metadata.txt
+++ b/ManiaMapAnalyser by Leo_Black/metadata.txt
@@ -2,7 +2,7 @@ Usecase: ingame, obs-overlay
 Name: ManiaMapAnalyser
 Author: Leo_Black
 CompatibleWith: tosu
-Resolution: 520x610
+Resolution: 520x680
 Version: 2.0.1
 authorLinks: https://github.com/LeoBlackMT/osumania_map_analyser
 Notes: Real-time osu!mania overlay for tosu that estimates difficulty, analyzes Pattern/MSD, and visualizes graph + pause data for 4K, 6K, and 7K maps.

--- a/ManiaMapAnalyser by Leo_Black/styles/base.css
+++ b/ManiaMapAnalyser by Leo_Black/styles/base.css
@@ -36,6 +36,11 @@ body {
     margin: 0;
     display: grid;
     grid-template-columns: 1fr;
+    /* 固定高度（而非 min-height）：grid 的 align-content 只在容器有多余空间时
+       生效。卡片 auto 高度且内容超高时，min-height 容器会被内容撑大、余量归零，
+       .extend-upward 的 align-content:end 因此失效（表现为反转后仍向下延伸）。
+       固定为 100% 后，超高内容按 end 对齐从底边锚定、向上溢出，反转语义成立。 */
+    height: 100%;
     min-height: 100%;
     align-content: start;
     gap: 14px;

--- a/ManiaMapAnalyser by Leo_Black/styles/card-modes.css
+++ b/ManiaMapAnalyser by Leo_Black/styles/card-modes.css
@@ -3,11 +3,11 @@
     grid-template-rows: auto auto 1fr;
     gap: 8px;
     width: 475px;
-    height: 540px;
+    height: auto;
     min-width: 475px;
     max-width: 475px;
     min-height: 540px;
-    max-height: 540px;
+    max-height: none;
     overflow: hidden;
 }
 
@@ -64,23 +64,29 @@
     border-radius: 1px;
 }
 
+/* Pattern mode: content-driven height — the card grows with the pattern
+   subtype list instead of clipping it; min-height keeps the resting height
+   stable. */
 .main-card.bars-pattern {
-    height: 575px;
+    height: auto;
     min-height: 575px;
-    max-height: 575px;
+    max-height: none;
 }
 
+/* 键型细分列表随卡片高度整体展开；底部留出 margin 避开绝对定位的
+   mode-tag 胶囊（bottom:10px、高约 21px）。 */
 .main-card.bars-pattern .cluster-bars {
-    overflow-y: hidden;
+    overflow-y: visible;
+    margin-bottom: 28px;
 }
 
 .main-card.bars-graph {
     grid-template-rows: auto auto auto;
     align-content: start;
     gap: 6px;
-    height: 396px;
+    height: auto;
     min-height: 396px;
-    max-height: 396px;
+    max-height: none;
 }
 
 .main-card.bars-graph .cluster-bars,
@@ -94,9 +100,9 @@
 
 .main-card.bars-none {
     grid-template-rows: auto auto;
-    height: 200px;
+    height: auto;
     min-height: 200px;
-    max-height: 200px;
+    max-height: none;
     gap: 4px;
     padding: 10px 10px 30px 10px;
 }

--- a/ManiaMapAnalyser by Leo_Black/styles/responsive.css
+++ b/ManiaMapAnalyser by Leo_Black/styles/responsive.css
@@ -12,41 +12,41 @@
 
     .main-card {
         width: 475px;
-        height: 520px;
+        height: auto;
         min-width: 475px;
         max-width: 475px;
         min-height: 520px;
-        max-height: 520px;
+        max-height: none;
     }
 
     .main-card.bars-pattern {
-        height: 555px;
+        height: auto;
         min-height: 555px;
-        max-height: 555px;
+        max-height: none;
     }
 
     .main-card.bars-graph {
-        height: 400px;
+        height: auto;
         min-height: 400px;
-        max-height: 400px;
+        max-height: none;
     }
 
     .main-card.bars-none {
-        height: 200px;
+        height: auto;
         min-height: 200px;
-        max-height: 200px;
+        max-height: none;
     }
 
     .main-card.bars-etterna {
-        height: 540px;
+        height: auto;
         min-height: 540px;
-        max-height: 540px;
+        max-height: none;
     }
 
     .main-card.bars-etterna.bars-etterna-compact {
-        height: 500px;
+        height: auto;
         min-height: 500px;
-        max-height: 500px;
+        max-height: none;
     }
 
     .main-card.bars-pp {


### PR DESCRIPTION
## Summary

Fixes #57 — the card no longer clips its body content. All fixed-height card modes now grow with their content (min-height keeps the resting height stable), and both the expand and collapse height transitions animate smoothly.

## Changes

- **styles/card-modes.css**: base / `bars-pattern` / `bars-graph` / `bars-none` switch from fixed `height`+`max-height` to `height: auto` + `min-height` floor + `max-height: none`; `bars-pattern`'s pattern subtype list expands fully (`overflow-y: visible`) with bottom margin clearing the absolutely-positioned mode-tag capsule; `bars-full` / `bars-etterna` / `bars-pp` were already content-driven and stay unchanged.
- **styles/responsive.css**: mirror the same auto-height sizing in the ≤640px responsive overrides.
- **js/app/analysis.js**: snapshot the card height before body render and replay `animateCardHeightTransition` after render, so skeleton → real-content growth animates smoothly instead of jumping (same mechanism as `setRuntimeContentBar`).
- **js/app/settings.js**: export `animateCardHeightTransition` — it was imported by analysis.js but not exported, which failed ESM module linking and bricked startup (stuck on the initial waiting screen); verified all named imports across the plugin resolve (507/507).

Closes #57 