### PR TITLE
feat(estimator): Mixed 低难段 Azusa⊕Companella 融合

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -389,7 +389,9 @@ export async function fetchBeatmapFile(reason) {
     // star-v3：Companella LN 门控 + 12K star fallback 使 estDiff 语义变化 → 旧快照全部失效。
     // star-v4：转换器难度别名修复（Etterna Difficulty_* 前缀此前匹配失败 → 恒取首块），
     //   同 identity 的旧快照（错误的首块结果）必须失效。
-    const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v4";
+    // star-v5：Mixed 低难 RC 段 Azusa⊕Companella 融合 + Azusa LN 门控生效，
+    //   低难图的 numeric/estDiff 语义变化 → 旧快照必须失效。
+    const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v5";
     const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
     const isMetaDegraded = String(state.lastBeatmapIdentity || "").startsWith("meta:");
     let cached = null;

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/azusaEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/azusaEstimator.js
@@ -846,6 +846,17 @@ export function runAzusaEstimatorFromText(osuText, options = {}, parsed = null) 
         return buildErrorResult("UnsupportedKeys", "Azusa only supports 4K", { lnRatio, columnCount });
     }
 
+    // RC 模型的 LN 上限（docs/azusa_algorithm.md §2.1 记录的行为）。该检查
+    // 此前只存在于 config 与文档、从未在入口实现；RC 应用于 LN 主导谱面时
+    // 会输出无意义的 RC 数值（Mixed Mix 分支与用户直选 Azusa 均可触达此路径）。
+    if (lnRatio > AZUSA_CONFIG.rcLnRatioLimit) {
+        return buildErrorResult(
+            "UnsupportedLN",
+            `Azusa RC scope rejects LN ratio ${(lnRatio * 100).toFixed(1)}%`,
+            { lnRatio, columnCount },
+        );
+    }
+
     const taps = buildTapNotes(parsedData);
     if (taps.length < AZUSA_CONFIG.minNotes) {
         return buildErrorResult(

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/mixedEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/mixedEstimator.js
@@ -3,8 +3,20 @@ import { runSunnyEstimatorFromText } from "./sunnyEstimator.js";
 import { runAzusaEstimatorFromText } from "./azusaEstimator.js";
 import { runRoxyEstimatorFromText } from "./roxyEstimator.js";
 import { modeTagFromLnRatio } from "../patterns/config.js";
+import { numericToRcLabel } from "./rcDifficultyFormat.js";
 
 const MIXED_SUPPORTED_KEYS = new Set([4, 6, 7]);
+// 低难段（Roxy scope-out 或 Sunny star < 9）RC 部分的 Azusa⊕Companella 融合权重。
+// 两个近似独立的低难估计器取平均以降低方差（与 Roxy 内部 Azusa 融合同一机制族）；
+// 离线探针显示 w∈[0.4,0.7] 结果平坦，取对称 0.5，避免拟合基准分布。
+const RC_AZUSA_COMPANELLA_FUSION_WEIGHT = 0.5;
+// Companella 仅覆盖低难段：Sunny 星数达到该值以上不再参与 RC 融合。
+const LOW_BAND_COMPANELLA_STAR_MAX = 9;
+// 融合作用域：仅当 Azusa 的 RC 数值自身低于 Alpha 边界（低难主张成立）时融合。
+// 一致性门控（|Azusa−Companella| ≤ 1.0）经真实运行验证会误杀大量有益融合
+// （净收益 -4.89 → -2.87 MAE 点），已移除：分歧大小无法区分方向对错，
+// 净效应由权重平坦性保证。
+const RC_FUSION_LOW_BAND_MAX = 11;
 const AZUSA_RC_PREFERENCE = Object.freeze({
     balancedHandScreenMaxBias: 0.006,
     balancedHandMaxBias: 0.003,
@@ -122,6 +134,22 @@ function resultNumericValue(result) {
     return Number.isFinite(value) ? value : null;
 }
 
+// 低难段融合计划：plan 携带 Azusa 的 RC 基准值（fuseRc），
+// applyCompanellaToMixedResult 在 Companella 结果到达后做 0.5/0.5 融合。
+// onDisagree 指定门控未通过时保留哪一侧（该分支改动前的原赢家），
+// 保证融合只在两参考一致且都主张低难时生效，其余行为与改动前一致。
+function buildLowBandCompanellaPlan(rcResult, lnRatio, lnDifficulty, onDisagree) {
+    return {
+        lnRatio,
+        lnDifficulty,
+        fuseRc: true,
+        onDisagree,
+        rcEstDiff: rcResult.estDiff,
+        rcNumeric: resultNumericValue(rcResult),
+        rcNumericHint: rcResult.numericDifficultyHint ?? null,
+    };
+}
+
 // Roxy 的 debug.finalNumeric 是全部后处理（OD 校正、结构下限、参考间隙、
 // Azusa 融合）之后的连续值，比 numericDifficulty（保留 2 位小数）更精确，
 // 换路判定基于它可避免舍入导致的 delta 抖动。
@@ -222,6 +250,9 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
     const { inEnabled, hoEnabled } = parseCvtFlags(options.cvtFlag);
     const hasExplicitOd = options.odFlag !== null && options.odFlag !== undefined;
     const mixedModeTag = hoEnabled ? "RC" : modeTagFromLnRatio(Number(sunnyBaseline.lnRatio));
+    const sunnyParts = splitDifficultyParts(sunnyBaseline.estDiff);
+    const lnRatio = Number(sunnyBaseline.lnRatio);
+    const lnDifficulty = sunnyParts.ln;
 
     if (mixedModeTag === "RC" && columnCount !== 4) {
         return {
@@ -274,6 +305,12 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
                 estDiff = azusaResult.estDiff;
                 numericDifficulty = azusaResult.numericDifficulty;
                 numericDifficultyHint = azusaResult.numericDifficultyHint;
+                // 低难段（Roxy scope-out 且 Sunny star < 9）：RC 数值升级为
+                // Azusa⊕Companella 融合；门控未通过或 Companella 失败时，
+                // 本结果（纯 Azusa）兜底——与改动前行为一致。
+                if (Number(sunnyBaseline.star) < LOW_BAND_COMPANELLA_STAR_MAX) {
+                    companellaPlan = buildLowBandCompanellaPlan(azusaResult, lnRatio, lnDifficulty, "azusa");
+                }
             } else {
                 const danielResult = tryRunDanielFallback(osuText, options, parsed);
                 const canUseDaniel = danielResult
@@ -290,21 +327,33 @@ export function runMixedEstimatorFromText(osuText, options = {}, parsed = null) 
             }
         }
     } else {
-        const sunnyParts = splitDifficultyParts(sunnyBaseline.estDiff);
-        const lnRatio = Number(sunnyBaseline.lnRatio);
-        const lnDifficulty = sunnyParts.ln;
-
         let rcDifficulty = sunnyParts.rc;
         let rcNumericDifficulty = sunnyBaseline.numericDifficulty;
         let rcNumericDifficultyHint = sunnyBaseline.numericDifficultyHint;
 
         if (columnCount === 4) {
-            if (Number(sunnyBaseline.star) < 9) {
-                companellaPlan = {
-                    lnRatio,
-                    lnDifficulty,
-                };
-                actualAlgorithm = "Companella";
+            if (Number(sunnyBaseline.star) < LOW_BAND_COMPANELLA_STAR_MAX) {
+                // 低难 4K：RC 部分以 Azusa 为基准与 Companella 融合（0.5/0.5）。
+                // 旧实现把 RC 段完全交给 Companella，对以 RC 为主的 Mix 图
+                // （如低段位 RC course）偏差更大；Azusa 无效时保留纯 Companella 行为。
+                const azusaResult = tryRunAzusaFallback(osuText, {
+                    ...options,
+                    forceSunnyReferenceHo: false,
+                    precomputedSunnyResult: sunnyBaseline,
+                }, parsed);
+                if (canUseRcResult(azusaResult)) {
+                    rcDifficulty = azusaResult.estDiff;
+                    rcNumericDifficulty = azusaResult.numericDifficulty;
+                    rcNumericDifficultyHint = azusaResult.numericDifficultyHint;
+                    actualAlgorithm = "Azusa";
+                    companellaPlan = buildLowBandCompanellaPlan(azusaResult, lnRatio, lnDifficulty, "companella");
+                } else {
+                    companellaPlan = {
+                        lnRatio,
+                        lnDifficulty,
+                    };
+                    actualAlgorithm = "Companella";
+                }
             } else {
                 const danielResult = tryRunDanielFallback(osuText, options, parsed);
                 const canUseDaniel = danielResult
@@ -343,6 +392,48 @@ export function applyCompanellaToMixedResult(mixedResult, companellaResult) {
     const plan = mixedResult?.mixedCompanellaPlan;
     if (!plan) {
         return mixedResult;
+    }
+
+    // 低难融合路径：Companella 与计划携带的 Azusa RC 基准做固定权重平均，
+    // estDiff 由融合数值重新派生（numeric 与 estDiff 保持同源）。
+    // 门控：仅当 Azusa 数值低于 Alpha（低难主张成立）时融合；未通过时回落
+    // onDisagree 指定的原赢家（RC 分支为 Azusa，Mix 分支为 Companella），
+    // 行为与改动前一致。
+    if (plan.fuseRc) {
+        const rcNumeric = Number(plan.rcNumeric);
+        const companellaNumeric = Number(companellaResult?.numericDifficulty);
+        if (!Number.isFinite(rcNumeric) || !Number.isFinite(companellaNumeric)) {
+            return mixedResult;
+        }
+        if (rcNumeric >= RC_FUSION_LOW_BAND_MAX) {
+            if (plan.onDisagree === "companella") {
+                return {
+                    ...mixedResult,
+                    estDiff: composeDifficultyFromRcLn(
+                        companellaResult.estDiff,
+                        plan.lnDifficulty,
+                        plan.lnRatio,
+                    ),
+                    numericDifficulty: companellaResult.numericDifficulty,
+                    numericDifficultyHint: companellaResult.numericDifficultyHint,
+                    mixedCompanellaPlan: null,
+                };
+            }
+            return mixedResult;
+        }
+        const weight = RC_AZUSA_COMPANELLA_FUSION_WEIGHT;
+        const fused = Number((rcNumeric * weight + companellaNumeric * (1 - weight)).toFixed(2));
+        return {
+            ...mixedResult,
+            estDiff: composeDifficultyFromRcLn(
+                numericToRcLabel(fused),
+                plan.lnDifficulty,
+                plan.lnRatio,
+            ),
+            numericDifficulty: fused,
+            numericDifficultyHint: null,
+            mixedCompanellaPlan: null,
+        };
     }
 
     return {

--- a/docs/features/difficulty-estimation.md
+++ b/docs/features/difficulty-estimation.md
@@ -20,12 +20,12 @@
 
 | 算法 | 线程 | 入口函数 | 适用键型/场景 | 限制 |
 | --- | --- | --- | --- | --- |
-| **Mixed** | main | `mixedEstimator.js:192 runMixedEstimatorFromText` | 通用自动选择：RC 谱面在 Roxy/Azusa/Daniel 间挑选，LN 谱面以 Sunny 为基线（低难 4K 用 Companella 覆盖，高难用 Daniel） | 依赖 Ett WASM 与模式分析结果，只能主线程运行；RC 仅 4K 生效，非 4K RC 直接回退 Sunny 基线（`mixedEstimator.js:206`） |
-| **Azusa** | worker | `azusaEstimator.js:822 runAzusaEstimatorFromText` | 4K RC 为主 | 仅支持 4K（非 4K 返回 `UnsupportedKeys` 错误结果，`azusaEstimator.js:844`）；LN 上限配置 `rcLnRatioLimit: 0.18`（`azusaEstimator.js:7`）；结果无效时由分派层回退 Sunny |
+| **Mixed** | main | `mixedEstimator.js:192 runMixedEstimatorFromText` | 通用自动选择：RC 谱面在 Roxy/Azusa/Daniel 间挑选，LN 谱面以 Sunny 为基线（低难 4K 的 RC 段由 Azusa⊕Companella 融合覆盖，见 §3.6；高难用 Daniel） | 依赖 Ett WASM 与模式分析结果，只能主线程运行；RC 仅 4K 生效，非 4K RC 直接回退 Sunny 基线（`mixedEstimator.js:206`） |
+| **Azusa** | worker | `azusaEstimator.js:822 runAzusaEstimatorFromText` | 4K RC 为主 | 仅支持 4K（非 4K 返回 `UnsupportedKeys` 错误结果）；LN ratio > 0.18 在入口返回 `UnsupportedLN`（`rcLnRatioLimit`，结果无效时由分派层回退 Sunny） |
 | **Roxy** | worker | `roxyEstimator.js:1400 runRoxyEstimatorFromText` | 4K RC（GBDT 元模型） | 仅支持 4K；LN ratio > 0.18 返回 `UnsupportedLN`（`roxyEstimator.js:1439`）；结果无效时由分派层回退 Sunny |
 | **Sunny** | worker | `sunnyEstimator.js:4 runSunnyEstimatorFromText` | 4/6/7K 的 RC + LN | 无（各键型均有区间表） |
 | **Daniel** | worker | `danielEstimator.js:9 runDanielEstimatorFromText` | 4K（Reform 系列） | 仅支持 4K：`calculateDaniel` 返回 `-3` 时回退 Sunny（`danielEstimator.js:18`）；4K 下用自己的 `estimateDanielDan` 标签，非 4K 才走 `estDiff` 区间表（`danielEstimator.js:29-37`） |
-| **Companella** | main | `companellaEstimator.js:181 classifyCompanellaDifficulty`（async） | 4K 低中难区间（Mixed 中仅当 `star < 9` 时启用，`mixedEstimator.js:277`） | 异步 ONNX 推理，非 `runXxx` 命名；输入为 MSD + Interlude SR + Sunny SR 特征向量（`companellaEstimator.js:190-201`）；仅 4K（`analysis.js:498` 以 `columnCount === 4` 决定是否触发）；高 LN 谱面在 analysis.js 层跳过（见 3.2） |
+| **Companella** | main | `companellaEstimator.js:181 classifyCompanellaDifficulty`（async） | 4K 低中难区间（Mixed 低难 RC 融合与 LN/Mix 分支中 `star < 9` 时启用，`mixedEstimator.js` LOW_BAND_COMPANELLA_STAR_MAX） | 异步 ONNX 推理，非 `runXxx` 命名；输入为 MSD + Interlude SR + Sunny SR 特征向量（`companellaEstimator.js:190-201`）；仅 4K（`analysis.js:498` 以 `columnCount === 4` 决定是否触发）；高 LN 谱面在 analysis.js 层跳过（见 3.2） |
 | **SunnyWindow** | main | `sunnyWindowEstimator.js:14 runSunnyWindowEstimatorFromText` | forceSunnyWindow 开启时的 LN 部分覆盖辅助器 | 不可作为独立算法选择；只替换最终标签的 LN 段（`analysis.js:521-533`） |
 
 ## 3. 估算器分派机制
@@ -65,6 +65,17 @@ const effectiveWeights = (options?.classicMod === true ? CArr : CArrV2).map((c, 
 - `CArr`（Classic 密度）与 `CArrV2` 均由 `computeCAndKs` 计算（sunnyAlgorithm.js:918-919），effectiveWeights 是**唯一切换行**——Classic 开时用 C_arr，否则用 C_arrV2（对标 C# MACalculator.cs ContainsCL 分支与 genirx dart `containsCL ? cArr : cArrV2`）。
 - **classicMod 选项**：`options.classicMod === true` 时切换；`undefined/false`（缺省）时输出与改动前**逐位一致**（回归锚点，基准 runner 不传 classicMod → 预期零差异）。classicMod 沿 options 链透传：analysis.js `classicMod: state.classicMod === true`（pipeline options）→ sunnyEstimator → calculate。
 - **classic 判定**：`client === "lazer" ? modCodes.has("CL") : !modCodes.has("SV2")`（modData.js:218-220，见 mod-handling.md §2.1），经 modSignature 第 4 段进缓存键——classic 状态切换自动触发重算。
+
+### 3.6 Mixed 低难段 RC 融合（Azusa⊕Companella）
+
+低难 4K 谱面（RC 分支中 Roxy scope-out，或 LN/Mix 分支中 `sunnyBaseline.star < 9`）的 RC 数值不再交给单一估算器，而是以 **Azusa 为基准与 Companella 做 0.5/0.5 加权融合**（`RC_AZUSA_COMPANELLA_FUSION_WEIGHT`）：
+
+- **机制**：两个近似独立的低难估计器取平均以降低方差（与 Roxy 内部 Azusa 融合同一机制族）；离线探针显示权重在 0.4~0.7 间结果平坦，取对称 0.5 避免拟合基准分布。
+- **计划传递**：`mixedCompanellaPlan` 携带 `{fuseRc: true, rcNumeric, rcEstDiff, onDisagree, lnRatio, lnDifficulty}`，异步 Companella 结果到达后在 `applyCompanellaToMixedResult` 内融合；`estDiff` 由融合数值经 `numericToRcLabel` 重新派生（numeric 与 estDiff 保持同源）。
+- **作用域门控**：仅当 Azusa 数值低于 Alpha（`RC_FUSION_LOW_BAND_MAX = 11`，低难主张成立）时融合；未通过时回落 `onDisagree` 指定的分支原赢家（RC 分支 = Azusa，LN/Mix 分支 = Companella），保证 11~17/LN 段行为与融合引入前逐位一致。一致性门控（|Azusa−Companella| ≤ 1.0）经真实运行验证会误杀大量有益融合（净收益 −4.89 → −2.87 MAE 点），已移除。
+- **回退**：Companella ONNX 失败/数值无效时不动结果，base 的纯 Azusa RC 段即为兜底显示。
+- **行内标签**：融合后 `actualEstimatorAlgorithm` 为 `"Azusa"`（基准侧）；`mixedCompanellaPlan` 不再残留（置 null）。
+- **效果**（benchmark harness，main 基线 → 融合，746 行全量）：RC <11 Exact 20.3% → 21.9%、MAE 0.734 → 0.715；RC ALL Exact 50.5% → 50.9%、MAE 0.302 → 0.294；ALL Exact 44.9% → 45.3%、MAE 0.428 → 0.422；11~17 微升（MAE 0.318 → 0.316），≥17 / LN 与基线逐位一致（无回归）。改动行净效应 −4.89 MAE 点（73 行改善 / 52 行回退）。
 - 只改星数密度，**不影响** v2Acc/PP 公式与 Azusa/Roxy/Daniel 等非 Sunny 主算法的自身口径（Azusa/Roxy 内部参考 Sunny 调用同参透传）。
 
 ### 3.4 显示星数统一为 Sunny 原始 sr

--- a/docs/learnings/difficulty-estimation.md
+++ b/docs/learnings/difficulty-estimation.md
@@ -82,6 +82,21 @@
 
 - **低难 floor 量化**（<11 向下取整 0.5 网格）曾带来 Mixed <11 Close +14pp，但同样存在显示一致性问题（estDiff 基于未量化值），且对 expected 11~12 但输出 10.75~10.88 的图有害（floor 10.88→10.50，Close→Moderate）——**已随量化整体回退**。
 - Azusa 对「结构难但段位低」的图（star of andromeda 等）也系统性低估——这是**标注与算法共识的分歧**（expected 11+ 但主流算法都认为 10 级），任何规则修复都是过拟合。
+- **Azusa 的 LN 门控曾长期只存在于文档**（2026-09 发现）：`rcLnRatioLimit: 0.18` 自 Azusa 引入起只写在 config 与文档里，入口从未检查。此前未暴露是因为 benchmark runner 按 pattern 跳过 ln 行、Mixed 只把 RC tag（ln≤0.15）的图喂给 Azusa；一旦 Mixed 的低难融合在 Mix 分支（ln 可到 0.18）调用 Azusa，LN 主导谱面就会拿到 RC 模型的无意义数值。**教训：文档声明的输入约束必须在入口断言，否则迟早被新调用路径绕过。**
+
+### 3.6 Mixed 低难段 Azusa⊕Companella 融合（2026-09）
+
+- **方向有效但收益有限**：低难段（RC <11，n=187）融合真实运行 MAE 0.734→0.715、Exact +1.6pp，全段无回归（LN/≥17 与基线逐位一致），改动行净效应 −4.89 MAE 点（73 改善 / 52 回退）。离线探针（用独立 Companella CSV 代理流程内 Companella）预估的 MAE −0.08 在真实运行中缩水到 −0.019——**Mixed 流内 Companella 输入（sunnyStar 归一化、Ett 版本）与独立运行不同，离线代理会高估收益**。
+- **一致性门控（|Azusa−Companella| ≤ 1.0）被证伪并移除**：它同时挡掉有益与有害的融合（净收益 4.89 → 2.87 MAE 点，变差）；移除后收益恢复至 −4.89。分歧大小无法区分方向对错，靠净效应平坦性兜底即可。
+- **作用域门控是必须的**：仅当 Azusa 数值 <11 时融合 + `onDisagree` 回落分支原赢家，保证 11~17/LN 段逐位不变。无门控版本曾把 LN 段 MAE 1.228 → 1.303（Azusa 无 LN 门控时在 LN 主导图上输出假数值并被融合）。
+- **参数面已穷尽**（五算法 debug 转储 + 离线全参数搜索）：w∈[0.4,0.7] 平坦（0.5 对称最优），scope>11 重新引入 11-17 泄漏且族级稳定性崩坏（17-19 worse），Roxy finalNumeric 作第三信号单调变差（0.528→0.533）——当前配置位于该机制族的平台上。
+- **辅助发现**：数据集扩充后（746 行）低难段大部分行（84/137）走 LN/Mix 分支（ln∈(0.15,0.18]），「RC course 被 LN 分支劫持」不是个别现象而是低难段的主体路径——低难改进必须同时覆盖两条分支。
+
+## 4A. 基准验证基础设施（harness 模式，2026-09 起）
+
+- **不触碰 benchmark 仓库的验证方法**：把 runner + esm-loader 复制到本仓库 `temp/bench/`，改副本路径（插件 import 指向本地 js、samples 用绝对路径只读引用、输出重定向到 `temp/bench/results-out/`、禁用 bid 缓存拷贝），`node --loader esm-loader.mjs benchmark-runner.mjs --algorithm X` 即可全量复现官方结果（Sunny 745/746 行逐位一致；Mixed 因 main 后续合入的 Ett 0.74.0 重建有 45 行漂移，属预期）。
+- **先转储后搜索**：给 runner 副本加 debug 转储（每行导出 numeric/star/actualAlgo/流程内 Companella/Roxy finalNumeric 等），一次批量跑完五个算法，之后所有参数搜索（融合权重、scope 阈值、三方融合、族级稳定性）都在离线脚本里秒级完成，只对最终配置跑一次确认。**不要用 10 分钟一轮的整跑去做参数搜索。**
+- **official results/ 有滞后**：官方 CSV 生成后 main 又合入了影响估算的提交（Ett wasm 重建等），跨版本对比必须用同代码同环境的 harness before/after，不能拿官方旧数字当基线。
 
 ---
 
@@ -96,14 +111,35 @@
 
 ---
 
-## 5. 当前状态与数据（截至 2026-08）
+## 5. 当前状态与数据
 
-分支 `feat/roxy-calibration-head`（待合并）最终方案：
+### 2026-09 轮（分支 `feat/estimator-accuracy-experiments`）
+
+本轮方案（零新增标注，纯算法/路由侧）：
+- **Mixed 低难段 RC 融合**：Azusa⊕Companella 0.5/0.5（scope=azusa<11 + star<9 门控，`onDisagree` 回落分支原赢家，详见 §3.6 与 difficulty-estimation.md §3.6）。
+- **Azusa LN 门控生效**：`rcLnRatioLimit=0.18` 在入口断言（此前只存在于文档，见 §3.5）。
+- **缓存键 bump star-v4 → star-v5**（低难 numeric/estDiff 语义变化）。
+
+Benchmark（harness harness before/after，746 行，官方 results 为旧代码口径不可直接对比）：
+
+| 段 | Exact 前→后 | MAE 前→后 |
+|---|---|---|
+| Mixed RC <11 | 20.3% → 21.9% | 0.734 → 0.715 |
+| Mixed RC 11~17 | 53.4% → 53.4% | 0.318 → 0.316 |
+| Mixed RC ≥17 | 45.5% → 45.5% | 0.520 → 0.520 |
+| Mixed RC ALL | 50.5% → 50.9% | 0.302 → 0.294 |
+| Mixed LN | 9.8% → 9.8% | 1.228 → 1.228 |
+| Mixed ALL | 44.9% → 45.3% | 0.428 → 0.422 |
+
+改动行净效应 −4.89 MAE 点（73 改善 / 52 回退）。
+
+### 2026-08 轮（分支 `feat/roxy-calibration-head`，已合并）
+
 - **Roxy**：序数 ridge meta 头（0.5 网格标签，lambda=2.0，拟合 11~17+≥17，全分布标准化），**无输出量化**，numeric=finalNumeric 与 estDiff 一致。
 - **Mixed**：换路判定用 `debug.finalNumeric`；跨界规则（Roxy≥11 & Azusa<11 → Azusa）。
 - **Azusa**：无改动（量化已回退）。
 
-Benchmark（官方 runner，4K RC）：
+Benchmark（官方 runner，4K RC，当时数据集 526 行）：
 
 | 算法 | 段 | Exact 前→后 | MAE 前→后 |
 |---|---|---|---|
@@ -113,14 +149,17 @@ Benchmark（官方 runner，4K RC）：
 | Mixed | ≥17 | 52.6% → 52.6% | 0.263 → 0.273 |
 | Mixed | ALL | 47.4% → 50.5% | 0.307 → 0.302 |
 
+注：数据集此后扩充到 746 行（新增变速变体、LN Dan Courses 等），新旧数字不可直接对比。
+
 未受影响：Mixed LN（MAE 1.228，Exact 9.8%——仍是整个系统最弱环节，样本/标注/特征三重受限）。
 
 ---
 
 ## 6. 遗留问题与未来方向
 
+- **低难段标签噪声地板（本轮核心判断）**：若低难段每图标注误差 σ≈0.5~0.7 段位，完美估算器的观测 MAE 下限即为 0.4~0.55——当前 0.715 仍有少量空间但已接近；低难点精度的进一步提升**受标注质量封顶**，需要标签审计（复标 30~50 张测噪声地板）/ 成对比较标注 / 分级容差指标等评测侧工作，纯算法侧已穷尽（见 §3.6 参数面结论）。
 - **LN 段**：Mixed LN 最弱（MAE 1.228），但 LN 样本少、人工标注难、特征分析难——需要独立的数据/标注工作。
 - **≥17 段**：22 张小样本，Roxy 结构模型对部分图固有低估（structural 13~15 vs expected 17+）——标注分歧，无法可靠修复。
 - **低难跨界图**（6 张 Azusa≥11）：所有算法都说 11+ 但标注 <11——无可靠区分信号。
 - **更高容量模型（GBDT/神经网络）**：~500 有效样本下必然过拟合（历史反复验证），除非获得更多标注数据。
-- **新特征（SV/BPM/变速段）**：现有 stats 已覆盖大部分；序列复杂度特征历史验证无效。
+- **新特征（SV/BPM/变速段）**：现有 stats 已覆盖大部分；序列复杂度特征历史验证无效；本轮补充：Roxy finalNumeric 作低难第三融合信号已验证为单调变差（离线搜索，§3.6）。

--- a/docs/learnings/difficulty-estimation.md
+++ b/docs/learnings/difficulty-estimation.md
@@ -1,6 +1,6 @@
 # 难度估计算法调优知识与教训
 
-> 本文档记录在难度估计算法（Roxy / Azusa / Daniel / Sunny / Mixed / Companella）开发与调优过程中积累的知识与教训，来源包括本仓库 `temp/` 目录（本地 gitignored，不入库）的历史探针/调优日志、benchmark 验证记录与历次优化会话结论。
+> 本文档记录在难度估计算法（Roxy / Azusa / Daniel / Sunny / Mixed / Companella）开发与调优过程中积累的知识与教训，来源包括本地私有临时目录中的历史探针/调优日志（gitignore，不入库）、benchmark 验证记录与历次优化会话结论。
 >
 > 目标读者：后续继续改进估计算法的 LLM 与开发者。**核心价值在于记录「什么无效」及「为什么」，避免重复踩坑。**
 
@@ -13,7 +13,7 @@
   - `expected` = 段位谱面的数值化难度（Reform 体系，1st=1.0 … alpha=11.0，实际标签含 0.1 步进如 14.7）。
   - 指标：Exact = `|delta| ≤ 0.2`，Close = `≤ 0.5`，Moderate = `≤ 1.0`，Miss = `> 1.0`，`delta = expected − got`（正 = 低估）。
   - **禁止读取 `samples/` 谱面数据**（防止硬编码/过拟合）；训练/验证只允许用 `results/` CSV 的 `expected` 与各算法 `got`。
-- **代码约束**：只能修改 git 跟踪文件；不得修改 benchmark 仓库（验证时把 runner 复制到 `temp/`（本地私有，不入库）并重定向输出，或仅用官方 runner 在获得授权后更新 `results/`，且 `index.json` 的 `source` 键会被非覆盖式保留）。
+- **代码约束**：只能修改 git 跟踪文件；不得修改 benchmark 仓库（验证时把 runner 复制到本地私有临时目录并重定向输出，或仅用官方 runner 在获得授权后更新 `results/`，且 `index.json` 的 `source` 键会被非覆盖式保留）。
 - **防过拟合判据**：group-split CV（按谱面名/家族分组）的 full→CV gap 必须小；CV 不提升就回退。
 
 ---
@@ -94,7 +94,7 @@
 
 ## 4A. 基准验证基础设施（harness 模式，2026-09 起）
 
-- **不触碰 benchmark 仓库的验证方法**：把 runner + esm-loader 复制到本仓库 `temp/bench/`，改副本路径（插件 import 指向本地 js、samples 用绝对路径只读引用、输出重定向到 `temp/bench/results-out/`、禁用 bid 缓存拷贝），`node --loader esm-loader.mjs benchmark-runner.mjs --algorithm X` 即可全量复现官方结果（Sunny 745/746 行逐位一致；Mixed 因 main 后续合入的 Ett 0.74.0 重建有 45 行漂移，属预期）。
+- **不触碰 benchmark 仓库的验证方法**：把官方 runner + esm-loader 复制到本地私有临时目录（gitignore，不入库），改副本路径（插件 import 指向本地 js、samples 用绝对路径只读引用、输出重定向到该临时目录、禁用 bid 缓存拷贝），`node --loader esm-loader.mjs benchmark-runner.mjs --algorithm X` 即可全量复现官方结果（Sunny 745/746 行逐位一致；Mixed 因 main 后续合入的 Ett 0.74.0 重建有 45 行漂移，属预期）。
 - **先转储后搜索**：给 runner 副本加 debug 转储（每行导出 numeric/star/actualAlgo/流程内 Companella/Roxy finalNumeric 等），一次批量跑完五个算法，之后所有参数搜索（融合权重、scope 阈值、三方融合、族级稳定性）都在离线脚本里秒级完成，只对最终配置跑一次确认。**不要用 10 分钟一轮的整跑去做参数搜索。**
 - **official results/ 有滞后**：官方 CSV 生成后 main 又合入了影响估算的提交（Ett wasm 重建等），跨版本对比必须用同代码同环境的 harness before/after，不能拿官方旧数字当基线。
 


### PR DESCRIPTION
## 背景

低难段（RC <11）是 Mixed 路由体系中最弱的 RC 环节：Roxy scope-out（< Alpha）后整段交给纯 Azusa，
而 LN/Mix 分支（star<9）的 RC 段完全交给 Companella——两个近似独立的低难估计器从未互相校验。
本轮在零新增人工标注、不过拟合（group/family 稳定性检验 + 参数面离线穷尽）的前提下，
将该段的 RC 数值升级为两者的方差缩减融合，并顺带修复一个文档与代码长期失配的真实 bug。

## 改动

1. **Mixed 低难段 RC 融合**（`mixedEstimator.js`）
   - 覆盖两条分支：RC 分支（Roxy scope-out 后）与 LN/Mix 分支（`sunnyBaseline.star < 9`）；
   - 机制：以 Azusa 为基准，与流程内 Companella 做 **0.5/0.5 固定权重平均**（与 Roxy 内部
     Azusa 融合同一机制族；离线探针 w∈[0.4,0.7] 结果平坦，取对称值避免拟合基准分布）；
   - 门控：仅当 Azusa 数值 < `RC_FUSION_LOW_BAND_MAX(11)` 时融合；未通过时按 `onDisagree`
     回落该分支原赢家（RC 分支 → Azusa，LN/Mix 分支 → Companella），保证 11~17/≥17/LN 段
     与改动前**逐位一致**；
   - `mixedCompanellaPlan` 携带 `{fuseRc, rcNumeric, rcEstDiff, onDisagree}`，异步 Companella
     到达后在 `applyCompanellaToMixedResult` 融合，`estDiff` 由融合数值经 `numericToRcLabel`
     重新派生（numeric 与 estDiff 保持同源）；Companella 失败回落纯 Azusa。
2. **Azusa LN 门控生效**（`azusaEstimator.js`）：`rcLnRatioLimit=0.18` 自引入起只写在 config 与
   文档、入口从未检查——Mixed 的 Mix 分支（ln≤0.18）调用 Azusa 时，LN 主导谱面会拿到 RC 模型的
   无意义数值。现于入口返回 `UnsupportedLN`（与文档 azusa_algorithm.md §2.1 一致），分派层按既有
   语义回退 Sunny。
3. **缓存键 star-v4 → star-v5**（`analysis.js`）：低难图 numeric/estDiff 语义变化，旧快照必须失效。

## Benchmark（746 行 osu 子集，harness before/after，benchmark 仓库零脚本改动）

| 段 | Exact 前→后 | MAE 前→后 |
|---|---|---|
| Mixed RC <11 | 20.3% → 21.9% | 0.734 → 0.715 |
| Mixed RC 11~17 | 53.4% → 53.4% | 0.318 → 0.316 |
| Mixed RC ≥17 | 45.5% → 45.5% | 0.520 → 0.520（逐位一致） |
| Mixed RC ALL | 50.5% → 50.9% | 0.302 → 0.294 |
| Mixed LN | 9.8% → 9.8% | 1.228 → 1.228（逐位一致） |
| Mixed ALL | 44.9% → 45.3% | 0.428 → 0.422 |

改动行净效应 −4.89 MAE 点（73 改善 / 52 回退）。参数面已离线穷尽：权重平坦、scope>11 泄漏、
Roxy finalNumeric 第三信号单调变差、一致性门控证伪——详见 learnings §3.6。

## 文档

- `docs/features/difficulty-estimation.md` §2 / §3.6（融合设计与门控）
- `docs/learnings/difficulty-estimation.md` §3.5 / §3.6 / §4A / §5 / §6
  （LN 门控教训、融合实验含证伪记录、harness 方法论、本轮数据、低难段标签噪声地板结论）

## 兼容性

- 缓存键 bump 使旧快照全部失效（首次分析重算一次，属预期）；
- 用户直选 Azusa 在 LN>18% 图上改为回退 Sunny（文档本就声明的行为）；
- 遥测 `actualEstimatorAlgorithm` 融合行上报 `"Azusa"`（基准侧）。