### PR TITLE
fix(probe): never crash on nonexistent drive letters (installer + shell auto-detection)

### DIFF
--- a/bridges/README.md
+++ b/bridges/README.md
@@ -11,7 +11,7 @@
 
 - 双击 `install-bridge.bat`（英文界面）或 `install-bridge-zh.bat`（中文界面）即可；命令行运行：`powershell -NoProfile -ExecutionPolicy Bypass -File install-bridge.ps1 [-Chinese]`。
 - 主菜单选择 **Install** / **Uninstall**，再选择游戏（Etterna / Malody V）。全程交互确认。
-- 游戏根目录自动探测：正在运行的进程 → `MMA_ETTERNA_ROOT` / `MMA_MALODY_ROOT` 环境变量 → 常见安装路径；Malody V（Steam 游戏）额外探测 Steam 库（注册表 + `steamapps/libraryfolders.vdf`），Etterna 不是 Steam 应用、不走 Steam 检测。
+- 游戏根目录自动探测：正在运行的进程 → `MMA_ETTERNA_ROOT` / `MMA_MALODY_ROOT` 环境变量 → 常见安装路径；Malody V（Steam 游戏）额外探测 Steam 库（注册表 + `steamapps/libraryfolders.vdf`），Etterna 不是 Steam 应用、不走 Steam 检测。探测前先做盘符就绪预检——不存在的盘符（如没有 D: 盘）直接跳过，绝不因探测不存在的路径而中断安装器。
 - **自动探测失败时**：可从「浏览选择目录」图形对话框选择、手动输入路径（`/`、`\`、`\\` 写法与包裹引号、尾部斜杠都能兼容归一化），或按提示查看「如何找到游戏路径」指引。
 - **Etterna 主题预检**：安装前检查每个主题的目录结构，只列出结构完整（`ScreenSelectMusic decorations/default.lua` 与 `ScreenGameplay overlay/default.lua` 都存在）的主题；`_fallback` 这类缺少屏目录的主题会被跳过并说明原因。默认安装到 **Rebirth**（存在时；否则列出可安装主题供选择；不提供一次性安装到全部主题）。
 - 写入/更新插件根目录（`bridges/..`，即 `mma-shell.exe` 旁）的 `mma-shell-config.json` 的 `etternaRoot` / `malodyRoot`（正斜杠路径）。
@@ -36,7 +36,7 @@ For users unfamiliar with manual steps, this folder ships an interactive install
 
 - Double-click `install-bridge.bat` (English UI) or `install-bridge-zh.bat` (Chinese UI); or run `powershell -NoProfile -ExecutionPolicy Bypass -File install-bridge.ps1 [-Chinese]`.
 - Main menu: **Install** / **Uninstall**, then pick the game (Etterna / Malody V). Every step asks for confirmation.
-- Game roots are auto-detected: running process → `MMA_ETTERNA_ROOT` / `MMA_MALODY_ROOT` env vars → common install paths; Malody V (a Steam game) additionally probes Steam libraries (registry + `steamapps/libraryfolders.vdf`), while Etterna is not a Steam app and is never probed there.
+- Game roots are auto-detected: running process → `MMA_ETTERNA_ROOT` / `MMA_MALODY_ROOT` env vars → common install paths; Malody V (a Steam game) additionally probes Steam libraries (registry + `steamapps/libraryfolders.vdf`), while Etterna is not a Steam app and is never probed there. Drive readiness is checked before probing: candidates on drives that do not exist (e.g. no D:) are skipped silently — probing never aborts the installer.
 - **If auto-detection finds nothing**: pick the folder from a browse dialog, type a path (`/`, `\` or `\\` separators, wrapping quotes and trailing slashes are all normalized), or follow the built-in "how do I find the path" hint.
 - **Etterna theme pre-check**: each theme's structure is validated before listing — only themes with both `ScreenSelectMusic decorations/default.lua` and `ScreenGameplay overlay/default.lua` present are offered; incomplete themes (like `_fallback`) are skipped with the reason shown. Installs into **Rebirth** by default (falls back to the installable-theme picker if missing; installing to all themes at once is intentionally not offered).
 - Writes/updates `etternaRoot` / `malodyRoot` (forward-slash paths) in `mma-shell-config.json` next to the plugin root (`bridges/..`, i.e. next to `mma-shell.exe`).

--- a/bridges/install-bridge.ps1
+++ b/bridges/install-bridge.ps1
@@ -377,6 +377,26 @@ function Format-PathInput {
     return $p
 }
 
+function Test-PathRootAvailable {
+    <#
+        Drive-letter pre-check. Join-Path throws DriveNotFoundException when the
+        first path segment names a drive that does not exist (e.g. the common-path
+        candidates probe D:\ while the user has no D: drive) - a terminating error
+        under $ErrorActionPreference = 'Stop' that would kill the installer.
+        Detection must never crash: probe the drive root first and skip.
+    #>
+    param([string]$p)
+    if (-not $p) { return $false }
+    $root = [System.IO.Path]::GetPathRoot($p)
+    if (-not $root) { return $true }  # relative path: no drive to validate
+    if ($root -notmatch '^[A-Za-z]:') { return $true }  # UNC / device path
+    try {
+        return [System.IO.DriveInfo]::new($root.Substring(0, 1)).IsReady
+    } catch {
+        return $false
+    }
+}
+
 function Select-FolderBrowser {
     param([string]$Description)
     try {
@@ -442,6 +462,7 @@ function Get-SteamLibraryRoots {
     # 2. libraryfolders.vdf inside every known root
     $snapshot = @($roots)
     foreach ($r in $snapshot) {
+        if (-not (Test-PathRootAvailable $r)) { continue }
         $vdf = Join-Path $r 'steamapps\libraryfolders.vdf'
         if (Test-Path $vdf) {
             $text = Get-Content -LiteralPath $vdf -Raw -ErrorAction SilentlyContinue
@@ -459,6 +480,7 @@ function Get-SteamLibraryRoots {
 function Test-EtternaRoot {
     param([string]$p)
     if (-not $p) { return $false }
+    if (-not (Test-PathRootAvailable $p)) { return $false }
     $save = Join-Path $p 'Save'
     $themes = Join-Path $p 'Themes'
     return (Test-Path $save -PathType Container) -and (Test-Path $themes -PathType Container)
@@ -467,6 +489,7 @@ function Test-EtternaRoot {
 function Test-MalodyRoot {
     param([string]$p)
     if (-not $p) { return $false }
+    if (-not (Test-PathRootAvailable $p)) { return $false }
     return (Test-Path (Join-Path $p 'chart') -PathType Container) -and
            (Test-Path (Join-Path $p 'skin') -PathType Container)
 }
@@ -488,8 +511,12 @@ function Get-EtternaCandidates {
     $cands = New-Object 'System.Collections.Generic.List[string]'
     $add = {
         param($p)
-        if ($p) { $p = Format-PathInput -Path $p }
-        if ($p -and (Test-EtternaRoot $p) -and -not $cands.Contains($p)) { $cands.Add($p) }
+        # probing is best-effort: never let an unexpected provider error
+        # terminate the installer ($ErrorActionPreference = 'Stop')
+        try {
+            if ($p) { $p = Format-PathInput -Path $p }
+            if ($p -and (Test-EtternaRoot $p) -and -not $cands.Contains($p)) { $cands.Add($p) }
+        } catch { }
     }
     # running process
     $p = Get-RunningProcessRoot -Names 'Etterna'
@@ -507,13 +534,18 @@ function Get-MalodyCandidates {
     $cands = New-Object 'System.Collections.Generic.List[string]'
     $add = {
         param($p)
-        if ($p) { $p = Format-PathInput -Path $p }
-        if ($p -and (Test-MalodyRoot $p) -and -not $cands.Contains($p)) { $cands.Add($p) }
+        # probing is best-effort: never let an unexpected provider error
+        # terminate the installer ($ErrorActionPreference = 'Stop')
+        try {
+            if ($p) { $p = Format-PathInput -Path $p }
+            if ($p -and (Test-MalodyRoot $p) -and -not $cands.Contains($p)) { $cands.Add($p) }
+        } catch { }
     }
     $p = Get-RunningProcessRoot -Names 'Malody V', 'MalodyV'
     if ($p) { & $add $p }
     if ($env:MMA_MALODY_ROOT) { & $add $env:MMA_MALODY_ROOT }
     foreach ($lib in (Get-SteamLibraryRoots)) {
+        if (-not (Test-PathRootAvailable $lib)) { continue }
         & $add (Join-Path $lib 'steamapps\common\MalodyV')
     }
     foreach ($c in @(

--- a/desktop/release.ps1
+++ b/desktop/release.ps1
@@ -8,7 +8,12 @@ $root = Split-Path $PSScriptRoot -Parent
 $pluginDir = Join-Path $root "ManiaMapAnalyser by Leo_Black"
 $desktop = Join-Path $root "desktop"
 $outDir = Join-Path $root "release"
-$version = "2.1.0"
+# 版本号以插件 metadata.txt 为唯一来源（避免与 index.js/metadata 漂移）。
+$metadataPath = Join-Path $pluginDir "metadata.txt"
+$version = ((Get-Content -LiteralPath $metadataPath) |
+    Where-Object { $_ -like 'Version:*' } |
+    Select-Object -First 1) -replace '^Version:\s*', ''
+if (-not $version) { throw "version not found in $metadataPath" }
 
 if (-not (Test-Path (Join-Path $pluginDir "index.html"))) {
     throw "plugin dir not found: $pluginDir"

--- a/desktop/src/config.rs
+++ b/desktop/src/config.rs
@@ -5,7 +5,8 @@ use std::env;
 use std::fs;
 use std::net::TcpStream;
 use std::path::{Path, PathBuf};
-use std::time::Duration;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 pub const PLUGIN_FOLDER: &str = "ManiaMapAnalyser by Leo_Black";
 
@@ -318,6 +319,47 @@ fn exe_dir() -> Option<PathBuf> {
 
 // ---- Steam 库发现（注册表 + libraryfolders.vdf）+ 常见路径启发探测 ----
 
+/// 盘符预检：候选路径探测前先确认盘符存在且就绪。用户可能没有 D: 盘；
+/// "存在但未就绪"的驱动器（读卡器/光驱）上的元数据查询还可能阻塞数秒——
+/// 先探根目录快速跳过。非盘符前缀（UNC/相对路径）视为可用，交由后续判定。
+fn drive_root_ready(p: &Path) -> bool {
+    let Some(first) = p.iter().next() else {
+        return false;
+    };
+    let first = first.to_string_lossy();
+    let bytes = first.as_bytes();
+    if bytes.len() == 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+        fs::metadata(format!("{}/", &first[..2])).is_ok()
+    } else {
+        true
+    }
+}
+
+/// 探测结果 30s TTL 缓存：未配置根目录时轮询器每个周期都会走到 detect_*，
+/// 每次都打注册表 + vdf + 逐候选盘符探测既浪费也会放大未就绪驱动器的阻塞。
+const DETECT_CACHE_TTL: Duration = Duration::from_secs(30);
+
+static ETTERNA_DETECT_CACHE: Mutex<Option<(Instant, Option<PathBuf>)>> = Mutex::new(None);
+static MALODY_DETECT_CACHE: Mutex<Option<(Instant, Option<PathBuf>)>> = Mutex::new(None);
+
+fn detect_cached(
+    cache: &Mutex<Option<(Instant, Option<PathBuf>)>>,
+    once: fn() -> Option<PathBuf>,
+) -> Option<PathBuf> {
+    if let Ok(guard) = cache.lock() {
+        if let Some((at, hit)) = guard.as_ref() {
+            if at.elapsed() < DETECT_CACHE_TTL {
+                return hit.clone();
+            }
+        }
+    }
+    let hit = once();
+    if let Ok(mut guard) = cache.lock() {
+        *guard = Some((Instant::now(), hit.clone()));
+    }
+    hit
+}
+
 /// 读 Windows 注册表拿 Steam 安装路径（SteamPath/InstallPath），并解析
 /// libraryfolders.vdf 收集全部 Steam 库根（含 Steam 自身库与其他库）。
 /// 非 Windows 平台：仅靠硬编码候选（壳目前 Windows-only，Linux 构建时跳过注册表）。
@@ -379,15 +421,19 @@ fn steam_library_roots() -> Vec<PathBuf> {
 
 /// Etterna：Steam 库（appid 607810 的 common/Etterna）→ 常见路径 → env。
 pub fn detect_etterna_root() -> Option<PathBuf> {
+    detect_cached(&ETTERNA_DETECT_CACHE, detect_etterna_root_once)
+}
+
+fn detect_etterna_root_once() -> Option<PathBuf> {
     if let Ok(over) = env::var("MMA_ETTERNA_ROOT") {
         let p = PathBuf::from(normalize_path(&over));
-        if p.join("Save").is_dir() {
+        if drive_root_ready(&p) && p.join("Save").is_dir() {
             return Some(p);
         }
     }
     for lib in steam_library_roots() {
         let dir = lib.join("steamapps").join("common").join("Etterna");
-        if dir.join("Save").is_dir() {
+        if drive_root_ready(&dir) && dir.join("Save").is_dir() {
             return Some(dir);
         }
     }
@@ -399,7 +445,7 @@ pub fn detect_etterna_root() -> Option<PathBuf> {
     ];
     for c in candidates {
         let dir = PathBuf::from(c);
-        if dir.join("Save").is_dir() {
+        if drive_root_ready(&dir) && dir.join("Save").is_dir() {
             return Some(dir);
         }
     }
@@ -408,15 +454,19 @@ pub fn detect_etterna_root() -> Option<PathBuf> {
 
 /// MalodyV：Steam 库（common/MalodyV）→ 常见路径 → env。
 pub fn detect_malody_root() -> Option<PathBuf> {
+    detect_cached(&MALODY_DETECT_CACHE, detect_malody_root_once)
+}
+
+fn detect_malody_root_once() -> Option<PathBuf> {
     if let Ok(over) = env::var("MMA_MALODY_ROOT") {
         let p = PathBuf::from(normalize_path(&over));
-        if p.join("chart").is_dir() && p.join("skin").is_dir() {
+        if drive_root_ready(&p) && p.join("chart").is_dir() && p.join("skin").is_dir() {
             return Some(p);
         }
     }
     for lib in steam_library_roots() {
         let dir = lib.join("steamapps").join("common").join("MalodyV");
-        if dir.join("chart").is_dir() && dir.join("skin").is_dir() {
+        if drive_root_ready(&dir) && dir.join("chart").is_dir() && dir.join("skin").is_dir() {
             return Some(dir);
         }
     }
@@ -428,7 +478,7 @@ pub fn detect_malody_root() -> Option<PathBuf> {
     ];
     for c in candidates {
         let dir = PathBuf::from(c);
-        if dir.join("chart").is_dir() && dir.join("skin").is_dir() {
+        if drive_root_ready(&dir) && dir.join("chart").is_dir() && dir.join("skin").is_dir() {
             return Some(dir);
         }
     }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -84,9 +84,19 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .setup(move |app| {
+            // 插件版本从 metadata.txt 读取（不再硬编码，避免版本漂移）。
+            let plugin_version = std::fs::read_to_string(plugin_dir.join("metadata.txt"))
+                .ok()
+                .and_then(|text| {
+                    text.lines().find_map(|line| {
+                        line.trim().strip_prefix("Version:").map(|v| v.trim().to_string())
+                    })
+                })
+                .unwrap_or_else(|| "?".to_string());
             server::log::log_line(&format!(
-                "mma-shell start (crate v{}, plugin v2.1.0, ts={})",
+                "mma-shell start (crate v{}, plugin v{}, ts={})",
                 env!("CARGO_PKG_VERSION"),
+                plugin_version,
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .map(|d| d.as_secs())

--- a/docs/features/desktop-shell.md
+++ b/docs/features/desktop-shell.md
@@ -32,7 +32,7 @@ window.navigate(url)
 
 - **插件目录**：`MMA_PLUGIN_DIR` 环境变量 > exe 目录逐级上溯 0–3 层，每层拼 `ManiaMapAnalyser by Leo_Black` 并校验 `index.html` 存在；都不中则用相对路径。发布形态（exe 与插件目录同层）上溯 0 层即命中；开发形态（target/debug）上溯 2 层命中仓库根。
 - **tosu.env**：从 exe 所在目录开始向上（含当前层）最多 3 层；解析 `SERVER_PORT`（默认 24050）与 `SERVER_IP`（默认 127.0.0.1）；根目录 = tosu.env 所在目录（用于 `settings/{插件名}.json` 只读读取）。
-- **Etterna/Malody 根**：`MMA_ETTERNA_ROOT` / `MMA_MALODY_ROOT` 环境变量 > **壳配置 `mma-shell-config.json`**（exe 旁，`{gameClient, etternaRoot, malodyRoot, hotkeys, logLevel}`，可直接编辑，30s 周期检测变化后重载并推送 settings 帧）> tosu 在线只读。无 tosu 用户无需下载 tosu 即可配置游戏路径。
+- **Etterna/Malody 根**：`MMA_ETTERNA_ROOT` / `MMA_MALODY_ROOT` 环境变量 > **壳配置 `mma-shell-config.json`**（exe 旁，`{gameClient, etternaRoot, malodyRoot, hotkeys, logLevel}`，可直接编辑，30s 周期检测变化后重载并推送 settings 帧）> tosu 在线只读。无 tosu 用户无需下载 tosu 即可配置游戏路径。启发探测（Steam 库/常见路径）带**盘符就绪预检**——不存在的盘符（用户没有 D: 盘等）快速跳过、绝不 panic/阻塞；且探测结果 30s TTL 缓存，未配置根目录时轮询器不会每个周期都打注册表与盘符。
 
 ## 3. 契约 v2 帧
 


### PR DESCRIPTION
## 问题

安装桥文件时安装器直接退出。根因是 `install-bridge.ps1` 的 `Test-EtternaRoot` 在候选路径探测时对 `D:/Games/Etterna` 这类常见路径调用 `Join-Path`，而 Windows PowerShell 的 `Join-Path` 在路径首段盘符不存在（用户没有 D: 盘，或提权会话看不到映射盘）时抛出 `DriveNotFoundException`；脚本顶层 `$ErrorActionPreference = 'Stop'` 使其成为终止错误，安装器以 exit code 1 退出，自动探测完全不可用。

## 修复

- `install-bridge.ps1`：新增 `Test-PathRootAvailable` 盘符就绪预检（`DriveInfo.IsReady`，UNC/相对路径直接放行），`Test-EtternaRoot` / `Test-MalodyRoot` / `Get-SteamLibraryRoots` 的 vdf 循环 / `Get-MalodyCandidates` 的 Steam 库循环在 `Join-Path` 前先探盘符；两个候选收集函数的探测逻辑整体包上 best-effort `try/catch`——探测是启发式的，任何异常都不应终止安装流程。
- `desktop/src/config.rs`：`detect_etterna_root` / `detect_malody_root` 的全部 7 处探测点（env 覆盖 / Steam 库 / 常见路径候选）加 `drive_root_ready` 预检——Rust 侧虽不会 panic，但不存在的盘符可快速失败、"存在但未就绪"的驱动器（读卡器/光驱）元数据查询可能阻塞数秒；同时给探测结果加 30s TTL 缓存，未配置根目录时轮询器不再每个周期（Etterna 500ms / Malody 1.5s）重打注册表 + libraryfolders.vdf + 逐候选盘符。
- `desktop/src/main.rs`：启动日志中的插件版本号从硬编码字符串改为解析 `metadata.txt`（消除版本漂移点）。
- `desktop/release.ps1`：打包版本号从硬编码 `"2.1.0"` 改为读取 `metadata.txt` 的 `Version` 字段（同一类问题：版本多来源）。

## 同类问题排查

- 全脚本 26 处 `Join-Path` 逐一审计：外部输入（候选路径/env/Steam 库根/手动输入/卸载时配置记录的根目录）共 5 处不安全，已全部加守卫；其余均 rooted 于已通过校验的游戏根目录或 `$PSScriptRoot`。注册表与文件读取本就带 try/catch 或 `-ErrorAction`，无需改动。
- Rust 侧 `is_dir` / `read_dir` / `metadata` 在不存在盘符上语义安全（返回 false/Err，不 panic），确认壳本体无 panic 点；预检的作用是快速失败与避免未就绪驱动器上的阻塞轮询。
- 全仓扫描（`desktop/src`、`bridges/`、`tools/`、`backend/`、Lua）：硬编码盘符候选仅存在于 `config.rs` 与安装器，均已覆盖。
- 已知残留：会话进行中物理拔除已选中的游戏盘仍会让后续文件操作报错退出（TOCTOU），概率极低，未处理。

## 验证

- 以必然不存在的 `Q:` 盘复现：`Join-Path 'Q:/Games/Etterna' 'Save'` 抛 `DriveNotFoundException`，加守卫后 `Test-EtternaRoot` 在 `$ErrorActionPreference = 'Stop'` 下返回 False、无崩溃。
- 真实 D: 盘机器上回归：预检返回 True、探测行为不变；UNC / 相对路径 / 空输入边界用例通过。
- 两个 ps1 经 `Language.Parser` 语法解析 0 错误；`cargo check` 通过；release.ps1 实际出包验证版本读取正确。

## 文档

- `bridges/README.md`（中/英）自动探测条目补充盘符预检说明；`docs/features/desktop-shell.md` 目录检测章节补充盘符预检与 30s 探测缓存。