### PR TITLE
feat(debug): add surface timing compare panel + unified collapsible debug page

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/debug.html
+++ b/ManiaMapAnalyser by Leo_Black/debug.html
@@ -185,6 +185,50 @@
             padding: 12px;
             background: rgba(0, 0, 0, 0.28);
         }
+
+        details {
+            margin-bottom: 12px;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 8px 12px;
+            background: rgba(0, 0, 0, 0.18);
+        }
+
+        summary {
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: inherit;
+            user-select: none;
+            padding: 2px 0;
+        }
+
+        summary:hover {
+            color: var(--text);
+        }
+
+        .module-body {
+            padding-top: 10px;
+        }
+
+        .kv {
+            display: grid;
+            grid-template-columns: max-content 1fr;
+            gap: 2px 12px;
+            font-size: 13px;
+        }
+
+        .kv dt {
+            color: var(--soft);
+        }
+
+        .kv dd {
+            margin: 0;
+            color: var(--text);
+        }
+
+        .kv dd strong {
+            color: var(--ok);
+        }
     </style>
 </head>
 
@@ -197,13 +241,25 @@
             <button id="pause-btn" type="button">Pause</button>
             <button id="clear-btn" type="button">Clear</button>
         </div>
-        <div id="estimator-debug-root"></div>
-        <pre id="payload">Waiting for websocket data...</pre>
+        <details id="module-estimator" open>
+            <summary>Estimator Compare</summary>
+            <div id="estimator-debug-root" class="module-body"></div>
+        </details>
+        <details id="module-surface">
+            <summary>Surface Timing Compare <span id="surface-version-badge" class="badge" hidden></span></summary>
+            <div id="surface-timing-root" class="module-body"></div>
+        </details>
+        <details id="module-payload">
+            <summary>Raw payload</summary>
+            <pre id="payload" class="module-body">Waiting for websocket data...</pre>
+        </details>
     </main>
 
     <script type="module">
         import WebSocketManager from "./js/app/socket.js";
         import { createEstimatorDebugPanel } from "./js/debug/estimatorDebugPanel.js";
+        import { createSurfaceTimingPanel } from "./js/debug/surfaceTimingPanel.js";
+        import { SURFACE_TIMING_MODEL } from "./js/debug/surfaceTimingCurve.js";
 
         const payloadEl = document.getElementById("payload");
         const connEl = document.getElementById("conn");
@@ -214,6 +270,48 @@
             root: document.getElementById("estimator-debug-root"),
             socketHost: "127.0.0.1:24050",
         });
+        // Surface Timing panel — real instance (S4), mounted at S5.
+        const surfacePanel = createSurfaceTimingPanel({
+            root: document.getElementById("surface-timing-root"),
+            socketHost: "127.0.0.1:24050",
+        });
+        const surfaceVersionBadge = document.getElementById("surface-version-badge");
+        surfaceVersionBadge.textContent = `v${SURFACE_TIMING_MODEL.VERSION}`;
+        surfaceVersionBadge.hidden = false;
+
+        const LAYOUT_KEY = "mma-debug-layout-v1";
+        const LAYOUT_KEYS = {
+            "module-estimator": "estimator",
+            "module-surface": "surface",
+            "module-payload": "payload",
+        };
+        const layout = { estimator: true, surface: false, payload: false };
+
+        try {
+            const saved = JSON.parse(localStorage.getItem(LAYOUT_KEY));
+            if (saved && typeof saved === "object") {
+                for (const key of Object.keys(layout)) {
+                    if (typeof saved[key] === "boolean") {
+                        layout[key] = saved[key];
+                    }
+                }
+            }
+        } catch {
+            // Missing/corrupt stored layout: keep defaults.
+        }
+
+        for (const [id, key] of Object.entries(LAYOUT_KEYS)) {
+            const details = document.getElementById(id);
+            details.open = layout[key];
+            details.addEventListener("toggle", () => {
+                layout[key] = details.open;
+                try {
+                    localStorage.setItem(LAYOUT_KEY, JSON.stringify(layout));
+                } catch {
+                    // Storage unavailable: layout persistence is best-effort.
+                }
+            });
+        }
 
         let paused = false;
         let messageCount = 0;
@@ -243,13 +341,13 @@
 
         socket.api_v2((data) => {
             setConnectionState("ok", "Connected");
-            estimatorPanel.handleSocketPayload(data);
-            if (paused) {
-                return;
+            if (layout.estimator) estimatorPanel.handleSocketPayload(data);
+            if (layout.surface && typeof surfacePanel?.handleSocketPayload === "function") surfacePanel.handleSocketPayload(data);
+            if (layout.payload && !paused) {
+                messageCount += 1;
+                updateCount();
+                payloadEl.textContent = JSON.stringify(data, null, 2);
             }
-            messageCount += 1;
-            updateCount();
-            payloadEl.textContent = JSON.stringify(data, null, 2);
         });
 
         window.addEventListener("error", (event) => {

--- a/ManiaMapAnalyser by Leo_Black/debug.html
+++ b/ManiaMapAnalyser by Leo_Black/debug.html
@@ -229,6 +229,93 @@
         .kv dd strong {
             color: var(--ok);
         }
+
+        .surface-map-info {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            flex-wrap: wrap;
+            font-size: 13px;
+            padding: 8px 0 4px;
+            border-bottom: 1px solid var(--border);
+            margin-bottom: 10px;
+        }
+
+        .surface-map-info .badge {
+            font-size: 12px;
+        }
+
+        .surface-dim {
+            opacity: 0.55;
+        }
+
+        .surface-hero {
+            display: flex;
+            gap: 10px;
+            align-items: stretch;
+            margin: 10px 0 4px;
+        }
+
+        .surface-pp-cell {
+            flex: 1;
+            min-width: 0;
+            text-align: center;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 8px 6px;
+            background: rgba(0, 0, 0, 0.18);
+        }
+
+        .surface-pp-value {
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text);
+            white-space: nowrap;
+        }
+
+        .surface-pp-label {
+            font-size: 11px;
+            color: var(--soft);
+            margin-top: 2px;
+        }
+
+        .surface-hero-pp {
+            border-color: var(--ok);
+        }
+
+        .surface-hero-pp .surface-pp-value {
+            color: var(--ok);
+            font-size: 26px;
+        }
+
+        .surface-hero-delta {
+            font-size: 12px;
+            color: var(--warn);
+            text-align: right;
+            margin-bottom: 6px;
+        }
+
+        .surface-group {
+            margin: 10px 0;
+            padding: 8px 10px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            background: rgba(0, 0, 0, 0.12);
+        }
+
+        .surface-group-title {
+            font-size: 12px;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--ok);
+            margin-bottom: 6px;
+            border-bottom: 1px dashed var(--border);
+            padding-bottom: 4px;
+        }
+
+        .surface-footnote {
+            margin-top: 8px;
+        }
     </style>
 </head>
 

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
@@ -22,8 +22,8 @@ import {
  * xxy constants used by sunny.rs.
  */
 export const SURFACE_TIMING_MODEL = Object.freeze({
-    /** Upstream commit the whole surface timing port tracks: rosu-pp @ 595541d. */
-    VERSION: "595541d",
+    /** Upstream commit the whole surface timing port tracks: rosu-pp @ 529e612. */
+    VERSION: "529e612",
     // ErrorModel production defaults (sunny_accuracy.rs DEFAULT_* / MEASURED_*;
     // sigma_ref & co. are `#[cfg(test)]` there and reserved here).
     ERROR_MODEL: Object.freeze({
@@ -58,9 +58,11 @@ export const SURFACE_TIMING_MODEL = Object.freeze({
     }),
     /** sunny_accuracy.rs `TIMING_CORE_SIGMA` (replay-measured, reserved). */
     TIMING_CORE_SIGMA: 8.5,
-    /** sunny_accuracy.rs `TIMING_BASELINE_SIGMA` — used by BOTH map-factor
-     * (compute_timing_pp_with_units) and score adjustment
-     * (compute_per_judgement_timing_adjustment) since ad3fbe1. */
+    /** sunny_accuracy.rs `TIMING_BASELINE_SIGMA` (11.0). Since a44a63 (529e612)
+     * the sigma actually fed into expected counts is SR-scaled:
+     * `base_timing_sigma = TIMING_BASELINE_SIGMA * sr_to_base_sigma_scale(SR)`,
+     * applied to BOTH map-factor expected accuracy (compute_timing_pp_with_units)
+     * and score adjustment (compute_per_judgement_timing_adjustment L930). */
     TIMING_BASELINE_SIGMA: 11.0,
     /** retired: score adjustment now uses TIMING_BASELINE_SIGMA (=11.0); kept
      * for reference to the pre-ad3fbe1 local 12.0. */
@@ -287,6 +289,20 @@ export function sigmaScaleFromDifficulty(difficulty) {
 }
 
 /**
+ * Map-level sigma scaling from SR (sunny_accuracy.rs `sr_to_base_sigma_scale`,
+ * @ a44a63 / 529e612). Converts the map's star rating into a multiplier for
+ * TIMING_BASELINE_SIGMA — same power-law as sigma_scale_from_difficulty_ratio
+ * but operating on SR instead of local difficulty; applied once per map
+ * (`base_timing_sigma = TIMING_BASELINE_SIGMA * sr_to_base_sigma_scale(SR)`),
+ * not per operation.
+ * @param {number} sr
+ * @returns {number}
+ */
+export function srToBaseSigmaScale(sr) {
+    return sigmaScaleFromDifficultyRatio(sr, SURFACE_TIMING_MODEL.TIMING_DIFFICULTY_REFERENCE);
+}
+
+/**
  * `count` judgements sharing one local difficulty (sunny_accuracy.rs
  * `JudgementUnit::repeated`, @ 595541d). Since 595541d the sigma scale carries
  * the fixed-spread difficulty factor `sigma_scale_from_difficulty(difficulty)`.
@@ -472,9 +488,10 @@ export function buildJudgementUnits({ stars, unitsTotal, nObjects, nLongNotes, l
 
 /**
  * Map-based timing difficulty factor (sunny.rs `compute_map_timing_difficulty`,
- * L818-874, @ ad3fbe1). A PP multiplier in ~[0.75, 1.15] reflecting the map's
- * inherent accuracy difficulty: window tightness via expected accuracy at
- * baseline sigma. **The LN structural boost was removed upstream** (commented
+ * L833-889, @ ad3fbe1). A PP multiplier in ~[0.75, 1.15] reflecting the map's
+ * inherent accuracy difficulty: window tightness via expected accuracy at the
+ * SR-scaled baseline sigma (since a44a63 the caller computes `expectedAcc`
+ * with `base_timing_sigma`). **The LN structural boost was removed upstream** (commented
  * out in ad3fbe1), so `lnFactor` is always 1.0; nLongNotes/lnBuckets are kept
  * in the signature only for call-site stability.
  * @param {{expectedAcc: number, nLongNotes?: number, nObjects?: number, lnBuckets?: number[]}} args
@@ -491,21 +508,23 @@ export function computeMapTimingFactor({ expectedAcc, lnBuckets = [], nLongNotes
 
 /**
  * Score-based timing adjustment from per-judgement loss analysis (sunny.rs
- * `compute_per_judgement_timing_adjustment`, L896-980, @ ad3fbe1).
- * Player distribution is compared against expected counts at
- * TIMING_BASELINE_SIGMA (11.0 since ad3fbe1; previously a local 12.0);
+ * `compute_per_judgement_timing_adjustment`, L912-995, @ 529e612).
+ * Player distribution is compared against expected counts at the SR-scaled
+ * `baseTimingSigma` (since a44a63; = TIMING_BASELINE_SIGMA [11.0] ×
+ * sr_to_base_sigma_scale(SR); previously a fixed 11.0);
  * asymmetric PENALTY_WEIGHTS weight misses most. Better than expected
  * rewards > 1.0, worse penalises < 1.0, clamp [0.75, 1.15].
- * @param {{playerCounts: number[], units: object[], windows: object, hitTotal: number, model: object}} args
+ * @param {{playerCounts: number[], units: object[], windows: object, hitTotal: number, model: object, baseTimingSigma?: number}} args
  * @returns {{multiplier: number, playerLoss: number, expectedLoss: number, lossDiff: number, expectedArr: number[]}}
  */
-export function computeScoreAdjustment({ playerCounts, units, windows, hitTotal, model }) {
+export function computeScoreAdjustment({ playerCounts, units, windows, hitTotal, model, baseTimingSigma }) {
     const M = SURFACE_TIMING_MODEL;
     if (hitTotal <= 0) {
         return { multiplier: 1, playerLoss: 0, expectedLoss: 0, lossDiff: 0, expectedArr: [0, 0, 0, 0, 0, 0] };
     }
-    // ad3fbe1: expected uses TIMING_BASELINE_SIGMA, the same 11.0 as SR phase.
-    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, M.TIMING_BASELINE_SIGMA);
+    // a44a63 (529e612): expected uses the SR-scaled base_timing_sigma; falls
+    // back to the plain 11.0 baseline when no SR-scaled value is supplied.
+    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, baseTimingSigma ?? M.TIMING_BASELINE_SIGMA);
     let totalPlayerLoss = 0;
     let totalExpectedLoss = 0;
     for (let i = 0; i < 6; i += 1) {

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
@@ -22,8 +22,8 @@ import {
  * xxy constants used by sunny.rs.
  */
 export const SURFACE_TIMING_MODEL = Object.freeze({
-    /** Upstream commit the whole surface timing port tracks: rosu-pp @ 529e612. */
-    VERSION: "529e612",
+    /** Upstream commit the whole surface timing port tracks: rosu-pp @ dd5eeb5. */
+    VERSION: "dd5eeb5",
     // ErrorModel production defaults (sunny_accuracy.rs DEFAULT_* / MEASURED_*;
     // sigma_ref & co. are `#[cfg(test)]` there and reserved here).
     ERROR_MODEL: Object.freeze({
@@ -58,12 +58,18 @@ export const SURFACE_TIMING_MODEL = Object.freeze({
     }),
     /** sunny_accuracy.rs `TIMING_CORE_SIGMA` (replay-measured, reserved). */
     TIMING_CORE_SIGMA: 8.5,
-    /** sunny_accuracy.rs `TIMING_BASELINE_SIGMA` (11.0). Since a44a63 (529e612)
-     * the sigma actually fed into expected counts is SR-scaled:
+    /** sunny_accuracy.rs `TIMING_BASELINE_SIGMA` (11.0). Since a44a63 the sigma
+     * actually fed into expected counts is SR-scaled:
      * `base_timing_sigma = TIMING_BASELINE_SIGMA * sr_to_base_sigma_scale(SR)`,
      * applied to BOTH map-factor expected accuracy (compute_timing_pp_with_units)
      * and score adjustment (compute_per_judgement_timing_adjustment L930). */
     TIMING_BASELINE_SIGMA: 11.0,
+    /** sunny_accuracy.rs SR-level sigma scaling constants (34fde58a / dd5eeb5):
+     * `sr_to_base_sigma_scale` uses its own neutral SR reference (8★), separate
+     * from the per-note difficulty reference (TIMING_DIFFICULTY_REFERENCE 6.0). */
+    SR_REFERENCE: 8.0,
+    SR_SCALING_FLOOR: 0.6,
+    SR_SCALING_EXPONENT: 1.7,
     /** retired: score adjustment now uses TIMING_BASELINE_SIGMA (=11.0); kept
      * for reference to the pre-ad3fbe1 local 12.0. */
     SCORE_ADJ_SIGMA: 12.0,
@@ -290,16 +296,23 @@ export function sigmaScaleFromDifficulty(difficulty) {
 
 /**
  * Map-level sigma scaling from SR (sunny_accuracy.rs `sr_to_base_sigma_scale`,
- * @ a44a63 / 529e612). Converts the map's star rating into a multiplier for
- * TIMING_BASELINE_SIGMA — same power-law as sigma_scale_from_difficulty_ratio
- * but operating on SR instead of local difficulty; applied once per map
- * (`base_timing_sigma = TIMING_BASELINE_SIGMA * sr_to_base_sigma_scale(SR)`),
- * not per operation.
+ * @ 34fde58a / dd5eeb5). Converts the map's star rating into a multiplier for
+ * TIMING_BASELINE_SIGMA — its own power-law with a separate neutral reference:
+ * `((sr.max(0) + SR_SCALING_FLOOR) / (SR_REFERENCE + SR_SCALING_FLOOR))^SR_SCALING_EXPONENT`
+ * i.e. ((SR + 0.6) / 8.6)^1.7. 8★ is the neutral point (scale 1, base sigma
+ * 11ms); below 8★ expects tighter timing (smaller sigma), above 8★ looser.
+ * NOT the per-note gauge (which keeps TIMING_DIFFICULTY_REFERENCE = 6.0).
+ * Applied once per map (`base_timing_sigma = TIMING_BASELINE_SIGMA *
+ * sr_to_base_sigma_scale(SR)`), not per operation.
  * @param {number} sr
  * @returns {number}
  */
 export function srToBaseSigmaScale(sr) {
-    return sigmaScaleFromDifficultyRatio(sr, SURFACE_TIMING_MODEL.TIMING_DIFFICULTY_REFERENCE);
+    const M = SURFACE_TIMING_MODEL;
+    const numerator = Math.max(sr, 0) + M.SR_SCALING_FLOOR;
+    const denominator = M.SR_REFERENCE + M.SR_SCALING_FLOOR;
+    const scale = Math.pow(numerator / denominator, M.SR_SCALING_EXPONENT);
+    return Number.isFinite(scale) && scale > 0 ? scale : 1;
 }
 
 /**

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
@@ -1,0 +1,524 @@
+// Surface timing judgement curves, units, and PP composition.
+//
+// Ported from rosu-pp mania-surface-map-timing-difficulty @ 328e339
+// (`src/mania/sunny_accuracy.rs` for curves/units, `src/mania/sunny.rs` for
+// the two-factor + xxy PP combination). Pure, DOM-free module: runs unchanged
+// in the tosu overlay (browser) and in Node (benchmark smoke). Imports the
+// window bands from ./surfaceTimingWindows.js (S2) via explicit `.js`
+// extension, which the esm-loader and both runtime environments require.
+
+import {
+    getBand,
+    JUDGEMENT_NAMES,
+} from "./surfaceTimingWindows.js";
+
+/**
+ * Frozen model constants for the surface timing pipeline.
+ *
+ * `ERROR_MODEL` mirrors `ErrorModel::default()` in sunny_accuracy.rs; the
+ * sigma_ref / skill_exponent / difficulty_floor / sigma_floor fields are
+ * `#[cfg(test)]` in upstream (test-only) and kept here as reserved constants.
+ * The remaining scalars are the production defaults plus the two-factor and
+ * xxy constants used by sunny.rs.
+ */
+export const SURFACE_TIMING_MODEL = Object.freeze({
+    /** Upstream commit the whole surface timing port tracks: rosu-pp @ 328e339. */
+    VERSION: "328e339",
+    // ErrorModel production defaults (sunny_accuracy.rs DEFAULT_* / MEASURED_*;
+    // sigma_ref & co. are `#[cfg(test)]` there and reserved here).
+    ERROR_MODEL: Object.freeze({
+        /** sunny_accuracy.rs `DEFAULT_SIGMA_REF` (test-only upstream). */
+        sigmaRef: 18.0,
+        /** sunny_accuracy.rs `DEFAULT_SKILL_EXPONENT` (test-only upstream). */
+        skillExponent: 1.7,
+        /** sunny_accuracy.rs `DEFAULT_DIFFICULTY_FLOOR` (test-only upstream). */
+        difficultyFloor: 0.6,
+        /** sunny_accuracy.rs `ErrorModel::default` sigma_floor (test-only upstream). */
+        sigmaFloor: 0.0,
+        /** sunny_accuracy.rs `DEFAULT_LAPSE_WEIGHT`. */
+        lapseWeight: 0.0296,
+        /** sunny_accuracy.rs `DEFAULT_LAPSE_RATIO`. */
+        lapseRatio: 3.339,
+        /** sunny_accuracy.rs `ErrorModel::default` release_sigma_ratio. */
+        releaseSigmaRatio: 1.0,
+        /** sunny_accuracy.rs `ErrorModel::default` short_hold_penalty. */
+        shortHoldPenalty: 0.0,
+        /** sunny_accuracy.rs `DEFAULT_SHORT_HOLD_SCALE`. */
+        shortHoldScale: 120.0,
+        /** sunny_accuracy.rs `ErrorModel::default` slip_rate. */
+        slipRate: 0.0,
+        /** sunny_accuracy.rs `DEFAULT_RELEASE_MEAN_OFFSET` (unfitted starting value). */
+        releaseMeanOffset: 8.0,
+        /** sunny_accuracy.rs `MEASURED_RECOVERY_OFFSET`. */
+        recoveryOffset: 20.425,
+        /** sunny_accuracy.rs `MEASURED_RECOVERY_TAU`. */
+        recoveryTau: 116.68,
+        /** sunny_accuracy.rs `MEASURED_ANTICIPATION_OFFSET`. */
+        anticipationOffset: -2.517,
+    }),
+    /** sunny_accuracy.rs `TIMING_CORE_SIGMA` (replay-measured, reserved). */
+    TIMING_CORE_SIGMA: 8.5,
+    /** sunny_accuracy.rs `TIMING_BASELINE_SIGMA` — map-factor side (compute_timing_pp_with_units). */
+    TIMING_BASELINE_SIGMA: 11.0,
+    /** sunny.rs `compute_per_judgement_timing_adjustment` BASELINE_SIGMA local. */
+    SCORE_ADJ_SIGMA: 12.0,
+    /** sunny.rs `compute_map_timing_difficulty` BASELINE_ACC. */
+    BASELINE_ACC: 0.994,
+    /** sunny.rs `compute_map_timing_difficulty` ACC_SCALE. */
+    ACC_SCALE: 15.0,
+    /** sunny.rs `compute_map_timing_difficulty` ln_factor boost. */
+    LN_FACTOR_BOOST: 1.03,
+    /** sunny.rs `compute_map_timing_difficulty` LN ratio gate (0.3). */
+    LN_RATIO_GATE: 0.3,
+    /** sunny.rs `compute_map_timing_difficulty` LN boost ratio gate (0.5). */
+    LN_RATIO_BOOST_GATE: 0.5,
+    /** sunny.rs `compute_map_timing_difficulty` LN bucket-count gate (3). */
+    LN_BUCKET_GATE: 3,
+    /** sunny.rs `compute_map_timing_difficulty` combined clamp. */
+    MAP_CLAMP: [0.85, 1.15],
+    /** sunny.rs `compute_per_judgement_timing_adjustment` multiplier clamp. */
+    SCORE_CLAMP: [0.85, 1.15],
+    /** sunny.rs `compute_per_judgement_timing_adjustment` SCALE. */
+    LOSS_SCALE: 5.0,
+    /** sunny_accuracy.rs `LN_DURATION_BUCKETS`. */
+    LN_DURATION_BUCKETS: 8,
+    /** sunny.rs `LN_DURATION_EDGES`. */
+    LN_DURATION_EDGES: [45, 70, 100, 145, 210, 320, 550],
+    /** sunny.rs `LN_DURATION_REPRESENTATIVES`. */
+    LN_DURATION_REPRESENTATIVES: [34, 56, 84, 120, 175, 259, 419, 900],
+    /** sunny.rs `compute_per_judgement_timing_adjustment` ACC_WEIGHTS (305-based). */
+    ACC_WEIGHTS: [1, 300 / 305, 200 / 305, 100 / 305, 50 / 305, 0],
+    /** sunny.rs `compute_per_judgement_timing_adjustment` PENALTY_WEIGHTS (uniform). */
+    PENALTY_WEIGHTS: [1, 1, 1, 1, 1, 1],
+    /** sunny.rs `calculate_performance_inner` xxy pattern coefficient 9.8. */
+    PATTERN_MULTIPLIER: 9.8,
+    /** sunny.rs `calculate_performance_inner` pattern difficulty floor (0.2). */
+    PATTERN_FLOOR: 0.2,
+});
+
+/**
+ * Complementary error function, Numerical Recipes rational approximation
+ * (sunny_accuracy.rs `erfc`, L846-862). Fractional error below 1.2e-7
+ * everywhere, including deep in the tail.
+ * @param {number} x
+ * @returns {number}
+ */
+export function erfc(x) {
+    const z = Math.abs(x);
+    const t = 1 / (1 + 0.5 * z);
+    const poly =
+        -1.26551223 +
+        t * (1.00002368 +
+        t * (0.37409196 +
+        t * (0.09678418 +
+        t * (-0.18628806 +
+        t * (0.27886807 +
+        t * (-1.13520398 +
+        t * (1.48851587 + t * (-0.82215223 + t * 0.17087277))))))));
+    const value = t * Math.exp(-z * z + poly);
+    return x >= 0 ? value : 2 - value;
+}
+
+/**
+ * Probability that a zero-mean normal with sd `sigma` exceeds `x` (not in
+ * absolute value); `P(Z > x)` (sunny_accuracy.rs `one_sided_tail`, L812-838).
+ * @param {number} x
+ * @param {number} sigma
+ * @returns {number}
+ */
+export function oneSidedTail(x, sigma) {
+    if (x === Infinity || x === -Infinity) {
+        return x > 0 ? 0 : 1;
+    }
+    if (sigma === Infinity || sigma === -Infinity) {
+        return 0.5;
+    }
+    if (Number.isNaN(sigma) || sigma <= 0) {
+        return x > 0 ? 0 : (x < 0 ? 1 : 0.5);
+    }
+    return 0.5 * erfc(x / (sigma * Math.SQRT2));
+}
+
+/**
+ * Probability that a zero-mean normal with sd `sigma` produces an absolute
+ * error greater than `bound` (sunny_accuracy.rs `tail`, L771-791).
+ * @param {number} bound
+ * @param {number} sigma
+ * @returns {number}
+ */
+export function tail(bound, sigma) {
+    if (bound <= 0) {
+        return 1;
+    }
+    if (bound === Infinity) {
+        return 0;
+    }
+    if (sigma === Infinity || sigma === -Infinity) {
+        return 1;
+    }
+    if (Number.isNaN(sigma) || sigma <= 0) {
+        return 0;
+    }
+    return erfc(bound / (sigma * Math.SQRT2));
+}
+
+/**
+ * Two-component mixture exceedance (sunny_accuracy.rs `ErrorModel::exceedance`,
+ * L663-675). The lapse component is `lapse_ratio` times as wide as the core.
+ * @param {number} bound
+ * @param {number} sigma
+ * @param {{lapseWeight: number, lapseRatio: number}} model
+ * @returns {number}
+ */
+export function exceedance(bound, sigma, model) {
+    const weight = Math.min(1, Math.max(0, model.lapseWeight));
+    if (weight <= 0) {
+        return tail(bound, sigma);
+    }
+    const ratio = Math.max(model.lapseRatio, 1);
+    return (1 - weight) * tail(bound, sigma) + weight * tail(bound, sigma * ratio);
+}
+
+/**
+ * Exceedance for a distribution shifted by mean `mu` (sunny_accuracy.rs
+ * `ErrorModel::exceedance_with_offset`, L703-727). At `mu === 0` short-circuits
+ * to {@link exceedance} bit-for-bit, exactly like upstream.
+ * @param {number} bound
+ * @param {number} sigma
+ * @param {number} mu
+ * @param {{lapseWeight: number, lapseRatio: number}} model
+ * @returns {number}
+ */
+export function exceedanceWithOffset(bound, sigma, mu, model) {
+    if (mu === 0) {
+        return exceedance(bound, sigma, model);
+    }
+    if (bound <= 0) {
+        return 1;
+    }
+    const twoSided = (s) => oneSidedTail(bound - mu, s) + oneSidedTail(bound + mu, s);
+    const weight = Math.min(1, Math.max(0, model.lapseWeight));
+    if (weight <= 0) {
+        return twoSided(sigma);
+    }
+    const ratio = Math.max(model.lapseRatio, 1);
+    return (1 - weight) * twoSided(sigma) + weight * twoSided(sigma * ratio);
+}
+
+/**
+ * Judgement probabilities for an explicit timing spread (sunny_accuracy.rs
+ * `judgement_probabilities_with_sigma`, L925-970). Bands come from the
+ * windows module via {@link getBand}; entries sum to 1 (minus any slip rate).
+ * @param {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} windows finalized windows
+ * @param {{lapseWeight: number, lapseRatio: number, slipRate: number}} model
+ * @param {number} sigma timing spread in ms
+ * @param {number} [mu=0] mean offset in ms
+ * @returns {number[]} length-6 probabilities in JUDGEMENT_NAMES order
+ */
+export function judgementProbabilitiesWithSigma(windows, model, sigma, mu) {
+    const probabilities = new Array(6).fill(0);
+    let remaining = 1.0;
+    JUDGEMENT_NAMES.forEach((name, i) => {
+        const upper = getBand(windows, name)[1];
+        const outside = Math.min(remaining, exceedanceWithOffset(upper, sigma, mu, model));
+        probabilities[i] = remaining - outside;
+        remaining = outside;
+    });
+    const slip = Math.min(1, Math.max(0, model.slipRate));
+    if (slip > 0) {
+        for (let i = 0; i < 6; i += 1) {
+            probabilities[i] *= 1 - slip;
+        }
+        probabilities[5] += slip;
+    }
+    return probabilities;
+}
+
+/**
+ * A judgement unit: `weight` judgements at local difficulty `difficulty`,
+ * spread scaled by `sigmaScale`, error mean shifted by `meanOffset` (+
+ * `fadingMeanOffset` at full spread). Mirrors sunny_accuracy.rs
+ * `JudgementUnit`; returned as a plain object.
+ * @param {{difficulty: number, weight: number, sigmaScale?: number, meanOffset?: number, fadingMeanOffset?: number}} fields
+ * @returns {{difficulty: number, weight: number, sigmaScale: number, meanOffset: number, fadingMeanOffset: number}}
+ */
+export function makeUnit({ difficulty, weight, sigmaScale = 1, meanOffset = 0, fadingMeanOffset = 0 }) {
+    return { difficulty, weight, sigmaScale, meanOffset, fadingMeanOffset };
+}
+
+/**
+ * `count` judgements sharing one local difficulty (sunny_accuracy.rs
+ * `JudgementUnit::repeated`, L1211).
+ * @param {number} difficulty
+ * @param {number} count
+ * @returns {object}
+ */
+export function makeRepeatedUnit(difficulty, count) {
+    return makeUnit({ difficulty, weight: count });
+}
+
+/**
+ * Timing-spread multiplier for a ScoreV1 long note whose release is
+ * `releaseRatio` times as wide as its press: `sqrt(1 + ratio^2)`
+ * (sunny_accuracy.rs `ln_sigma_scale`, L1123-1131). At ratio 1 this is
+ * `sqrt(2)`.
+ * @param {number} releaseRatio
+ * @returns {number}
+ */
+export function lnSigmaScale(releaseRatio) {
+    if (!Number.isFinite(releaseRatio)) {
+        return Math.SQRT2;
+    }
+    const ratio = Math.max(releaseRatio, 1);
+    return Math.sqrt(1 + ratio * ratio);
+}
+
+/**
+ * How much wider a release lands than a press for a hold of `durationMs`
+ * (sunny_accuracy.rs `release_ratio_for_duration`, L1163-1187).
+ * @param {{releaseSigmaRatio: number, shortHoldPenalty: number, shortHoldScale: number}} model
+ * @param {number} durationMs
+ * @returns {number}
+ */
+export function releaseRatioForDuration(model, durationMs) {
+    const base = Math.max(model.releaseSigmaRatio, 1);
+    if (!Number.isFinite(durationMs) || durationMs <= 0) {
+        return base * (1 + Math.max(model.shortHoldPenalty, 0));
+    }
+    const penalty = Math.max(model.shortHoldPenalty, 0);
+    if (penalty <= 0) {
+        return base;
+    }
+    const scale = model.shortHoldScale;
+    if (!Number.isFinite(scale) || scale <= 0) {
+        return base;
+    }
+    return base * (1 + penalty * Math.exp(-durationMs / scale));
+}
+
+/**
+ * `lnSigmaScale(releaseRatioForDuration(...))` (sunny_accuracy.rs
+ * `ln_sigma_scale_for_duration`, L1194).
+ * @param {{releaseSigmaRatio: number, shortHoldPenalty: number, shortHoldScale: number}} model
+ * @param {number} durationMs
+ * @returns {number}
+ */
+export function lnSigmaScaleForDuration(model, durationMs) {
+    return lnSigmaScale(releaseRatioForDuration(model, durationMs));
+}
+
+/**
+ * `count` ScoreV1 long-note judgements of local difficulty `difficulty`,
+ * widened by the release-asymmetry spread and shifted by the release mean
+ * offset (sunny_accuracy.rs `JudgementUnit::long_note`, L1229-1237).
+ * @param {number} difficulty
+ * @param {number} count
+ * @param {object} model ErrorModel (uses releaseSigmaRatio / shortHoldPenalty / shortHoldScale / releaseMeanOffset)
+ * @param {number} durationMs hold length in map time
+ * @returns {object}
+ */
+export function makeLongNoteUnit(difficulty, count, model, durationMs) {
+    return makeUnit({
+        difficulty,
+        weight: count,
+        sigmaScale: lnSigmaScaleForDuration(model, durationMs),
+        meanOffset: model.releaseMeanOffset,
+        fadingMeanOffset: 0,
+    });
+}
+
+/**
+ * Expected judgement counts over a unit list at a supplied core timing spread
+ * (sunny_accuracy.rs `expected_counts_at_core_sigma`, L1286-1313). `coreSigma`
+ * must be finite and > 0, mirroring the upstream assert.
+ * @param {object[]} units judgement units
+ * @param {object} windows finalized windows
+ * @param {object} model ErrorModel
+ * @param {number} coreSigma core timing spread in ms
+ * @returns {number[]} length-6 totals in JUDGEMENT_NAMES order
+ */
+export function expectedCountsAtCoreSigma(units, windows, model, coreSigma) {
+    if (!Number.isFinite(coreSigma) || coreSigma <= 0) {
+        throw new Error("core timing spread must be finite and positive");
+    }
+    const totals = new Array(6).fill(0);
+    for (const unit of units) {
+        const sigma = coreSigma * unit.sigmaScale;
+        const probs = judgementProbabilitiesWithSigma(windows, model, sigma, unit.meanOffset + unit.fadingMeanOffset);
+        for (let i = 0; i < 6; i += 1) {
+            totals[i] += unit.weight * probs[i];
+        }
+    }
+    return totals;
+}
+
+/**
+ * 305-weighted accuracy implied by a counts vector (sunny_accuracy.rs
+ * `ExpectedCounts::custom_accuracy`, L993-1010).
+ * @param {number[]} countsOrExpected length-6 counts in JUDGEMENT_NAMES order
+ * @returns {number} 0..1
+ */
+export function expectedCountsCustomAccuracy(countsOrExpected) {
+    const total = countsOrExpected.reduce((sum, c) => sum + c, 0);
+    if (total <= 0) {
+        return 0;
+    }
+    const weights = [305, 300, 200, 100, 50, 0];
+    let weighted = 0;
+    for (let i = 0; i < 6; i += 1) {
+        weighted += countsOrExpected[i] * weights[i];
+    }
+    return weighted / (total * 305);
+}
+
+/**
+ * Bin long-note durations into the 8 LN_DURATION_EDGES buckets
+ * (sunny.rs `ln_duration_bucket` + `ln_duration_histogram`, L74/L111).
+ * Non-positive durations are skipped; durations past the last edge go to the
+ * open top bucket (index 7).
+ * @param {number[]} longNoteDurationsMs
+ * @returns {number[]} length-8 bucket counts
+ */
+export function buildLnDurationBuckets(longNoteDurationsMs) {
+    const buckets = new Array(SURFACE_TIMING_MODEL.LN_DURATION_BUCKETS).fill(0);
+    for (const duration of longNoteDurationsMs) {
+        if (duration <= 0) {
+            continue;
+        }
+        const bin = SURFACE_TIMING_MODEL.LN_DURATION_EDGES.findIndex((edge) => duration < edge);
+        buckets[bin === -1 ? SURFACE_TIMING_MODEL.LN_DURATION_BUCKETS - 1 : bin] += 1;
+    }
+    return buckets;
+}
+
+/**
+ * Build the judgement-unit list for a map/score (sunny.rs `judgement_units`
+ * L1298-1381 as finalised by the plan). `unitsTotal` is an explicit input —
+ * callers pass `classic ? nObjects : nObjects + nLongNotes`. Under V2
+ * (`classic: false`) or for pure-rice maps a single uniform repeated unit is
+ * returned; under V1 with long notes the LN buckets each become a long-note
+ * unit at their representative duration, and the remainder becomes a rice unit.
+ * @param {{stars: number, unitsTotal: number, nObjects: number, nLongNotes: number, lnBuckets: number[], classic: boolean, model: object, options?: {unitsOverride?: object[]}}} args
+ * @returns {object[]} judgement units
+ */
+export function buildJudgementUnits({ stars, unitsTotal, nObjects, nLongNotes, lnBuckets, classic, model, options = {} }) {
+    if (options.unitsOverride) {
+        return options.unitsOverride;
+    }
+    const uniform = [makeRepeatedUnit(stars, unitsTotal)];
+    if (!classic || nLongNotes === 0 || nObjects === 0) {
+        return uniform;
+    }
+    const perObject = unitsTotal / nObjects;
+    const units = [];
+    let lnTotal = 0;
+    for (let bin = 0; bin < SURFACE_TIMING_MODEL.LN_DURATION_BUCKETS; bin += 1) {
+        const count = lnBuckets[bin];
+        if (count > 0) {
+            const weight = count * perObject;
+            lnTotal += weight;
+            units.push(makeLongNoteUnit(stars, weight, model, SURFACE_TIMING_MODEL.LN_DURATION_REPRESENTATIVES[bin]));
+        }
+    }
+    const rice = Math.max(unitsTotal - lnTotal, 0);
+    if (rice > 0) {
+        units.push(makeRepeatedUnit(stars, rice));
+    }
+    return units.length > 0 ? units : uniform;
+}
+
+/**
+ * Map-based timing difficulty factor (sunny.rs `compute_map_timing_difficulty`,
+ * L818-873). A PP multiplier in ~[0.85, 1.15] reflecting the map's inherent
+ * accuracy difficulty: window tightness via expected accuracy at baseline
+ * sigma, plus an LN boost for varied-duration high-LN maps.
+ * @param {{expectedAcc: number, nLongNotes: number, nObjects: number, lnBuckets: number[]}} args
+ * @returns {{factor: number, windowFactor: number, lnFactor: number, expectedAcc: number}}
+ */
+export function computeMapTimingFactor({ expectedAcc, nLongNotes, nObjects, lnBuckets }) {
+    const M = SURFACE_TIMING_MODEL;
+    const windowFactor = 1 + (M.BASELINE_ACC - expectedAcc) * M.ACC_SCALE;
+    const lnRatio = nObjects > 0 ? nLongNotes / nObjects : 0;
+    let lnFactor = 1.0;
+    if (lnRatio > M.LN_RATIO_GATE && nLongNotes > 0) {
+        const bucketsUsed = lnBuckets.filter((c) => c > 0).length;
+        if (bucketsUsed >= M.LN_BUCKET_GATE && lnRatio > M.LN_RATIO_BOOST_GATE) {
+            lnFactor = M.LN_FACTOR_BOOST;
+        }
+    }
+    const factor = Math.min(M.MAP_CLAMP[1], Math.max(M.MAP_CLAMP[0], windowFactor * lnFactor));
+    return { factor, windowFactor, lnFactor, expectedAcc };
+}
+
+/**
+ * Score-based timing adjustment from per-judgement loss analysis (sunny.rs
+ * `compute_per_judgement_timing_adjustment`, L896-978). Player distribution is
+ * compared against expected counts at SCORE_ADJ_SIGMA; better than expected
+ * rewards > 1.0, worse penalises < 1.0.
+ * @param {{playerCounts: number[], units: object[], windows: object, hitTotal: number, model: object}} args
+ * @returns {{multiplier: number, playerLoss: number, expectedLoss: number, lossDiff: number, expectedArr: number[]}}
+ */
+export function computeScoreAdjustment({ playerCounts, units, windows, hitTotal, model }) {
+    const M = SURFACE_TIMING_MODEL;
+    if (hitTotal <= 0) {
+        return { multiplier: 1, playerLoss: 0, expectedLoss: 0, lossDiff: 0, expectedArr: [0, 0, 0, 0, 0, 0] };
+    }
+    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, M.SCORE_ADJ_SIGMA);
+    let totalPlayerLoss = 0;
+    let totalExpectedLoss = 0;
+    for (let i = 0; i < 6; i += 1) {
+        const lossPerHit = 1 - M.ACC_WEIGHTS[i];
+        const playerLoss = (playerCounts[i] / hitTotal) * lossPerHit;
+        const expectedLoss = (expectedArr[i] / hitTotal) * lossPerHit;
+        totalPlayerLoss += playerLoss * M.PENALTY_WEIGHTS[i];
+        totalExpectedLoss += expectedLoss * M.PENALTY_WEIGHTS[i];
+    }
+    const lossDiff = totalPlayerLoss - totalExpectedLoss;
+    const multiplier = Math.min(M.SCORE_CLAMP[1], Math.max(M.SCORE_CLAMP[0], 1 - lossDiff * M.LOSS_SCALE));
+    return { multiplier, playerLoss: totalPlayerLoss, expectedLoss: totalExpectedLoss, lossDiff, expectedArr };
+}
+
+/**
+ * Full surface PP composition (sunny.rs `calculate_performance_inner`
+ * L992-1103 plus the xxy_* helpers). Pattern difficulty follows the xxy
+ * formulation; timing difficulty multiplies it by `mapFactor * scoreAdj`;
+ * `noFail` applies the 0.75 normalize_for_human_reference factor to the final
+ * pp. All returned fields are numbers.
+ * @param {{stars: number, variety: number, accScalar: number, nObjects: number, scoreAccuracy: number, mapFactor: number, scoreAdj: number, noFail?: boolean}} args
+ * @returns {object} full pp breakdown
+ */
+export function computeSurfacePp({ stars, variety, accScalar, nObjects, scoreAccuracy, mapFactor, scoreAdj, noFail = false }) {
+    const M = SURFACE_TIMING_MODEL;
+    const proportion = scoreAccuracy > 0.8
+        ? 4.5 * (scoreAccuracy - 0.8) / Math.pow(100 * (1 - scoreAccuracy) + Math.pow(0.9, 20), 0.05)
+        : 0;
+    const varietyMultiplier = 0.945 + (1.055 - 0.945) / (1 + Math.exp(-3 * (variety - 3.25)));
+    const sigmoid = 0.87 + 0.26 / (1 + Math.exp(-20 * (accScalar - 1)));
+    const accMultiplier = sigmoid * (2 * Math.pow(scoreAccuracy, 20) - 1) + 2 - 2 * Math.pow(scoreAccuracy, 20);
+    const lengthMultiplier = 1.1 / (1 + Math.sqrt(stars / (2 * nObjects)));
+    const patternDifficulty = Math.max(stars, M.PATTERN_FLOOR) - 0.15;
+    const xxyPpPattern = M.PATTERN_MULTIPLIER * Math.pow(patternDifficulty, 2.2) * varietyMultiplier * lengthMultiplier * 1.0;
+    const xxyPpAccuracy = xxyPpPattern * (proportion * accMultiplier - 1);
+    const xxyPp = xxyPpPattern + xxyPpAccuracy;
+    const timingMultiplier = mapFactor * scoreAdj;
+    const ppWithTiming = xxyPp * timingMultiplier;
+    const ppTiming = ppWithTiming - xxyPp;
+    const pp = ppWithTiming * (noFail ? 0.75 : 1);
+    return {
+        pp,
+        ppTiming,
+        ppWithTiming,
+        xxyPp,
+        xxyPpPattern,
+        xxyPpAccuracy,
+        timingMultiplier,
+        mapFactor,
+        scoreAdj,
+        proportion,
+        accMultiplier,
+        varietyMultiplier,
+        lengthMultiplier,
+        scoreAccuracy,
+        patternDifficulty,
+    };
+}

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
@@ -22,8 +22,8 @@ import {
  * xxy constants used by sunny.rs.
  */
 export const SURFACE_TIMING_MODEL = Object.freeze({
-    /** Upstream commit the whole surface timing port tracks: rosu-pp @ 328e339. */
-    VERSION: "328e339",
+    /** Upstream commit the whole surface timing port tracks: rosu-pp @ ad3fbe1. */
+    VERSION: "ad3fbe1",
     // ErrorModel production defaults (sunny_accuracy.rs DEFAULT_* / MEASURED_*;
     // sigma_ref & co. are `#[cfg(test)]` there and reserved here).
     ERROR_MODEL: Object.freeze({
@@ -58,28 +58,32 @@ export const SURFACE_TIMING_MODEL = Object.freeze({
     }),
     /** sunny_accuracy.rs `TIMING_CORE_SIGMA` (replay-measured, reserved). */
     TIMING_CORE_SIGMA: 8.5,
-    /** sunny_accuracy.rs `TIMING_BASELINE_SIGMA` — map-factor side (compute_timing_pp_with_units). */
+    /** sunny_accuracy.rs `TIMING_BASELINE_SIGMA` — used by BOTH map-factor
+     * (compute_timing_pp_with_units) and score adjustment
+     * (compute_per_judgement_timing_adjustment) since ad3fbe1. */
     TIMING_BASELINE_SIGMA: 11.0,
-    /** sunny.rs `compute_per_judgement_timing_adjustment` BASELINE_SIGMA local. */
+    /** retired: score adjustment now uses TIMING_BASELINE_SIGMA (=11.0); kept
+     * for reference to the pre-ad3fbe1 local 12.0. */
     SCORE_ADJ_SIGMA: 12.0,
-    /** sunny.rs `compute_map_timing_difficulty` BASELINE_ACC. */
-    BASELINE_ACC: 0.994,
-    /** sunny.rs `compute_map_timing_difficulty` ACC_SCALE. */
-    ACC_SCALE: 15.0,
-    /** sunny.rs `compute_map_timing_difficulty` ln_factor boost. */
+    /** sunny.rs `compute_map_timing_difficulty` BASELINE_ACC (ad3fbe1). */
+    BASELINE_ACC: 0.98,
+    /** sunny.rs `compute_map_timing_difficulty` ACC_SCALE (ad3fbe1). */
+    ACC_SCALE: 1.0,
+    /** retired (ad3fbe1): the LN structural boost was commented out upstream;
+     * kept for reference to the pre-ad3fbe1 1.03 policy. */
     LN_FACTOR_BOOST: 1.03,
-    /** sunny.rs `compute_map_timing_difficulty` LN ratio gate (0.3). */
+    /** retired (ad3fbe1): LN ratio gate, no longer applied. */
     LN_RATIO_GATE: 0.3,
-    /** sunny.rs `compute_map_timing_difficulty` LN boost ratio gate (0.5). */
+    /** retired (ad3fbe1): LN boost ratio gate, no longer applied. */
     LN_RATIO_BOOST_GATE: 0.5,
-    /** sunny.rs `compute_map_timing_difficulty` LN bucket-count gate (3). */
+    /** retired (ad3fbe1): LN bucket-count gate, no longer applied. */
     LN_BUCKET_GATE: 3,
-    /** sunny.rs `compute_map_timing_difficulty` combined clamp. */
-    MAP_CLAMP: [0.85, 1.15],
-    /** sunny.rs `compute_per_judgement_timing_adjustment` multiplier clamp. */
-    SCORE_CLAMP: [0.85, 1.15],
-    /** sunny.rs `compute_per_judgement_timing_adjustment` SCALE. */
-    LOSS_SCALE: 5.0,
+    /** sunny.rs `compute_map_timing_difficulty` combined clamp (ad3fbe1). */
+    MAP_CLAMP: [0.75, 1.15],
+    /** sunny.rs `compute_per_judgement_timing_adjustment` multiplier clamp (ad3fbe1). */
+    SCORE_CLAMP: [0.75, 1.15],
+    /** sunny.rs `compute_per_judgement_timing_adjustment` SCALE (ad3fbe1, dialed back from 5.0). */
+    LOSS_SCALE: 1.0,
     /** sunny_accuracy.rs `LN_DURATION_BUCKETS`. */
     LN_DURATION_BUCKETS: 8,
     /** sunny.rs `LN_DURATION_EDGES`. */
@@ -88,12 +92,20 @@ export const SURFACE_TIMING_MODEL = Object.freeze({
     LN_DURATION_REPRESENTATIVES: [34, 56, 84, 120, 175, 259, 419, 900],
     /** sunny.rs `compute_per_judgement_timing_adjustment` ACC_WEIGHTS (305-based). */
     ACC_WEIGHTS: [1, 300 / 305, 200 / 305, 100 / 305, 50 / 305, 0],
-    /** sunny.rs `compute_per_judgement_timing_adjustment` PENALTY_WEIGHTS (uniform). */
-    PENALTY_WEIGHTS: [1, 1, 1, 1, 1, 1],
+    /** sunny.rs `compute_per_judgement_timing_adjustment` PENALTY_WEIGHTS
+     * (asymmetric since ad3fbe1: misses penalized most). */
+    PENALTY_WEIGHTS: [1.0, 1.1, 1.2, 1.4, 1.8, 2.6],
     /** sunny.rs `calculate_performance_inner` xxy pattern coefficient 9.8. */
     PATTERN_MULTIPLIER: 9.8,
     /** sunny.rs `calculate_performance_inner` pattern difficulty floor (0.2). */
     PATTERN_FLOOR: 0.2,
+    /** sunny_accuracy.rs `TIMING_DIFFICULTY_REFERENCE` — six-star gauge for the
+     * fixed-spread difficulty power law (added 595541d). */
+    TIMING_DIFFICULTY_REFERENCE: 6.0,
+    /** sunny_accuracy.rs `TIMING_DIFFICULTY_FLOOR`. */
+    TIMING_DIFFICULTY_FLOOR: 0.6,
+    /** sunny_accuracy.rs `TIMING_DIFFICULTY_EXPONENT` — old skill-curve exponent. */
+    TIMING_DIFFICULTY_EXPONENT: 1.7,
 });
 
 /**
@@ -247,14 +259,43 @@ export function makeUnit({ difficulty, weight, sigmaScale = 1, meanOffset = 0, f
 }
 
 /**
+ * Relative timing spread for a note of local difficulty `difficulty` against a
+ * map-level `reference` difficulty (sunny_accuracy.rs
+ * `sigma_scale_from_difficulty_ratio`, @ 595541d). Preserves the old skill
+ * curve's difficulty relationship `((d + 0.6) / (reference + 0.6))^1.7`
+ * without making core_sigma map-dependent.
+ * @param {number} difficulty
+ * @param {number} reference
+ * @returns {number}
+ */
+export function sigmaScaleFromDifficultyRatio(difficulty, reference) {
+    const M = SURFACE_TIMING_MODEL;
+    const numerator = Math.max(difficulty, 0) + M.TIMING_DIFFICULTY_FLOOR;
+    const denominator = Math.max(reference, 0) + M.TIMING_DIFFICULTY_FLOOR;
+    const scale = Math.pow(numerator / denominator, M.TIMING_DIFFICULTY_EXPONENT);
+    return Number.isFinite(scale) && scale > 0 ? scale : 1;
+}
+
+/**
+ * Relative timing spread using six stars as the reference gauge
+ * (sunny_accuracy.rs `sigma_scale_from_difficulty`, @ 595541d).
+ * @param {number} difficulty
+ * @returns {number}
+ */
+export function sigmaScaleFromDifficulty(difficulty) {
+    return sigmaScaleFromDifficultyRatio(difficulty, SURFACE_TIMING_MODEL.TIMING_DIFFICULTY_REFERENCE);
+}
+
+/**
  * `count` judgements sharing one local difficulty (sunny_accuracy.rs
- * `JudgementUnit::repeated`, L1211).
+ * `JudgementUnit::repeated`, @ 595541d). Since 595541d the sigma scale carries
+ * the fixed-spread difficulty factor `sigma_scale_from_difficulty(difficulty)`.
  * @param {number} difficulty
  * @param {number} count
  * @returns {object}
  */
 export function makeRepeatedUnit(difficulty, count) {
-    return makeUnit({ difficulty, weight: count });
+    return makeUnit({ difficulty, weight: count, sigmaScale: sigmaScaleFromDifficulty(difficulty) });
 }
 
 /**
@@ -310,7 +351,8 @@ export function lnSigmaScaleForDuration(model, durationMs) {
 /**
  * `count` ScoreV1 long-note judgements of local difficulty `difficulty`,
  * widened by the release-asymmetry spread and shifted by the release mean
- * offset (sunny_accuracy.rs `JudgementUnit::long_note`, L1229-1237).
+ * offset (sunny_accuracy.rs `JudgementUnit::long_note`, @ 595541d). Since
+ * 595541d the sigma scale = difficulty factor × release factor.
  * @param {number} difficulty
  * @param {number} count
  * @param {object} model ErrorModel (uses releaseSigmaRatio / shortHoldPenalty / shortHoldScale / releaseMeanOffset)
@@ -321,7 +363,8 @@ export function makeLongNoteUnit(difficulty, count, model, durationMs) {
     return makeUnit({
         difficulty,
         weight: count,
-        sigmaScale: lnSigmaScaleForDuration(model, durationMs),
+        sigmaScale: sigmaScaleFromDifficulty(difficulty)
+            * lnSigmaScaleForDuration(model, durationMs),
         meanOffset: model.releaseMeanOffset,
         fadingMeanOffset: 0,
     });
@@ -429,32 +472,30 @@ export function buildJudgementUnits({ stars, unitsTotal, nObjects, nLongNotes, l
 
 /**
  * Map-based timing difficulty factor (sunny.rs `compute_map_timing_difficulty`,
- * L818-873). A PP multiplier in ~[0.85, 1.15] reflecting the map's inherent
- * accuracy difficulty: window tightness via expected accuracy at baseline
- * sigma, plus an LN boost for varied-duration high-LN maps.
- * @param {{expectedAcc: number, nLongNotes: number, nObjects: number, lnBuckets: number[]}} args
+ * L818-874, @ ad3fbe1). A PP multiplier in ~[0.75, 1.15] reflecting the map's
+ * inherent accuracy difficulty: window tightness via expected accuracy at
+ * baseline sigma. **The LN structural boost was removed upstream** (commented
+ * out in ad3fbe1), so `lnFactor` is always 1.0; nLongNotes/lnBuckets are kept
+ * in the signature only for call-site stability.
+ * @param {{expectedAcc: number, nLongNotes?: number, nObjects?: number, lnBuckets?: number[]}} args
  * @returns {{factor: number, windowFactor: number, lnFactor: number, expectedAcc: number}}
  */
-export function computeMapTimingFactor({ expectedAcc, nLongNotes, nObjects, lnBuckets }) {
+export function computeMapTimingFactor({ expectedAcc, lnBuckets = [], nLongNotes = 0, nObjects = 0 }) {
     const M = SURFACE_TIMING_MODEL;
     const windowFactor = 1 + (M.BASELINE_ACC - expectedAcc) * M.ACC_SCALE;
-    const lnRatio = nObjects > 0 ? nLongNotes / nObjects : 0;
-    let lnFactor = 1.0;
-    if (lnRatio > M.LN_RATIO_GATE && nLongNotes > 0) {
-        const bucketsUsed = lnBuckets.filter((c) => c > 0).length;
-        if (bucketsUsed >= M.LN_BUCKET_GATE && lnRatio > M.LN_RATIO_BOOST_GATE) {
-            lnFactor = M.LN_FACTOR_BOOST;
-        }
-    }
+    // LN structural boost retired upstream (ad3fbe1): window-based only.
+    const lnFactor = 1.0;
     const factor = Math.min(M.MAP_CLAMP[1], Math.max(M.MAP_CLAMP[0], windowFactor * lnFactor));
     return { factor, windowFactor, lnFactor, expectedAcc };
 }
 
 /**
  * Score-based timing adjustment from per-judgement loss analysis (sunny.rs
- * `compute_per_judgement_timing_adjustment`, L896-978). Player distribution is
- * compared against expected counts at SCORE_ADJ_SIGMA; better than expected
- * rewards > 1.0, worse penalises < 1.0.
+ * `compute_per_judgement_timing_adjustment`, L896-980, @ ad3fbe1).
+ * Player distribution is compared against expected counts at
+ * TIMING_BASELINE_SIGMA (11.0 since ad3fbe1; previously a local 12.0);
+ * asymmetric PENALTY_WEIGHTS weight misses most. Better than expected
+ * rewards > 1.0, worse penalises < 1.0, clamp [0.75, 1.15].
  * @param {{playerCounts: number[], units: object[], windows: object, hitTotal: number, model: object}} args
  * @returns {{multiplier: number, playerLoss: number, expectedLoss: number, lossDiff: number, expectedArr: number[]}}
  */
@@ -463,7 +504,8 @@ export function computeScoreAdjustment({ playerCounts, units, windows, hitTotal,
     if (hitTotal <= 0) {
         return { multiplier: 1, playerLoss: 0, expectedLoss: 0, lossDiff: 0, expectedArr: [0, 0, 0, 0, 0, 0] };
     }
-    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, M.SCORE_ADJ_SIGMA);
+    // ad3fbe1: expected uses TIMING_BASELINE_SIGMA, the same 11.0 as SR phase.
+    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, M.TIMING_BASELINE_SIGMA);
     let totalPlayerLoss = 0;
     let totalExpectedLoss = 0;
     for (let i = 0; i < 6; i += 1) {
@@ -480,8 +522,10 @@ export function computeScoreAdjustment({ playerCounts, units, windows, hitTotal,
 
 /**
  * Full surface PP composition (sunny.rs `calculate_performance_inner`
- * L992-1103 plus the xxy_* helpers). Pattern difficulty follows the xxy
- * formulation; timing difficulty multiplies it by `mapFactor * scoreAdj`;
+ * L994-1105 plus the xxy_* helpers, @ ad3fbe1). Pattern difficulty follows the
+ * xxy formulation; the timing multiplier is the **additive combination**
+ * `(score_timing_adjustment + map_timing_factor) - 1` (since ad3fbe1; was
+ * `mapFactor * scoreAdj` product before), applied onto xxy_pp;
  * `noFail` applies the 0.75 normalize_for_human_reference factor to the final
  * pp. All returned fields are numbers.
  * @param {{stars: number, variety: number, accScalar: number, nObjects: number, scoreAccuracy: number, mapFactor: number, scoreAdj: number, noFail?: boolean}} args
@@ -500,7 +544,8 @@ export function computeSurfacePp({ stars, variety, accScalar, nObjects, scoreAcc
     const xxyPpPattern = M.PATTERN_MULTIPLIER * Math.pow(patternDifficulty, 2.2) * varietyMultiplier * lengthMultiplier * 1.0;
     const xxyPpAccuracy = xxyPpPattern * (proportion * accMultiplier - 1);
     const xxyPp = xxyPpPattern + xxyPpAccuracy;
-    const timingMultiplier = mapFactor * scoreAdj;
+    // ad3fbe1: additive combination of map factor and score adjustment.
+    const timingMultiplier = (scoreAdj + mapFactor) - 1;
     const ppWithTiming = xxyPp * timingMultiplier;
     const ppTiming = ppWithTiming - xxyPp;
     const pp = ppWithTiming * (noFail ? 0.75 : 1);

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
@@ -22,8 +22,8 @@ import {
  * xxy constants used by sunny.rs.
  */
 export const SURFACE_TIMING_MODEL = Object.freeze({
-    /** Upstream commit the whole surface timing port tracks: rosu-pp @ dd5eeb5. */
-    VERSION: "dd5eeb5",
+    /** Upstream commit the whole surface timing port tracks: rosu-pp @ 143f0a8. */
+    VERSION: "143f0a8",
     // ErrorModel production defaults (sunny_accuracy.rs DEFAULT_* / MEASURED_*;
     // sigma_ref & co. are `#[cfg(test)]` there and reserved here).
     ERROR_MODEL: Object.freeze({
@@ -64,12 +64,12 @@ export const SURFACE_TIMING_MODEL = Object.freeze({
      * applied to BOTH map-factor expected accuracy (compute_timing_pp_with_units)
      * and score adjustment (compute_per_judgement_timing_adjustment L930). */
     TIMING_BASELINE_SIGMA: 11.0,
-    /** sunny_accuracy.rs SR-level sigma scaling constants (34fde58a / dd5eeb5):
-     * `sr_to_base_sigma_scale` uses its own neutral SR reference (8★), separate
-     * from the per-note difficulty reference (TIMING_DIFFICULTY_REFERENCE 6.0). */
-    SR_REFERENCE: 8.0,
-    SR_SCALING_FLOOR: 0.6,
-    SR_SCALING_EXPONENT: 1.7,
+    /** sunny_accuracy.rs Map-level SR scaling constants (143f0a8): logarithmic
+     * `sr_to_base_sigma_scale` centered at MAP_SR_REFERENCE (10★ neutral),
+     * factor 0.15 per log-unit, clamped [0.7, 1.3]. Separate from the per-note
+     * difficulty gauge (PER_NOTE_DIFFICULTY_REFERENCE_UNTUNED 6.0). */
+    MAP_SR_REFERENCE: 10.0,
+    MAP_SR_SCALING_FACTOR: 0.15,
     /** retired: score adjustment now uses TIMING_BASELINE_SIGMA (=11.0); kept
      * for reference to the pre-ad3fbe1 local 12.0. */
     SCORE_ADJ_SIGMA: 12.0,
@@ -107,13 +107,15 @@ export const SURFACE_TIMING_MODEL = Object.freeze({
     PATTERN_MULTIPLIER: 9.8,
     /** sunny.rs `calculate_performance_inner` pattern difficulty floor (0.2). */
     PATTERN_FLOOR: 0.2,
-    /** sunny_accuracy.rs `TIMING_DIFFICULTY_REFERENCE` — six-star gauge for the
-     * fixed-spread difficulty power law (added 595541d). */
-    TIMING_DIFFICULTY_REFERENCE: 6.0,
-    /** sunny_accuracy.rs `TIMING_DIFFICULTY_FLOOR`. */
-    TIMING_DIFFICULTY_FLOOR: 0.6,
-    /** sunny_accuracy.rs `TIMING_DIFFICULTY_EXPONENT` — old skill-curve exponent. */
-    TIMING_DIFFICULTY_EXPONENT: 1.7,
+    /** sunny_accuracy.rs `PER_NOTE_DIFFICULTY_REFERENCE_UNTUNED` — per-note
+     * difficulty gauge for the fixed-spread power law (6.0 since 595541d;
+     * named UNTUNED since 143f0a8). */
+    PER_NOTE_DIFFICULTY_REFERENCE_UNTUNED: 6.0,
+    /** sunny_accuracy.rs `PER_NOTE_DIFFICULTY_FLOOR` (0.5 since 143f0a8; was 0.6). */
+    PER_NOTE_DIFFICULTY_FLOOR: 0.5,
+    /** sunny_accuracy.rs `PER_NOTE_DIFFICULTY_EXPONENT` — per-note power-law
+     * exponent (2.0 since 143f0a8; was 1.7). */
+    PER_NOTE_DIFFICULTY_EXPONENT: 2.0,
 });
 
 /**
@@ -269,39 +271,41 @@ export function makeUnit({ difficulty, weight, sigmaScale = 1, meanOffset = 0, f
 /**
  * Relative timing spread for a note of local difficulty `difficulty` against a
  * map-level `reference` difficulty (sunny_accuracy.rs
- * `sigma_scale_from_difficulty_ratio`, @ 595541d). Preserves the old skill
- * curve's difficulty relationship `((d + 0.6) / (reference + 0.6))^1.7`
- * without making core_sigma map-dependent.
+ * `sigma_scale_from_difficulty_ratio`, @ 143f0a8). Preserves the per-note
+ * difficulty relationship `((d + 0.5) / (reference + 0.5))^2.0` (floor/exponent
+ * retuned 143f0a8; were 0.6 / 1.7).
  * @param {number} difficulty
  * @param {number} reference
  * @returns {number}
  */
 export function sigmaScaleFromDifficultyRatio(difficulty, reference) {
     const M = SURFACE_TIMING_MODEL;
-    const numerator = Math.max(difficulty, 0) + M.TIMING_DIFFICULTY_FLOOR;
-    const denominator = Math.max(reference, 0) + M.TIMING_DIFFICULTY_FLOOR;
-    const scale = Math.pow(numerator / denominator, M.TIMING_DIFFICULTY_EXPONENT);
+    const numerator = Math.max(difficulty, 0) + M.PER_NOTE_DIFFICULTY_FLOOR;
+    const denominator = Math.max(reference, 0) + M.PER_NOTE_DIFFICULTY_FLOOR;
+    const scale = Math.pow(numerator / denominator, M.PER_NOTE_DIFFICULTY_EXPONENT);
     return Number.isFinite(scale) && scale > 0 ? scale : 1;
 }
 
 /**
- * Relative timing spread using six stars as the reference gauge
- * (sunny_accuracy.rs `sigma_scale_from_difficulty`, @ 595541d).
+ * Relative timing spread using the untuned per-note difficulty reference (6.0)
+ * (sunny_accuracy.rs `sigma_scale_from_difficulty`, @ 143f0a8). Used by the
+ * standalone unit constructors (uniform fallback, LN duration split) when
+ * per-note difficulty bins are not available.
  * @param {number} difficulty
  * @returns {number}
  */
 export function sigmaScaleFromDifficulty(difficulty) {
-    return sigmaScaleFromDifficultyRatio(difficulty, SURFACE_TIMING_MODEL.TIMING_DIFFICULTY_REFERENCE);
+    return sigmaScaleFromDifficultyRatio(difficulty, SURFACE_TIMING_MODEL.PER_NOTE_DIFFICULTY_REFERENCE_UNTUNED);
 }
 
 /**
  * Map-level sigma scaling from SR (sunny_accuracy.rs `sr_to_base_sigma_scale`,
- * @ 34fde58a / dd5eeb5). Converts the map's star rating into a multiplier for
- * TIMING_BASELINE_SIGMA — its own power-law with a separate neutral reference:
- * `((sr.max(0) + SR_SCALING_FLOOR) / (SR_REFERENCE + SR_SCALING_FLOOR))^SR_SCALING_EXPONENT`
- * i.e. ((SR + 0.6) / 8.6)^1.7. 8★ is the neutral point (scale 1, base sigma
- * 11ms); below 8★ expects tighter timing (smaller sigma), above 8★ looser.
- * NOT the per-note gauge (which keeps TIMING_DIFFICULTY_REFERENCE = 6.0).
+ * @ 143f0a8). Converts the map's star rating into a multiplier for
+ * TIMING_BASELINE_SIGMA with a LOGARITHMIC formula centered at
+ * MAP_SR_REFERENCE (10★ neutral):
+ * `scale = clamp(1.0 - ln(SR / 10.0) * MAP_SR_SCALING_FACTOR, 0.7, 1.3)`.
+ * Below 10★ expects looser timing (scale > 1, bigger sigma); above 10★ tighter.
+ * log(0) guarded via sr.max(0.1); NaN propagates (matches `f64::clamp`).
  * Applied once per map (`base_timing_sigma = TIMING_BASELINE_SIGMA *
  * sr_to_base_sigma_scale(SR)`), not per operation.
  * @param {number} sr
@@ -309,10 +313,9 @@ export function sigmaScaleFromDifficulty(difficulty) {
  */
 export function srToBaseSigmaScale(sr) {
     const M = SURFACE_TIMING_MODEL;
-    const numerator = Math.max(sr, 0) + M.SR_SCALING_FLOOR;
-    const denominator = M.SR_REFERENCE + M.SR_SCALING_FLOOR;
-    const scale = Math.pow(numerator / denominator, M.SR_SCALING_EXPONENT);
-    return Number.isFinite(scale) && scale > 0 ? scale : 1;
+    const safeSr = Math.max(sr, 0.1);
+    const scale = 1 - Math.log(safeSr / M.MAP_SR_REFERENCE) * M.MAP_SR_SCALING_FACTOR;
+    return Math.min(1.3, Math.max(0.7, scale));
 }
 
 /**

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingCurve.js
@@ -22,8 +22,8 @@ import {
  * xxy constants used by sunny.rs.
  */
 export const SURFACE_TIMING_MODEL = Object.freeze({
-    /** Upstream commit the whole surface timing port tracks: rosu-pp @ ad3fbe1. */
-    VERSION: "ad3fbe1",
+    /** Upstream commit the whole surface timing port tracks: rosu-pp @ 595541d. */
+    VERSION: "595541d",
     // ErrorModel production defaults (sunny_accuracy.rs DEFAULT_* / MEASURED_*;
     // sigma_ref & co. are `#[cfg(test)]` there and reserved here).
     ERROR_MODEL: Object.freeze({

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingOfficial.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingOfficial.js
@@ -1,0 +1,192 @@
+// Official osu!mania star rating & pp — debug panel reference row.
+//
+// Ported from the genirx dart port of osu-master's official mania difficulty
+// / performance calculators (lib/logic/algorithm/official/), which is itself a
+// faithful translation of osu!lazer's osu.Game.Rulesets.Mania difficulty and
+// performance code. DOM-free pure module: runs in the browser and in Node.
+//
+// GetColumn here uses the parser's derived column number directly (the parser
+// already maps x → column); columnStrainTime and hold overlap use noteStarts /
+// noteEnds (0 for circles). All times are divided by speedRate like the
+// upstream CreateDifficultyHitObjects.
+
+/**
+ * Official mania star rating (osu-master ManiaDifficultyCalculator).
+ * @param {{
+ *   columns: number[],   // per-note column (0..keyCount-1)
+ *   noteStarts: number[],// per-note start ms (map time)
+ *   noteEnds: number[],  // per-note end ms (0 for circles)
+ * }} parsed getParsedData() output
+ * @param {number} [speedRate=1]
+ * @returns {number|null} official star rating, or null on invalid input
+ */
+export function calculateOfficialStar({ columns, noteStarts, noteEnds }, speedRate = 1) {
+    const n = columns ? columns.length : 0;
+    if (!n) return null;
+    if (!Number.isFinite(speedRate) || speedRate <= 0) return null;
+
+    const keyCount = Math.max(...columns) + 1;
+    if (keyCount < 1 || keyCount > 10) return null;
+
+    // Sorted by start time (stable by original index like the upstream index
+    // tie-break; circles have noteEnds[start] === 0).
+    const order = [...Array(n).keys()].sort((a, b) => noteStarts[a] - noteStarts[b]);
+    const times = order.map((i) => noteStarts[i] / speedRate);
+    const ends = order.map((i) => noteEnds[i] / speedRate);
+    const cols = order.map((i) => columns[i]);
+
+    // Difficulty hit objects: skip the first note (i = 1..n-1 upstream.
+    const dho = [];
+    const perColumn = Array.from({ length: keyCount }, () => []);
+
+    for (let i = 1; i < n; i += 1) {
+        const cur = {
+            column: cols[i],
+            startTime: times[i],
+            endTime: Math.max(ends[i], times[i]),
+            deltaTime: times[i] - times[i - 1],
+            columnStrainTime: 0,
+            previous: null,
+        };
+        // previous = copy of prevDho.previous + prevDho at its column.
+        const prevDho = dho.length ? dho[dho.length - 1] : null;
+        const previous = Array(keyCount).fill(null);
+        if (prevDho) {
+            for (let c = 0; c < keyCount; c += 1) previous[c] = prevDho.previous ? prevDho.previous[c] : null;
+            previous[prevDho.column] = prevDho;
+        }
+        cur.previous = previous;
+
+        const colIndex = perColumn[cur.column].length;
+        const prevInColumn = colIndex > 0 ? perColumn[cur.column][colIndex - 1] : null;
+        cur.columnStrainTime = prevInColumn ? cur.startTime - prevInColumn.startTime : cur.startTime;
+
+        dho.push(cur);
+        perColumn[cur.column].push(cur);
+    }
+
+    // Strain skills.
+    const individualStrains = Array(keyCount).fill(0);
+    let highestIndividualStrain = 0;
+    let overallStrain = 1;
+    let currentStrain = 0;
+    let currentSectionPeak = 0;
+    let currentSectionEnd = 0;
+    const strainPeaks = [];
+
+    const sectionLength = 400;
+    const decayWeight = 0.9;
+    const individualDecayBase = 0.125;
+    const overallDecayBase = 0.30;
+    const releaseThreshold = 30.0;
+
+    const applyDecay = (value, deltaTime, decayBase) => value * Math.pow(decayBase, deltaTime / 1000);
+    const definitelyBigger = (a, b) => a - 1 > b;
+    const logistic = (x, midpointOffset, multiplier) => 1 / (1 + Math.exp(multiplier * (midpointOffset - x)));
+
+    const individualEvaluator = (o) => {
+        let holdFactor = 1;
+        for (const prev of o.previous) {
+            if (!prev) continue;
+            if (definitelyBigger(prev.endTime, o.endTime) && definitelyBigger(o.startTime, prev.startTime)) {
+                holdFactor = 1.25;
+                break;
+            }
+        }
+        return 2.0 * holdFactor;
+    };
+
+    const overallEvaluator = (o) => {
+        let isOverlapping = false;
+        let closestEndTime = Math.abs(o.endTime - o.startTime);
+        let holdFactor = 1;
+        let holdAddition = 0;
+        for (const prev of o.previous) {
+            if (!prev) continue;
+            isOverlapping = isOverlapping ||
+                (definitelyBigger(prev.endTime, o.startTime)
+                    && definitelyBigger(o.endTime, prev.endTime)
+                    && definitelyBigger(o.startTime, prev.startTime));
+            if (definitelyBigger(prev.endTime, o.endTime) && definitelyBigger(o.startTime, prev.startTime)) {
+                holdFactor = 1.25;
+            }
+            closestEndTime = Math.min(closestEndTime, Math.abs(o.endTime - prev.endTime));
+        }
+        if (isOverlapping) holdAddition = logistic(closestEndTime, releaseThreshold, 0.27);
+        return (1 + holdAddition) * holdFactor;
+    };
+
+    for (let i = 0; i < dho.length; i += 1) {
+        const cur = dho[i];
+        if (i === 0) {
+            currentSectionEnd = Math.ceil(cur.startTime / sectionLength) * sectionLength;
+        }
+        while (cur.startTime > currentSectionEnd) {
+            strainPeaks.push(currentSectionPeak);
+            const prevStart = dho[i - 1].startTime;
+            currentSectionPeak =
+                applyDecay(highestIndividualStrain, currentSectionEnd - prevStart, individualDecayBase)
+                + applyDecay(overallStrain, currentSectionEnd - prevStart, overallDecayBase);
+            currentSectionEnd += sectionLength;
+        }
+
+        const col = cur.column;
+        individualStrains[col] = applyDecay(individualStrains[col], cur.columnStrainTime, individualDecayBase);
+        individualStrains[col] += individualEvaluator(cur);
+        highestIndividualStrain = cur.deltaTime <= 1
+            ? Math.max(highestIndividualStrain, individualStrains[col])
+            : individualStrains[col];
+
+        overallStrain = applyDecay(overallStrain, cur.deltaTime, overallDecayBase);
+        overallStrain += overallEvaluator(cur);
+
+        const strainValueOf = highestIndividualStrain + overallStrain - currentStrain;
+        currentStrain += strainValueOf;
+        currentSectionPeak = Math.max(currentStrain, currentSectionPeak);
+    }
+
+    // Difficulty value × 0.018.
+    const peaks = [...strainPeaks, currentSectionPeak].filter((p) => p > 0).sort((a, b) => b - a);
+    let difficulty = 0;
+    let weight = 1;
+    for (const peak of peaks) {
+        difficulty += peak * weight;
+        weight *= decayWeight;
+    }
+    const star = difficulty * 0.018;
+    return Number.isFinite(star) ? star : null;
+}
+
+/**
+ * Official osu!mania pp (osu-master ManiaPerformanceCalculator).
+ * @param {{
+ *   starRating: number,
+ *   perfect: number, great: number, good: number, ok: number, meh: number, miss: number,
+ *   noFail?: boolean, easy?: boolean,
+ * }} args counts in geki/300/katu/100/50/0 order
+ * @returns {number|null} official pp, or null on invalid input
+ */
+export function calculateOfficialPp({
+    starRating, perfect, great, good, ok, meh, miss, noFail = false, easy = false,
+}) {
+    if (!(starRating > 0) || !Number.isFinite(starRating)) return null;
+    if (perfect < 0 || great < 0 || good < 0 || ok < 0 || meh < 0 || miss < 0) return null;
+
+    const totalHits = perfect + great + good + ok + meh + miss;
+    const acc = totalHits === 0
+        ? 0
+        : (perfect * 320 + great * 300 + good * 200 + ok * 100 + meh * 50) / (totalHits * 320);
+    const clampedAcc = Math.min(1, Math.max(0, acc));
+
+    const difficultyValue = 8.0
+        * Math.pow(Math.max(starRating - 0.15, 0.05), 2.2)
+        * Math.max(0, 5 * clampedAcc - 4)
+        * (1 + 0.1 * Math.min(1, totalHits / 1500));
+
+    let multiplier = 1.0;
+    if (noFail) multiplier *= 0.75;
+    if (easy) multiplier *= 0.5;
+
+    const pp = difficultyValue * multiplier;
+    return Number.isFinite(pp) ? pp : null;
+}

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
@@ -41,6 +41,7 @@ import {
     expectedCountsCustomAccuracy,
     SURFACE_TIMING_MODEL,
 } from "./surfaceTimingCurve.js";
+import { calculateOfficialPp, calculateOfficialStar } from "./surfaceTimingOfficial.js";
 
 const SORTED_KNOWN_MOD_CODES = [...APP_CONFIG.mods.knownCodes].sort((a, b) => b.length - a.length);
 const MOD_BIT_FLAG_ENTRIES = Object.entries(APP_CONFIG.mods.bitFlags);
@@ -301,7 +302,7 @@ function buildPanelHtml(result) {
     const {
         mode, source, counts, unitsTotal, hitTotal, od, odAvailable,
         classic, isConvert, hr, ez, clockRate, windows, mapWindows,
-        expectedAcc, mapFactorRes, scoreAdjRes, ppRes, rework, deltaPct, timings,
+        expectedAcc, mapFactorRes, scoreAdjRes, ppRes, rework, deltaPct, official, timings,
     } = result;
 
     const diffMultiplier = hr ? 1.4 : (ez ? 1 / 1.4 : 1);
@@ -356,15 +357,17 @@ function buildPanelHtml(result) {
                 <dd>${formatNumber(ppRes.ppWithTiming, 2)}</dd>
                 <dt>pp_timing</dt>
                 <dd>${formatNumber(ppRes.ppTiming, 2)}</dd>
-                <dt>${mode} PP <span class="estimator-debug-meta">(${source})</span></dt>
+                <dt>${mode === "Live" ? "Live PP" : mode} <span class="estimator-debug-meta">(${source})</span></dt>
                 <dd>${formatNumber(ppRes.pp, 2)} <span class="estimator-debug-meta">(Rework ${formatNumber(rework && rework.pp, 2)} · Δ ${formatNumber(deltaPct, 2)}%)</span></dd>
             </div>
             <div class="estimator-debug-result-line">
-                <strong>Rework PP: ${formatNumber(rework && rework.pp, 2)}</strong>
+                <strong>${mode} (Surface): ${formatNumber(ppRes.pp, 2)}</strong>
                 <span>|</span>
-                <span>Surface PP: ${formatNumber(ppRes.pp, 2)}</span>
+                <span>Official PP: ${formatNumber(official && official.pp, 2)}</span>
                 <span>|</span>
-                <span>Δ: ${formatNumber(deltaPct, 2)}%</span>
+                <span>Rework PP: ${formatNumber(rework && rework.pp, 2)}</span>
+                <span>|</span>
+                <span>Δ(Surface−Rework): ${formatNumber(deltaPct, 2)}%</span>
             </div>
             <div class="estimator-debug-note">
                 timings — sunny ${formatNumber(timings.sunny ?? 0, 1)}ms · windows ${formatNumber(timings.windows, 1)}ms · units ${formatNumber(timings.units, 1)}ms · expected ${formatNumber(timings.expected, 1)}ms · mapFactor ${formatNumber(timings.mapFactor, 1)}ms · scoreAdj ${formatNumber(timings.scoreAdj, 1)}ms · total ${formatNumber(timings.total, 1)}ms
@@ -623,6 +626,23 @@ export function createSurfaceTimingPanel({
             model: SURFACE_TIMING_MODEL.ERROR_MODEL,
         });
 
+        // Official osu!mania reference row (genirx official port of osu-master).
+        const officialStar = calculateOfficialStar({
+            columns: lastParse.columns ?? [],
+            noteStarts: lastParse.noteStarts ?? [],
+            noteEnds: lastParse.noteEnds ?? [],
+        }, modData.speedRate);
+        const officialPp = officialStar != null
+            ? calculateOfficialPp({
+                starRating: officialStar,
+                perfect: counts[0], great: counts[1], good: counts[2],
+                ok: counts[3], meh: counts[4], miss: counts[5],
+                noFail: modCodes.includes("NF"),
+                easy: modCodes.includes("EZ"),
+            })
+            : null;
+        const official = officialPp != null ? { star: officialStar, pp: officialPp } : null;
+
         lastRender = {
             mode,
             source,
@@ -644,6 +664,7 @@ export function createSurfaceTimingPanel({
             ppRes: pipeline.ppRes,
             rework: pipeline.rework,
             deltaPct: pipeline.deltaPct,
+            official,
             timings: {
                 ...pipeline.timings,
                 sunny: sunnyMs,

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
@@ -367,7 +367,7 @@ function buildPanelHtml(result) {
                 <span>Δ: ${formatNumber(deltaPct, 2)}%</span>
             </div>
             <div class="estimator-debug-note">
-                timings — windows ${formatNumber(timings.windows, 1)}ms · units ${formatNumber(timings.units, 1)}ms · expected ${formatNumber(timings.expected, 1)}ms · mapFactor ${formatNumber(timings.mapFactor, 1)}ms · scoreAdj ${formatNumber(timings.scoreAdj, 1)}ms · total ${formatNumber(timings.total, 1)}ms
+                timings — sunny ${formatNumber(timings.sunny ?? 0, 1)}ms · windows ${formatNumber(timings.windows, 1)}ms · units ${formatNumber(timings.units, 1)}ms · expected ${formatNumber(timings.expected, 1)}ms · mapFactor ${formatNumber(timings.mapFactor, 1)}ms · scoreAdj ${formatNumber(timings.scoreAdj, 1)}ms · total ${formatNumber(timings.total, 1)}ms
                 · od ${formatNumber(od, 1)}${odAvailable ? "" : " (unavailable)"}
             </div>
         </section>
@@ -398,6 +398,7 @@ export function createSurfaceTimingPanel({
     let lastRender = null;   // {error: string} or full result object
     let lastFetchFailed = false; // transient fetch failure (tosu not ready yet)
     let lastFetchFailAt = 0;  // ms timestamp — throttle retry storms while tosu warms up
+    let lastCountsKey = null; // live/score hits fingerprint (recompute gate)
     const FETCH_RETRY_MS = 1000;
 
     async function fetchCurrentBeatmap() {
@@ -437,6 +438,7 @@ export function createSurfaceTimingPanel({
 
     async function handleSocketPayload(data) {
         if (collapsed) return;
+        const tStart = performance.now();
 
         // Invalidate any in-flight async from an earlier message FIRST, then
         // capture the new sequence (estimatorDebugPanel runAll pattern). Every
@@ -452,6 +454,39 @@ export function createSurfaceTimingPanel({
         const mapChanged = mapKey !== lastIdentity;
         const modsChanged = modData.modSignature !== lastModsKey;
         let needRecomputeSR = mapChanged || modsChanged;
+
+        // --- Recompute gate: skip the whole pipeline when nothing that feeds
+        // the display changed. ws messages arrive continuously (~10/s), and
+        // without this every message re-runs the pipeline + full re-render
+        // (all timings show ~0.0ms, panel churns for nothing). Two cases:
+        //   1. map+mods unchanged and a successful result already rendered →
+        //      nothing on screen can change (Max PP is a fixed SS snapshot).
+        //   2. live/score: same map+mods but identical hits counts → also a
+        //      no-op. Only a change in counts (or map/mods) triggers rework.
+        const stateName = normalizeClientStateName(data?.state?.name);
+        const isPlayState = isPlayStateName(stateName);
+        const isResultState = isResultScreenStateName(stateName);
+        const hitsNow = isResultState
+            ? (data && data.resultsScreen && data.resultsScreen.hits)
+            : isPlayState ? (data && data.play && data.play.hits) : null;
+        const countsNow = hitsNow ? extractCounts(hitsNow) : null;
+        const countsKey = countsNow
+            ? `${countsNow.perfect},${countsNow.great},${countsNow.good},${countsNow.ok},${countsNow.meh},${countsNow.miss}`
+            : null;
+        const modeStateKey = isResultState ? "score" : isPlayState ? "live" : "max";
+
+        if (!mapChanged && !modsChanged && lastParse) {
+            // Same map+mods with a prior successful parse. For max mode the
+            // display is a fixed SS snapshot — nothing can differ. For live/
+            // score, only a hits-count change is a real update.
+            if (modeStateKey === "max") {
+                return;
+            }
+            if (countsKey !== null && countsKey === lastCountsKey) {
+                return;
+            }
+            lastCountsKey = countsKey;
+        }
 
         // Beatmap changed (or no cached text): fetch + parse. Mods-only changes
         // reuse the cached text/parse — parse results are mod-independent
@@ -508,7 +543,9 @@ export function createSurfaceTimingPanel({
 
         // Sunny SR — cached across identical map+mods; rerun when either changed.
         let sunny = lastSunny;
+        let sunnyMs = 0;
         if (needRecomputeSR) {
+            const tSunny = performance.now();
             try {
                 sunny = runSunnyEstimatorFromText(lastOsuText, {
                     speedRate: modData.speedRate,
@@ -521,6 +558,7 @@ export function createSurfaceTimingPanel({
                 renderError(error?.message || "Sunny estimator failed");
                 return;
             }
+            sunnyMs = performance.now() - tSunny;
             if (seq !== runSeq) return;
             lastSunny = sunny;
         }
@@ -606,7 +644,11 @@ export function createSurfaceTimingPanel({
             ppRes: pipeline.ppRes,
             rework: pipeline.rework,
             deltaPct: pipeline.deltaPct,
-            timings: pipeline.timings,
+            timings: {
+                ...pipeline.timings,
+                sunny: sunnyMs,
+                total: performance.now() - tStart,
+            },
         };
         lastModsKey = modData.modSignature;
         render();

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
@@ -39,6 +39,7 @@ import {
     computeSurfacePp,
     expectedCountsAtCoreSigma,
     expectedCountsCustomAccuracy,
+    srToBaseSigmaScale,
     SURFACE_TIMING_MODEL,
 } from "./surfaceTimingCurve.js";
 import { calculateOfficialPp, calculateOfficialStar } from "./surfaceTimingOfficial.js";
@@ -237,14 +238,17 @@ export function runSurfacePipeline({
     const units = buildJudgementUnits({ stars, unitsTotal, nObjects, nLongNotes, lnBuckets, classic, model });
     const t2 = performance.now();
 
-    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, SURFACE_TIMING_MODEL.TIMING_BASELINE_SIGMA);
+    // a44a63 (529e612): SR-scaled baseline sigma, applied once per map to BOTH
+    // the map-factor expected accuracy and the score adjustment expected counts.
+    const baseTimingSigma = SURFACE_TIMING_MODEL.TIMING_BASELINE_SIGMA * srToBaseSigmaScale(stars);
+    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, baseTimingSigma);
     const expectedAcc = expectedCountsCustomAccuracy(expectedArr);
     const t3 = performance.now();
 
     const mapFactorRes = computeMapTimingFactor({ expectedAcc, nLongNotes, nObjects, lnBuckets });
     const t4 = performance.now();
 
-    const scoreAdjRes = computeScoreAdjustment({ playerCounts: counts, units, windows, hitTotal, model });
+    const scoreAdjRes = computeScoreAdjustment({ playerCounts: counts, units, windows, hitTotal, model, baseTimingSigma });
     const t5 = performance.now();
 
     const scoreAccuracy = expectedCountsCustomAccuracy(counts);

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
@@ -123,6 +123,13 @@ function schemeLabel(classic, isConvert) {
     return isConvert ? "classic convert" : "classic non-convert";
 }
 
+// Key count from the parsed chart's column range (max column + 1), falling back
+// to null when no parsed columns survive (should not happen in practice).
+function columnCountFromParsed(parsed) {
+    if (!parsed || !Array.isArray(parsed.columns) || parsed.columns.length === 0) return null;
+    return Math.max(...parsed.columns) + 1;
+}
+
 /**
  * Resolve the display mode and judgement counts from an api_v2 payload.
  * Pure DOM-free helper (Node smoke tested).
@@ -300,7 +307,7 @@ function bandValuesText(windows) {
 
 function buildPanelHtml(result) {
     const {
-        mode, source, counts, unitsTotal, hitTotal, od, odAvailable,
+        mapInfo, mode, source, counts, unitsTotal, hitTotal, od, odAvailable,
         classic, isConvert, hr, ez, clockRate, windows, mapWindows,
         expectedAcc, mapFactorRes, scoreAdjRes, ppRes, rework, deltaPct, official, timings,
     } = result;
@@ -311,6 +318,16 @@ function buildPanelHtml(result) {
         `difficulty ×${formatNumber(diffMultiplier, 2)}${hr ? " (HR)" : ""}${ez ? " (EZ)" : ""}`,
         `clock_rate ${formatNumber(clockRate, 3)}`,
     ].join(" · ");
+    const officialStarText = official && official.star != null ? formatNumber(official.star, 2) : "-";
+
+    const countNames = ["perfect", "great", "good", "ok", "meh", "miss"];
+    const countText = counts.map((c, i) => `${countNames[i]} ${c}`).join(" · ");
+
+    const ppCell = (label, value) => `
+        <div class="surface-pp-cell">
+            <div class="surface-pp-value ${value == null ? "surface-dim" : ""}">${formatNumber(value == null ? null : value, 2)}</div>
+            <div class="surface-pp-label">${label}</div>
+        </div>`;
 
     return `
         <section class="estimator-debug-panel">
@@ -324,57 +341,99 @@ function buildPanelHtml(result) {
                     </div>
                 </div>
             </div>
-            <div class="kv">
-                <dt>windows (${schemeLabel(classic, isConvert)})</dt>
-                <dd>${bandValuesText(windows)}</dd>
-                <dt>mods</dt>
-                <dd>${modsText}</dd>
-                <dt>map_windows</dt>
-                <dd>${bandValuesText(mapWindows)}</dd>
-                <dt>expected_acc</dt>
-                <dd>${formatNumber(expectedAcc * 100, 3)}%</dd>
-                <dt>window_factor</dt>
-                <dd>${formatNumber(mapFactorRes.windowFactor, 4)}</dd>
-                <dt>ln_factor</dt>
-                <dd>${formatNumber(mapFactorRes.lnFactor, 4)}</dd>
-                <dt>map_factor</dt>
-                <dd>${formatNumber(mapFactorRes.factor, 4)}</dd>
-                <dt>counts <span class="estimator-debug-meta">(${source})</span></dt>
-                <dd>perfect: ${counts[0]} · great: ${counts[1]} · good: ${counts[2]} · ok: ${counts[3]} · meh: ${counts[4]} · miss: ${counts[5]} <span class="estimator-debug-meta">(hitTotal ${hitTotal})</span></dd>
-                <dt>units_total</dt>
-                <dd>${unitsTotal} (${unitLabel})</dd>
-                <dt>score_adjustment</dt>
-                <dd>player_loss ${formatNumber(scoreAdjRes.playerLoss, 4)} · expected_loss ${formatNumber(scoreAdjRes.expectedLoss, 4)} · loss_diff ${formatNumber(scoreAdjRes.lossDiff, 4)} <strong>→ multiplier ${formatNumber(scoreAdjRes.multiplier, 4)}</strong></dd>
-                <dt>timing_multiplier</dt>
-                <dd>${formatNumber(ppRes.timingMultiplier, 4)} (map × score)</dd>
-                <dt>xxy_pp_pattern</dt>
-                <dd>${formatNumber(ppRes.xxyPpPattern, 2)}</dd>
-                <dt>xxy_pp_accuracy</dt>
-                <dd>${formatNumber(ppRes.xxyPpAccuracy, 2)}</dd>
-                <dt>xxy_pp</dt>
-                <dd>${formatNumber(ppRes.xxyPp, 2)}</dd>
-                <dt>pp_with_timing</dt>
-                <dd>${formatNumber(ppRes.ppWithTiming, 2)}</dd>
-                <dt>pp_timing</dt>
-                <dd>${formatNumber(ppRes.ppTiming, 2)}</dd>
-                <dt>${mode === "Live" ? "Live PP" : mode} <span class="estimator-debug-meta">(${source})</span></dt>
-                <dd>${formatNumber(ppRes.pp, 2)} <span class="estimator-debug-meta">(Rework ${formatNumber(rework && rework.pp, 2)} · Δ ${formatNumber(deltaPct, 2)}%)</span></dd>
+
+            <div class="surface-map-info">
+                <strong>${escapeHtml(mapInfo.artist)} - ${escapeHtml(mapInfo.title)} <span class="surface-dim">[${escapeHtml(mapInfo.version)}]</span></strong>
+                <span class="estimator-debug-meta">by ${escapeHtml(mapInfo.mapper)}</span>
+                <span class="badge">${mapInfo.keyCount != null ? `${mapInfo.keyCount}K` : "-K"}</span>
+                <span class="badge">od ${formatNumber(od, 1)}${odAvailable ? "" : "?"}</span>
+                <span class="badge">Sunny ${formatNumber(mapInfo.sunnyStar, 2)}★</span>
+                <span class="badge">Official ${officialStarText}★</span>
+                <span class="badge">${classic ? "classic" : "lazer"} · ${unitLabel}</span>
             </div>
-            <div class="estimator-debug-result-line">
-                <strong>${mode} (Surface): ${formatNumber(ppRes.pp, 2)}</strong>
-                <span>|</span>
-                <span>Official PP: ${formatNumber(official && official.pp, 2)}</span>
-                <span>|</span>
-                <span>Rework PP: ${formatNumber(rework && rework.pp, 2)}</span>
-                <span>|</span>
-                <span>Δ(Surface−Rework): ${formatNumber(deltaPct, 2)}%</span>
+
+            <div class="surface-hero">
+                <div class="surface-pp-cell surface-hero-pp">
+                    <div class="surface-pp-value">${formatNumber(ppRes.pp, 2)}</div>
+                    <div class="surface-pp-label">${mode === "Live" ? "Live PP" : mode} · Surface</div>
+                </div>
+                ${ppCell("Official PP", official && official.pp)}
+                ${ppCell("Rework PP", rework && rework.pp)}
+                ${ppCell("Δ vs Rework", deltaPct == null ? null : deltaPct)}
             </div>
-            <div class="estimator-debug-note">
+            ${deltaPct == null ? "" : `<div class="surface-hero-delta">${deltaPct >= 0 ? "+" : ""}${formatNumber(deltaPct, 2)}%</div>`}
+
+            <div class="surface-group">
+                <div class="surface-group-title">Map timing factor</div>
+                <div class="kv">
+                    <dt>windows (${schemeLabel(classic, isConvert)})</dt>
+                    <dd>${bandValuesText(windows)}</dd>
+                    <dt>map_windows</dt>
+                    <dd>${bandValuesText(mapWindows)}</dd>
+                    <dt>mods</dt>
+                    <dd>${modsText}</dd>
+                    <dt>expected_acc</dt>
+                    <dd>${formatNumber(expectedAcc * 100, 3)}%</dd>
+                    <dt>window_factor</dt>
+                    <dd>${formatNumber(mapFactorRes.windowFactor, 4)}</dd>
+                    <dt>ln_factor</dt>
+                    <dd>${formatNumber(mapFactorRes.lnFactor, 4)}</dd>
+                    <dt>map_factor</dt>
+                    <dd><strong>${formatNumber(mapFactorRes.factor, 4)}</strong></dd>
+                </div>
+            </div>
+
+            <div class="surface-group">
+                <div class="surface-group-title">Score timing adjustment</div>
+                <div class="kv">
+                    <dt>counts (${source})</dt>
+                    <dd>${countText} <span class="estimator-debug-meta">(hitTotal ${hitTotal})</span></dd>
+                    <dt>units_total</dt>
+                    <dd>${unitsTotal} (${unitLabel})</dd>
+                    <dt>player_loss</dt>
+                    <dd>${formatNumber(scoreAdjRes.playerLoss, 4)}</dd>
+                    <dt>expected_loss</dt>
+                    <dd>${formatNumber(scoreAdjRes.expectedLoss, 4)}</dd>
+                    <dt>loss_diff</dt>
+                    <dd>${formatNumber(scoreAdjRes.lossDiff, 4)}</dd>
+                    <dt>score multiplier</dt>
+                    <dd><strong>${formatNumber(scoreAdjRes.multiplier, 4)}</strong></dd>
+                    <dt>timing_multiplier <span class="estimator-debug-meta">(map+score)</span></dt>
+                    <dd><strong>${formatNumber(ppRes.timingMultiplier, 4)}</strong></dd>
+                </div>
+            </div>
+
+            <div class="surface-group">
+                <div class="surface-group-title">PP decomposition</div>
+                <div class="kv">
+                    <dt>xxy_pp_pattern</dt>
+                    <dd>${formatNumber(ppRes.xxyPpPattern, 2)}</dd>
+                    <dt>xxy_pp_accuracy</dt>
+                    <dd>${formatNumber(ppRes.xxyPpAccuracy, 2)}</dd>
+                    <dt>xxy_pp</dt>
+                    <dd>${formatNumber(ppRes.xxyPp, 2)}</dd>
+                    <dt>pp_with_timing</dt>
+                    <dd>${formatNumber(ppRes.ppWithTiming, 2)}</dd>
+                    <dt>pp_timing</dt>
+                    <dd>${formatNumber(ppRes.ppTiming, 2)}</dd>
+                </div>
+            </div>
+
+            <div class="estimator-debug-note surface-footnote">
                 timings — sunny ${formatNumber(timings.sunny ?? 0, 1)}ms · windows ${formatNumber(timings.windows, 1)}ms · units ${formatNumber(timings.units, 1)}ms · expected ${formatNumber(timings.expected, 1)}ms · mapFactor ${formatNumber(timings.mapFactor, 1)}ms · scoreAdj ${formatNumber(timings.scoreAdj, 1)}ms · total ${formatNumber(timings.total, 1)}ms
-                · od ${formatNumber(od, 1)}${odAvailable ? "" : " (unavailable)"}
             </div>
         </section>
     `;
+}
+
+// Minimal HTML escape for user-supplied beatmap metadata.
+function escapeHtml(value) {
+    return String(value ?? "")
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
 }
 
 /**
@@ -643,7 +702,21 @@ export function createSurfaceTimingPanel({
             : null;
         const official = officialPp != null ? { star: officialStar, pp: officialPp } : null;
 
+        // Beatmap metadata row (from the payload + sunny result).
+        const beatmap = data?.beatmap || {};
+        const mapInfo = {
+            artist: normalizeText(beatmap?.artist) || "-",
+            title: normalizeText(beatmap?.title) || "-",
+            version: normalizeText(beatmap?.version) || "-",
+            mapper: normalizeText(beatmap?.mapper) || "-",
+            keyCount: finiteNumber(ppMetrics?.totalNotes) != null
+                ? columnCountFromParsed(lastParse, classic)
+                : null,
+            sunnyStar: Number.isFinite(stars) ? stars : null,
+        };
+
         lastRender = {
+            mapInfo,
             mode,
             source,
             counts,

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
@@ -396,6 +396,9 @@ export function createSurfaceTimingPanel({
     let runSeq = 0;          // async invalidation
     let collapsed = false;   // second gate (debug.html layer gates first)
     let lastRender = null;   // {error: string} or full result object
+    let lastFetchFailed = false; // transient fetch failure (tosu not ready yet)
+    let lastFetchFailAt = 0;  // ms timestamp — throttle retry storms while tosu warms up
+    const FETCH_RETRY_MS = 1000;
 
     async function fetchCurrentBeatmap() {
         const response = await fetch(`http://${socketHost}/files/beatmap/file`, {
@@ -420,7 +423,9 @@ export function createSurfaceTimingPanel({
     function render() {
         const result = lastRender;
         if (result == null) {
-            root.innerHTML = "<div class=\"estimator-debug-empty\">Waiting for map data.</div>";
+            root.innerHTML = lastFetchFailed
+                ? "<div class=\"estimator-debug-note\">Waiting for beatmap file… (tosu not ready, retrying on next update)</div>"
+                : "<div class=\"estimator-debug-empty\">Waiting for map data.</div>";
             return;
         }
         if (result.error) {
@@ -433,11 +438,17 @@ export function createSurfaceTimingPanel({
     async function handleSocketPayload(data) {
         if (collapsed) return;
 
+        // Invalidate any in-flight async from an earlier message FIRST, then
+        // capture the new sequence (estimatorDebugPanel runAll pattern). Every
+        // async continuation checks `seq !== runSeq` and bails if a newer
+        // message arrived meanwhile.
+        runSeq += 1;
+        const seq = runSeq;
+
         const modData = getDebugModData(data);
         const mapKey = buildMapIdentity(data);
         if (!mapKey) return; // keep "Waiting for map data." until a real beatmap
 
-        const seq = runSeq;
         const mapChanged = mapKey !== lastIdentity;
         const modsChanged = modData.modSignature !== lastModsKey;
         let needRecomputeSR = mapChanged || modsChanged;
@@ -446,10 +457,17 @@ export function createSurfaceTimingPanel({
         // reuse the cached text/parse — parse results are mod-independent
         // (modIN/HO conversion happens inside sunnyAlgorithm on a clone).
         if (mapChanged || !lastOsuText) {
+            // Throttle retries while tosu/osu are warming up: ws messages arrive
+            // every ~100ms, so an immediate refetch on every message would spam
+            // the server during the startup window. Fetch again at most once
+            // per FETCH_RETRY_MS after a failure (or immediately after success).
+            const now = Date.now();
+            if (lastOsuText === "" && lastFetchFailed && now - lastFetchFailAt < FETCH_RETRY_MS) {
+                return;
+            }
             lastOsuText = "";
             lastParse = null;
             lastSunny = null;
-            runSeq += 1;
             try {
                 const osuText = await fetchCurrentBeatmap();
                 if (seq !== runSeq) return;
@@ -460,8 +478,23 @@ export function createSurfaceTimingPanel({
                 if (seq !== runSeq) return;
                 lastParse = parsed;
                 lastIdentity = mapKey;
+                if (lastFetchFailed) {
+                    lastFetchFailed = false;
+                    lastFetchFailAt = 0;
+                    lastRender = null;
+                    render();
+                }
             } catch (error) {
-                renderError(error?.message || "beatmap fetch/parse failed");
+                // Transient failure (e.g. tosu/osu just starting, menu beatmap
+                // not ready yet → HTTP 404): do NOT brick the panel into a
+                // permanent error. Mark the retry state and wait for the next
+                // api_v2 message with a beatmap — the empty lastIdentity /
+                // lastOsuText below makes any later payload retry the fetch
+                // (throttled by FETCH_RETRY_MS).
+                lastFetchFailed = true;
+                lastFetchFailAt = now;
+                lastRender = null;
+                render();
                 return;
             }
         }

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingPanel.js
@@ -1,0 +1,592 @@
+// Surface Timing Compare debug panel (browser-only, js/debug/).
+//
+// Renders the rosu-pp surface-map-timing pipeline (S2/S3 modules) against the
+// live tosu api_v2 payload: mode dispatch (Max PP / Score PP / Live), hit
+// judgement counts, map timing factor, score timing adjustment, and the
+// combined xxy+timing PP against the Rework PP reference.
+//
+// Mirrors estimatorDebugPanel.js conventions: root.innerHTML full re-render,
+// `.estimator-debug-*` + `.kv` classes from debug.html, performance.now()
+// segment timing, runSeq invalidation for the async beatmap fetch.
+//
+// The pure pipeline is split into module-level DOM-free exports so the Node
+// smoke (temp/surface-timing-smoke.mjs) can assert it without a browser:
+//   - resolveModeAndCounts(data, lastCounts, unitsTotal)  mode/hits dispatch
+//   - runSurfacePipeline({...})                            full calculation
+// createSurfaceTimingPanel itself is browser-only (fetch / innerHTML).
+
+import { APP_CONFIG } from "../../config.js";
+import { getModData } from "../app/modData.js";
+import {
+    isPlayStateName,
+    isResultScreenStateName,
+    normalizeClientStateName,
+} from "../app/modeLogic.js";
+import { extractCounts } from "../app/livePpCounts.js";
+import { runSunnyEstimatorFromText } from "../estimator/sunnyEstimator.js";
+import { OsuFileParser } from "../parser/osuFileParser.js";
+import { calculateReworkPp } from "../rework/reworkPerformance.js";
+import {
+    buildHitWindows,
+    buildMapWindows,
+    JUDGEMENT_NAMES,
+} from "./surfaceTimingWindows.js";
+import {
+    buildJudgementUnits,
+    buildLnDurationBuckets,
+    computeMapTimingFactor,
+    computeScoreAdjustment,
+    computeSurfacePp,
+    expectedCountsAtCoreSigma,
+    expectedCountsCustomAccuracy,
+    SURFACE_TIMING_MODEL,
+} from "./surfaceTimingCurve.js";
+
+const SORTED_KNOWN_MOD_CODES = [...APP_CONFIG.mods.knownCodes].sort((a, b) => b.length - a.length);
+const MOD_BIT_FLAG_ENTRIES = Object.entries(APP_CONFIG.mods.bitFlags);
+
+function finiteNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+}
+
+function formatNumber(value, digits = 2) {
+    const number = finiteNumber(value);
+    return number == null ? "-" : number.toFixed(digits);
+}
+
+function normalizeText(value) {
+    return String(value ?? "").trim();
+}
+
+function normalizePathText(value) {
+    return normalizeText(value).replace(/\\/g, "/").replace(/\/+/g, "/").toLowerCase();
+}
+
+function getDebugModData(data) {
+    return getModData(data, {
+        sortedKnownModCodes: SORTED_KNOWN_MOD_CODES,
+        modBitFlagEntries: MOD_BIT_FLAG_ENTRIES,
+        fallbackClient: data?.client || "",
+        preferPlayMods: false,
+    });
+}
+
+// Map-only identity (no mods suffix) — drives the "beatmap changed → refetch"
+// gate. Mods-only changes reuse the cached osu text and recompute SR instead.
+function buildMapIdentity(data) {
+    const beatmap = data?.beatmap || {};
+    const id = finiteNumber(beatmap?.id);
+    const setId = finiteNumber(beatmap?.set || beatmap?.setId || beatmap?.beatmapSetId);
+    const hash = normalizeText(beatmap?.md5 || beatmap?.checksum).toLowerCase();
+    const path = normalizePathText(data?.files?.beatmap || data?.directPath?.beatmapFile);
+    const title = [
+        beatmap?.artist,
+        beatmap?.title,
+        beatmap?.version,
+        beatmap?.mapper,
+    ].map(normalizeText).join("::").toLowerCase();
+
+    const parts = [];
+    if (id != null && id > 0) parts.push(`id:${Math.trunc(id)}`);
+    if (hash) parts.push(`hash:${hash}`);
+    if (path) parts.push(`path:${path}`);
+    if (parts.length === 0 && title.replace(/[:]/g, "")) parts.push(`meta:${title}`);
+    if (setId != null && setId > 0) parts.push(`set:${Math.trunc(setId)}`);
+    return parts.join("|");
+}
+
+// Full identity incl. mods (same shape as estimatorDebugPanel.buildBeatmapIdentity).
+function buildBeatmapIdentity(data, modSignature) {
+    const mapKey = buildMapIdentity(data);
+    return mapKey ? `${mapKey}|mods:${modSignature || "none"}` : "";
+}
+
+function countsToArray(counts) {
+    return [
+        Number(counts?.perfect) || 0,
+        Number(counts?.great) || 0,
+        Number(counts?.good) || 0,
+        Number(counts?.ok) || 0,
+        Number(counts?.meh) || 0,
+        Number(counts?.miss) || 0,
+    ];
+}
+
+function countsTotal(counts) {
+    return counts.reduce((sum, c) => sum + c, 0);
+}
+
+function schemeLabel(classic, isConvert) {
+    if (!classic) return "lazer";
+    return isConvert ? "classic convert" : "classic non-convert";
+}
+
+/**
+ * Resolve the display mode and judgement counts from an api_v2 payload.
+ * Pure DOM-free helper (Node smoke tested).
+ *
+ * Mode dispatch: resultscreen → "Score PP", play/gameplay/playing → "Live",
+ * anything else → "Max PP" (SS assumption: every unit judged perfect).
+ * Counts come from resultsScreen.hits / play.hits (extractCounts semantics);
+ * a resultscreen without hits retains the previous counts (retainOnEmpty).
+ *
+ * @param {object} data api_v2 payload
+ * @param {number[]|null} [lastCounts] previous counts in JUDGEMENT_NAMES order
+ * @param {number} [unitsTotal] judgement units for the SS override (0 → all-zero SS row)
+ * @returns {{mode: string, source: string, isResult: boolean, isPlay: boolean,
+ *            hits: object|null, counts: number[], hitTotal: number}}
+ */
+export function resolveModeAndCounts(data, lastCounts = null, unitsTotal = 0) {
+    const stateName = normalizeClientStateName(data?.state?.name);
+    const isResult = isResultScreenStateName(stateName);
+    const isPlay = isPlayStateName(stateName);
+
+    let mode = "Max PP";
+    let source = "SS assumption";
+    if (isResult) {
+        mode = "Score PP";
+        source = "resultsScreen.hits";
+    } else if (isPlay) {
+        mode = "Live";
+        source = "play.hits";
+    }
+
+    const hits = isResult
+        ? (data && data.resultsScreen && data.resultsScreen.hits)
+        : isPlay ? (data && data.play && data.play.hits) : null;
+
+    let counts;
+    if (hits) {
+        counts = countsToArray(extractCounts(hits));
+        if (isResult && countsTotal(counts) === 0 && lastCounts) {
+            counts = lastCounts.slice();
+        }
+    } else if (isResult && lastCounts) {
+        counts = lastCounts.slice();
+    } else {
+        counts = [0, 0, 0, 0, 0, 0];
+    }
+
+    // Max PP: assume perfect on every judgement unit.
+    if (!isPlay && !isResult) {
+        counts = [unitsTotal, 0, 0, 0, 0, 0];
+    }
+
+    return { mode, source, isResult, isPlay, hits, counts, hitTotal: countsTotal(counts) };
+}
+
+/**
+ * The full surface timing calculation for one snapshot. Pure DOM-free (Node
+ * smoke tested). Mirrors handleSocketPayload's orchestration with
+ * performance.now() segment timing; callers supply parsed/derived inputs
+ * (no fetching, no parsing, no DOM).
+ *
+ * @param {{
+ *   od: number, isConvert?: boolean, classic?: boolean,
+ *   hr?: boolean, ez?: boolean, clockRate?: number,
+ *   stars: number, variety: number, accScalar: number,
+ *   nObjects: number, nLongNotes?: number, lnBuckets: number[],
+ *   counts: number[], hitTotal: number, unitsTotal: number,
+ *   totalNotes?: number, noFail?: boolean, easy?: boolean,
+ *   model: object,
+ * }} args
+ * @returns {{
+ *   windows: object, mapWindows: object, units: object[],
+ *   expectedArr: number[], expectedAcc: number, scoreAccuracy: number,
+ *   mapFactorRes: object, scoreAdjRes: object, ppRes: object,
+ *   rework: object|null, deltaPct: number|null,
+ *   timings: {windows: number, units: number, expected: number,
+ *             mapFactor: number, scoreAdj: number, total: number},
+ * }}
+ */
+export function runSurfacePipeline({
+    od,
+    isConvert = false,
+    classic = true,
+    hr = false,
+    ez = false,
+    clockRate = 1,
+    stars,
+    variety,
+    accScalar,
+    nObjects,
+    nLongNotes = 0,
+    lnBuckets,
+    counts,
+    hitTotal,
+    unitsTotal,
+    totalNotes = unitsTotal,
+    noFail = false,
+    easy = false,
+    model,
+}) {
+    const t0 = performance.now();
+    const windows = buildHitWindows({ od, isConvert, classic, hr, ez, clockRate });
+    const mapWindows = buildMapWindows({ od, isConvert, classic, clockRate });
+    const t1 = performance.now();
+
+    const units = buildJudgementUnits({ stars, unitsTotal, nObjects, nLongNotes, lnBuckets, classic, model });
+    const t2 = performance.now();
+
+    const expectedArr = expectedCountsAtCoreSigma(units, windows, model, SURFACE_TIMING_MODEL.TIMING_BASELINE_SIGMA);
+    const expectedAcc = expectedCountsCustomAccuracy(expectedArr);
+    const t3 = performance.now();
+
+    const mapFactorRes = computeMapTimingFactor({ expectedAcc, nLongNotes, nObjects, lnBuckets });
+    const t4 = performance.now();
+
+    const scoreAdjRes = computeScoreAdjustment({ playerCounts: counts, units, windows, hitTotal, model });
+    const t5 = performance.now();
+
+    const scoreAccuracy = expectedCountsCustomAccuracy(counts);
+    const ppRes = computeSurfacePp({
+        stars,
+        variety,
+        accScalar,
+        nObjects,
+        scoreAccuracy,
+        mapFactor: mapFactorRes.factor,
+        scoreAdj: scoreAdjRes.multiplier,
+        noFail,
+    });
+    const now = performance.now();
+
+    const rework = calculateReworkPp({
+        starRating: stars,
+        variety,
+        accScalar,
+        totalNotes,
+        perfect: counts[0],
+        great: counts[1],
+        good: counts[2],
+        ok: counts[3],
+        meh: counts[4],
+        miss: counts[5],
+        noFail,
+        easy,
+    });
+    const deltaPct = rework && Number.isFinite(ppRes.pp) && rework.pp > 0
+        ? (ppRes.pp - rework.pp) / rework.pp * 100
+        : null;
+
+    return {
+        windows,
+        mapWindows,
+        units,
+        expectedArr,
+        expectedAcc,
+        scoreAccuracy,
+        mapFactorRes,
+        scoreAdjRes,
+        ppRes,
+        rework,
+        deltaPct,
+        timings: {
+            windows: t1 - t0,
+            units: t2 - t1,
+            expected: t3 - t2,
+            mapFactor: t4 - t3,
+            scoreAdj: t5 - t4,
+            total: now - t0,
+        },
+    };
+}
+
+function bandValuesText(windows) {
+    return JUDGEMENT_NAMES.map((name) => `${name}: ${formatNumber(windows[name], 1)}ms`).join(" · ");
+}
+
+function buildPanelHtml(result) {
+    const {
+        mode, source, counts, unitsTotal, hitTotal, od, odAvailable,
+        classic, isConvert, hr, ez, clockRate, windows, mapWindows,
+        expectedAcc, mapFactorRes, scoreAdjRes, ppRes, rework, deltaPct, timings,
+    } = result;
+
+    const diffMultiplier = hr ? 1.4 : (ez ? 1 / 1.4 : 1);
+    const unitLabel = classic ? "V1" : "V2";
+    const modsText = [
+        `difficulty ×${formatNumber(diffMultiplier, 2)}${hr ? " (HR)" : ""}${ez ? " (EZ)" : ""}`,
+        `clock_rate ${formatNumber(clockRate, 3)}`,
+    ].join(" · ");
+
+    return `
+        <section class="estimator-debug-panel">
+            <div class="estimator-debug-header">
+                <div>
+                    <h2>Surface Timing Compare</h2>
+                    <div class="estimator-debug-meta">
+                        <span class="badge">${mode}</span>
+                        <span class="badge">${source}</span>
+                        <span class="badge">v${SURFACE_TIMING_MODEL.VERSION}</span>
+                    </div>
+                </div>
+            </div>
+            <div class="kv">
+                <dt>windows (${schemeLabel(classic, isConvert)})</dt>
+                <dd>${bandValuesText(windows)}</dd>
+                <dt>mods</dt>
+                <dd>${modsText}</dd>
+                <dt>map_windows</dt>
+                <dd>${bandValuesText(mapWindows)}</dd>
+                <dt>expected_acc</dt>
+                <dd>${formatNumber(expectedAcc * 100, 3)}%</dd>
+                <dt>window_factor</dt>
+                <dd>${formatNumber(mapFactorRes.windowFactor, 4)}</dd>
+                <dt>ln_factor</dt>
+                <dd>${formatNumber(mapFactorRes.lnFactor, 4)}</dd>
+                <dt>map_factor</dt>
+                <dd>${formatNumber(mapFactorRes.factor, 4)}</dd>
+                <dt>counts <span class="estimator-debug-meta">(${source})</span></dt>
+                <dd>perfect: ${counts[0]} · great: ${counts[1]} · good: ${counts[2]} · ok: ${counts[3]} · meh: ${counts[4]} · miss: ${counts[5]} <span class="estimator-debug-meta">(hitTotal ${hitTotal})</span></dd>
+                <dt>units_total</dt>
+                <dd>${unitsTotal} (${unitLabel})</dd>
+                <dt>score_adjustment</dt>
+                <dd>player_loss ${formatNumber(scoreAdjRes.playerLoss, 4)} · expected_loss ${formatNumber(scoreAdjRes.expectedLoss, 4)} · loss_diff ${formatNumber(scoreAdjRes.lossDiff, 4)} <strong>→ multiplier ${formatNumber(scoreAdjRes.multiplier, 4)}</strong></dd>
+                <dt>timing_multiplier</dt>
+                <dd>${formatNumber(ppRes.timingMultiplier, 4)} (map × score)</dd>
+                <dt>xxy_pp_pattern</dt>
+                <dd>${formatNumber(ppRes.xxyPpPattern, 2)}</dd>
+                <dt>xxy_pp_accuracy</dt>
+                <dd>${formatNumber(ppRes.xxyPpAccuracy, 2)}</dd>
+                <dt>xxy_pp</dt>
+                <dd>${formatNumber(ppRes.xxyPp, 2)}</dd>
+                <dt>pp_with_timing</dt>
+                <dd>${formatNumber(ppRes.ppWithTiming, 2)}</dd>
+                <dt>pp_timing</dt>
+                <dd>${formatNumber(ppRes.ppTiming, 2)}</dd>
+                <dt>${mode} PP <span class="estimator-debug-meta">(${source})</span></dt>
+                <dd>${formatNumber(ppRes.pp, 2)} <span class="estimator-debug-meta">(Rework ${formatNumber(rework && rework.pp, 2)} · Δ ${formatNumber(deltaPct, 2)}%)</span></dd>
+            </div>
+            <div class="estimator-debug-result-line">
+                <strong>Rework PP: ${formatNumber(rework && rework.pp, 2)}</strong>
+                <span>|</span>
+                <span>Surface PP: ${formatNumber(ppRes.pp, 2)}</span>
+                <span>|</span>
+                <span>Δ: ${formatNumber(deltaPct, 2)}%</span>
+            </div>
+            <div class="estimator-debug-note">
+                timings — windows ${formatNumber(timings.windows, 1)}ms · units ${formatNumber(timings.units, 1)}ms · expected ${formatNumber(timings.expected, 1)}ms · mapFactor ${formatNumber(timings.mapFactor, 1)}ms · scoreAdj ${formatNumber(timings.scoreAdj, 1)}ms · total ${formatNumber(timings.total, 1)}ms
+                · od ${formatNumber(od, 1)}${odAvailable ? "" : " (unavailable)"}
+            </div>
+        </section>
+    `;
+}
+
+/**
+ * Surface Timing Compare debug panel.
+ * @param {{root: HTMLElement, socketHost?: string}} options
+ * @returns {{handleSocketPayload: (data: object) => Promise<void>, setCollapsed: (collapsed: boolean) => void}}
+ */
+export function createSurfaceTimingPanel({
+    root,
+    socketHost = "127.0.0.1:24050",
+} = {}) {
+    if (!root) {
+        throw new Error("Surface timing panel root is required");
+    }
+
+    let lastIdentity = "";   // map-only key (refetch gate)
+    let lastOsuText = "";    // cached osu text
+    let lastModsKey = "";    // modSignature (SR recompute gate)
+    let lastCounts = null;   // last judgement counts (resultscreen retain)
+    let lastParse = null;    // cached OsuFileParser getParsedData (same map)
+    let lastSunny = null;    // cached Sunny result (same map+mods)
+    let runSeq = 0;          // async invalidation
+    let collapsed = false;   // second gate (debug.html layer gates first)
+    let lastRender = null;   // {error: string} or full result object
+
+    async function fetchCurrentBeatmap() {
+        const response = await fetch(`http://${socketHost}/files/beatmap/file`, {
+            method: "GET",
+            cache: "no-store",
+        });
+        if (!response.ok) {
+            throw new Error(`beatmap fetch failed: HTTP ${response.status}`);
+        }
+        const text = await response.text();
+        if (!text.trim()) {
+            throw new Error("beatmap fetch returned empty content");
+        }
+        return text;
+    }
+
+    function renderError(message) {
+        lastRender = { error: message };
+        render();
+    }
+
+    function render() {
+        const result = lastRender;
+        if (result == null) {
+            root.innerHTML = "<div class=\"estimator-debug-empty\">Waiting for map data.</div>";
+            return;
+        }
+        if (result.error) {
+            root.innerHTML = `<div class="estimator-debug-error">${result.error}</div>`;
+            return;
+        }
+        root.innerHTML = buildPanelHtml(result);
+    }
+
+    async function handleSocketPayload(data) {
+        if (collapsed) return;
+
+        const modData = getDebugModData(data);
+        const mapKey = buildMapIdentity(data);
+        if (!mapKey) return; // keep "Waiting for map data." until a real beatmap
+
+        const seq = runSeq;
+        const mapChanged = mapKey !== lastIdentity;
+        const modsChanged = modData.modSignature !== lastModsKey;
+        let needRecomputeSR = mapChanged || modsChanged;
+
+        // Beatmap changed (or no cached text): fetch + parse. Mods-only changes
+        // reuse the cached text/parse — parse results are mod-independent
+        // (modIN/HO conversion happens inside sunnyAlgorithm on a clone).
+        if (mapChanged || !lastOsuText) {
+            lastOsuText = "";
+            lastParse = null;
+            lastSunny = null;
+            runSeq += 1;
+            try {
+                const osuText = await fetchCurrentBeatmap();
+                if (seq !== runSeq) return;
+                lastOsuText = osuText;
+                const parser = new OsuFileParser(osuText);
+                parser.process();
+                const parsed = parser.getParsedData();
+                if (seq !== runSeq) return;
+                lastParse = parsed;
+                lastIdentity = mapKey;
+            } catch (error) {
+                renderError(error?.message || "beatmap fetch/parse failed");
+                return;
+            }
+        }
+
+        if (lastParse.status === "Fail" || lastParse.status === "NotMania") {
+            renderError(lastParse.status === "NotMania"
+                ? "beatmap mode is not mania"
+                : "beatmap parse failed");
+            return;
+        }
+
+        // Sunny SR — cached across identical map+mods; rerun when either changed.
+        let sunny = lastSunny;
+        if (needRecomputeSR) {
+            try {
+                sunny = runSunnyEstimatorFromText(lastOsuText, {
+                    speedRate: modData.speedRate,
+                    odFlag: modData.odFlag,
+                    cvtFlag: modData.cvtFlag,
+                    withPpMetrics: true,
+                    classicMod: modData.classic,
+                });
+            } catch (error) {
+                renderError(error?.message || "Sunny estimator failed");
+                return;
+            }
+            if (seq !== runSeq) return;
+            lastSunny = sunny;
+        }
+
+        const ppMetrics = sunny?.ppMetrics;
+        const stars = finiteNumber(sunny?.star);
+        if (stars == null || stars <= 0 || !ppMetrics
+            || !Number.isFinite(finiteNumber(ppMetrics.variety))
+            || !Number.isFinite(finiteNumber(ppMetrics.accScalar))
+            || !(finiteNumber(ppMetrics.totalNotes) > 0)) {
+            renderError("Sunny result unavailable (star/ppMetrics invalid)");
+            return;
+        }
+
+        // LN histogram from the raw parsed chart (map-time ms, not ÷clockRate).
+        const nObjects = lastParse.noteTypes.length;
+        const longNoteDurations = [];
+        for (let i = 0; i < nObjects; i += 1) {
+            if ((lastParse.noteTypes[i] & 128) !== 0) {
+                longNoteDurations.push(lastParse.noteEnds[i] - lastParse.noteStarts[i]);
+            }
+        }
+        const nLongNotes = longNoteDurations.length;
+        const lnBuckets = buildLnDurationBuckets(longNoteDurations);
+
+        const classic = modData.classic;
+        const unitsTotal = classic ? nObjects : nObjects + nLongNotes;
+
+        const resolved = resolveModeAndCounts(data, lastCounts, unitsTotal);
+        const { mode, source, counts, hitTotal, hits, isResult } = resolved;
+        // Retain counts on the results screen; track live hits otherwise.
+        // Fresh-play all-zero counts are legitimate — keep them.
+        if (isResult || hits) lastCounts = counts;
+
+        // Raw map OD from the parser (getParsedData exposes `.od`); the HR/EZ
+        // difficulty multiplier is applied inside buildHitWindows, so no
+        // pre-conversion here. Fall back to 8 when the map lacks OverallDifficulty.
+        const rawOd = finiteNumber(lastParse.od);
+        const odAvailable = rawOd != null && rawOd >= 0;
+        const od = odAvailable ? rawOd : 8;
+
+        const modCodes = modData.modCodes;
+        const pipeline = runSurfacePipeline({
+            od,
+            isConvert: Boolean(modData.cvtFlag),
+            classic,
+            hr: modCodes.includes("HR"),
+            ez: modCodes.includes("EZ"),
+            clockRate: modData.speedRate,
+            stars,
+            variety: ppMetrics.variety,
+            accScalar: ppMetrics.accScalar,
+            nObjects,
+            nLongNotes,
+            lnBuckets,
+            counts,
+            hitTotal,
+            unitsTotal,
+            totalNotes: ppMetrics.totalNotes,
+            noFail: modCodes.includes("NF"),
+            easy: modCodes.includes("EZ"),
+            model: SURFACE_TIMING_MODEL.ERROR_MODEL,
+        });
+
+        lastRender = {
+            mode,
+            source,
+            counts,
+            unitsTotal,
+            hitTotal,
+            od,
+            odAvailable,
+            classic,
+            isConvert: Boolean(modData.cvtFlag),
+            hr: modCodes.includes("HR"),
+            ez: modCodes.includes("EZ"),
+            clockRate: modData.speedRate,
+            windows: pipeline.windows,
+            mapWindows: pipeline.mapWindows,
+            expectedAcc: pipeline.expectedAcc,
+            mapFactorRes: pipeline.mapFactorRes,
+            scoreAdjRes: pipeline.scoreAdjRes,
+            ppRes: pipeline.ppRes,
+            rework: pipeline.rework,
+            deltaPct: pipeline.deltaPct,
+            timings: pipeline.timings,
+        };
+        lastModsKey = modData.modSignature;
+        render();
+    }
+
+    function setCollapsed(nextCollapsed) {
+        collapsed = Boolean(nextCollapsed);
+    }
+
+    render();
+
+    return {
+        handleSocketPayload,
+        setCollapsed,
+    };
+}

--- a/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingWindows.js
+++ b/ManiaMapAnalyser by Leo_Black/js/debug/surfaceTimingWindows.js
@@ -1,0 +1,194 @@
+// Surface timing windows for osu!mania hit judgement.
+//
+// Ported from rosu-pp mania-surface-map-timing-difficulty @ 328e339
+// `src/mania/sunny_windows.rs`. Zero-import, DOM-free pure module:
+// runs unchanged in the tosu overlay (browser) and in Node (benchmark smoke).
+//
+// Window semantics match rosu-pp: raw ms windows are `finalize`d through
+// `(floor(value / multiplier * clockRate) + 0.5) / clockRate` — no epsilon
+// padding, exactly like the Rust `HitWindows::finalize`.
+
+/** Lazer hit windows per OD anchor: { od0, od5, od10 } (from sunny_windows.rs `LAZER_*`). */
+export const LAZER_PERFECT = { od0: 22.4, od5: 19.4, od10: 13.9 };
+export const LAZER_GREAT = { od0: 64, od5: 49, od10: 34 };
+export const LAZER_GOOD = { od0: 97, od5: 82, od10: 67 };
+export const LAZER_OK = { od0: 127, od5: 112, od10: 97 };
+export const LAZER_MEH = { od0: 151, od5: 136, od10: 121 };
+export const LAZER_MISS = { od0: 188, od5: 173, od10: 158 };
+
+/** Classic hit windows (convert maps, round(od) > 4) — sunny_windows.rs `CLASSIC_TIGHT`. */
+export const CLASSIC_TIGHT = { perfect: 16, great: 34, good: 67, ok: 97, meh: 121, miss: 158 };
+/** Classic hit windows (convert maps, round(od) <= 4) — sunny_windows.rs `CLASSIC_LOOSE`. */
+export const CLASSIC_LOOSE = { perfect: 16, great: 47, good: 77, ok: 97, meh: 121, miss: 158 };
+
+/** HR difficulty multiplier — sunny_windows.rs `DIFFICULTY_MULTIPLIER_HR`. */
+export const DIFFICULTY_MULTIPLIER_HR = 1.4;
+/** EZ difficulty multiplier — sunny_windows.rs `DIFFICULTY_MULTIPLIER_EZ`. */
+export const DIFFICULTY_MULTIPLIER_EZ = 1 / 1.4;
+
+/** Judgement names in ascending strictness order — sunny_windows.rs `JUDGEMENT_NAMES`. */
+export const JUDGEMENT_NAMES = ["perfect", "great", "good", "ok", "meh", "miss"];
+
+/**
+ * Interpolate an OD-anchored window range at `od` (Rust `difficulty_range`).
+ * @param {number} od overall difficulty (0..10)
+ * @param {{od0: number, od5: number, od10: number}} range anchor windows
+ * @returns {number} ms window
+ */
+export function difficultyRange(od, range) {
+    return od > 5
+        ? range.od5 + (range.od10 - range.od5) * (od - 5) / 5
+        : range.od0 + (range.od5 - range.od0) * od / 5;
+}
+
+/**
+ * Lazer hit windows at `od` (Rust `lazer_windows`).
+ * @param {number} od overall difficulty (0..10)
+ * @returns {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} raw ms windows
+ */
+export function lazerWindows(od) {
+    return {
+        perfect: difficultyRange(od, LAZER_PERFECT),
+        great: difficultyRange(od, LAZER_GREAT),
+        good: difficultyRange(od, LAZER_GOOD),
+        ok: difficultyRange(od, LAZER_OK),
+        meh: difficultyRange(od, LAZER_MEH),
+        miss: difficultyRange(od, LAZER_MISS),
+    };
+}
+
+/**
+ * Classic hit windows at `od` (Rust `classic_windows`). Convert maps pick the
+ * tight/loose table by `Math.round(od)`; non-convert maps widen linearly with
+ * `antiOd = clamp(10 - od, 0, 10)` (3 ms per band, perfect stays 16).
+ * @param {number} od overall difficulty (0..10)
+ * @param {boolean} [isConvert=false] true for convert (stable) maps
+ * @returns {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} raw ms windows
+ */
+export function classicWindows(od, isConvert) {
+    if (isConvert) {
+        return Math.round(od) > 4 ? CLASSIC_TIGHT : CLASSIC_LOOSE;
+    }
+    const antiOd = Math.min(10, Math.max(0, 10 - od));
+    const wide = 3 * antiOd;
+    return {
+        perfect: 16,
+        great: 34 + wide,
+        good: 67 + wide,
+        ok: 97 + wide,
+        meh: 121 + wide,
+        miss: 158 + wide,
+    };
+}
+
+/**
+ * Apply difficulty multiplier and clock rate to raw windows (Rust
+ * `HitWindows::finalize`): `(floor(value / multiplier * clockRate) + 0.5) / clockRate`.
+ * No epsilon padding — mirrors upstream exactly. Returns a new object.
+ * @param {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} windows raw ms windows
+ * @param {number} multiplier difficulty multiplier (HR/EZ)
+ * @param {number} [clockRate=1] playback rate
+ * @returns {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} final ms windows
+ */
+export function finalize(windows, multiplier, clockRate) {
+    const apply = (value) => (Math.floor(value / multiplier * clockRate) + 0.5) / clockRate;
+    return {
+        perfect: apply(windows.perfect),
+        great: apply(windows.great),
+        good: apply(windows.good),
+        ok: apply(windows.ok),
+        meh: apply(windows.meh),
+        miss: apply(windows.miss),
+    };
+}
+
+/**
+ * Difficulty multiplier from speed-rate-neutral mods (Rust
+ * `difficulty_multiplier`, HR checked before EZ).
+ * @param {{hr?: boolean, ez?: boolean}} [mods={}]
+ * @returns {number} 1.4 for HR, 1/1.4 for EZ, else 1.0
+ */
+export function difficultyMultiplier({ hr = false, ez = false } = {}) {
+    if (hr) {
+        return DIFFICULTY_MULTIPLIER_HR;
+    }
+    if (ez) {
+        return DIFFICULTY_MULTIPLIER_EZ;
+    }
+    return 1.0;
+}
+
+/**
+ * Build finalized hit windows for a map (Rust `hit_windows`): classic by
+ * default, lazer when `classic: false`.
+ * @param {{od: number, isConvert?: boolean, classic?: boolean, hr?: boolean, ez?: boolean, clockRate?: number}} options
+ * @returns {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} final ms windows
+ */
+export function buildHitWindows({ od, isConvert = false, classic = true, hr = false, ez = false, clockRate = 1 }) {
+    const raw = classic ? classicWindows(od, isConvert) : lazerWindows(od);
+    return finalize(raw, difficultyMultiplier({ hr, ez }), clockRate);
+}
+
+/**
+ * Build map windows with an empty mod set (Rust `map_windows`): no HR/EZ,
+ * clock rate applied.
+ * @param {{od: number, isConvert?: boolean, classic?: boolean, clockRate?: number}} options
+ * @returns {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} final ms windows
+ */
+export function buildMapWindows({ od, isConvert = false, classic = true, clockRate = 1 }) {
+    return buildHitWindows({ od, isConvert, classic, clockRate });
+}
+
+/**
+ * Map a hit error (ms) to a judgement (Rust `judge`). Negative errors use
+ * absolute value; misses are everything beyond the meh window.
+ * @param {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} windows finalized windows
+ * @param {number} errorMs hit error in ms
+ * @returns {"perfect"|"great"|"good"|"ok"|"meh"|"miss"} judgement
+ */
+export function judgeError(windows, errorMs) {
+    const error = Math.abs(errorMs);
+    if (error <= windows.perfect) {
+        return "perfect";
+    }
+    if (error <= windows.great) {
+        return "great";
+    }
+    if (error <= windows.good) {
+        return "good";
+    }
+    if (error <= windows.ok) {
+        return "ok";
+    }
+    if (error <= windows.meh) {
+        return "meh";
+    }
+    return "miss";
+}
+
+/**
+ * Absolute window band [lower, upper] in ms for a judgement (Rust `band()`,
+ * for the S3 curve module). Bands are contiguous: upper of one judgement is
+ * the lower of the next.
+ * @param {{perfect: number, great: number, good: number, ok: number, meh: number, miss: number}} windows finalized windows
+ * @param {string} judgementName one of JUDGEMENT_NAMES
+ * @returns {[number, number]} inclusive lower, exclusive upper (miss upper is Infinity)
+ */
+export function getBand(windows, judgementName) {
+    switch (judgementName) {
+        case "perfect":
+            return [0, windows.perfect];
+        case "great":
+            return [windows.perfect, windows.great];
+        case "good":
+            return [windows.great, windows.good];
+        case "ok":
+            return [windows.good, windows.ok];
+        case "meh":
+            return [windows.ok, windows.meh];
+        case "miss":
+            return [windows.meh, Infinity];
+        default:
+            throw new Error(`unknown judgement: ${judgementName}`);
+    }
+}


### PR DESCRIPTION
## Background
The debug page previously had only two modules (Estimator Compare and Raw payload) with no collapse mechanism. This PR adds a third module, Surface Timing Compare, which ports the two-factor timing model from the upstream rosu-pp branch `ppy-sb/rosu-pp @ mania-surface-map-timing-difficulty` (pinned at `328e339`, a rebased commit whose formulas are equivalent to `63a8eca`). It computes Max PP (SS assumption) on song select and Score PP / Live PP from real judgements during play, and displays all internal parameters, per-segment timings, and a live comparison against the existing Rework PP. Since the upstream branch is still evolving actively, this PR bakes in an update-adaptation mechanism (single-point frozen constants object + version badge + sync protocol) so future upstream changes can be followed with minimal effort.

## Changes
New files under js/debug/ (pure functions + browser panel layering):

- surfaceTimingWindows.js: six-band hit window pure functions (lazer / classic non-convert / classic convert schemes, finalize without epsilon per Rust, HR 1.4 / EZ 1/1.4 multipliers), DOM-free and Node smoke-testable.
- surfaceTimingCurve.js: frozen SURFACE_TIMING_MODEL constants object (including VERSION="328e339" with upstream source annotations) + NR erfc / tail functions / mixture exceedance curves / judgement units (LN split + uniform, unitsOverride reserved) / expected counts / map timing factor / loss-based score adjustment / xxy PP composition, all line-aligned with upstream.
- surfaceTimingPanel.js: mode dispatch (Max PP / Score PP / Live, reusing modeLogic semantics), hits selection (resultsScreen.hits authoritative / play.hits / SS assumption), Sunny SR and LN duration histogram inputs, Rework PP comparison row with Δ%, per-segment timings; core calculation split into DOM-free pure functions for Node assertions.

Modified (debug.html):

- Three unified collapsible modules: <details> wrapping Estimator Compare / Surface Timing Compare / Raw payload, collapse = no compute, expand naturally resumes, layout remembered in mma-debug-layout-v1.
- Surface module header shows the algorithm version badge (v328e339); collapse gating short-circuits at the message dispatch point.
- Estimator panel and pause/clear semantics unchanged (no regression).

## Verification

- Smoke: `node --loader ./temp/esm-loader.mjs temp/surface-timing-smoke.mjs` → SMOKE: 391/391 PASS (273 §P1 window anchors + 118 §P2 curve/factor/bucket/pipeline).
- node --check passes for all three new files and the debug.html inline script.
- Browser-verified (temporary static server, no tosu environment): three-module defaults, toggle, localStorage restore, version badge, Surface waiting state, index.html no regression.
- Upstream re-verified twice (S0/S6): tip remains 328e339, formulas zero-drift; sync record at .omo/evidence/surface-timing-debug/upstream-sync-328e339.txt.
- Smoke script and loader kept under temp/ (gitignored), to be deleted after acceptance.