### PR TITLE
fix(graph): put the difficulty graph on the chart timeline — Roxy graph times + late tosu timeline (issue #68)

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -391,7 +391,9 @@ export async function fetchBeatmapFile(reason) {
     //   同 identity 的旧快照（错误的首块结果）必须失效。
     // star-v5：Mixed 低难 RC 段 Azusa⊕Companella 融合 + Azusa LN 门控生效，
     //   低难图的 numeric/estDiff 语义变化 → 旧快照必须失效。
-    const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v5";
+    // star-v6：Roxy 的 graph 时间轴还原为原始谱面时间（此前是 canonicalizeOsuTiming
+    //   平移过的分析文本时间轴），旧快照里的 times 会让整张图的 x 轴窗口与进度线错位。
+    const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v6";
     const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
     const isMetaDegraded = String(state.lastBeatmapIdentity || "").startsWith("meta:");
     let cached = null;

--- a/ManiaMapAnalyser by Leo_Black/js/app/appContext.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/appContext.js
@@ -129,6 +129,9 @@ export const state = {
     currentModeTag: "Mix",
     etternaTechnicalHidden: false,
     graphSeries: null,
+    // 未裁剪的归一化序列 + 渲染时用的谱面时间线：时间线补全后据此重画 x 轴窗口。
+    graphSeriesSource: null,
+    graphSeriesTimelineStartMs: null,
     pauseMarkerTimes: [],
     pauseCount: 0,
     isPaused: false,

--- a/ManiaMapAnalyser by Leo_Black/js/app/graph.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/graph.js
@@ -141,13 +141,33 @@ function setGraphLoadingTextVisible(view, visible) {
     loadingTextEl.hidden = !visible;
 }
 
+// 谱面时间线（tosu beatmap.time.firstObject）常晚于首次渲染才补全：选歌阶段
+// 该字段为 0 / 缺失，真正载入谱面后才给出首个物件的谱面时间。这里的裁剪只在
+// 渲染时快照一次，所以时间线变化必须触发 refreshGraphTimeline 重建（否则整首歌
+// 都会保留前奏空档，进度线也一起偏）。
+function currentTimelineStartMs() {
+    const raw = state.songStartMs;
+    // Number(null) === 0 —— 显式区分"未知时间线"，否则会被当成 firstObject=0 的历史值。
+    if (raw === null || raw === undefined || raw === "") {
+        return null;
+    }
+    const startTime = Number(raw);
+    return Number.isFinite(startTime) ? startTime : null;
+}
+
+/** 丢弃重建源：曲线被清空 / 进入加载态 / 渲染失败时，不再按新时间线重画旧数据。 */
+function dropGraphSeriesSource() {
+    state.graphSeriesSource = null;
+    state.graphSeriesTimelineStartMs = null;
+}
+
 function trimSeriesStartToFirstObject(series) {
     if (!series || !Array.isArray(series.times) || !Array.isArray(series.values)) {
         return null;
     }
 
-    const startTime = Number(state.songStartMs);
-    if (!Number.isFinite(startTime)) {
+    const startTime = currentTimelineStartMs();
+    if (startTime === null) {
         return series;
     }
 
@@ -338,6 +358,7 @@ export function resetPauseRuntime(clearMarkers = false) {
 
 export function clearDiffGraph() {
     state.graphSeries = null;
+    dropGraphSeriesSource();
 
     forEachGraphView((view) => {
         if (view.svgEl) {
@@ -390,6 +411,12 @@ export function setGraphLoading(isLoading) {
         return;
     }
 
+    if (isLoading) {
+        // 进入加载态 = 当前曲线即将被替换：丢弃重建源，避免正在分析时
+        // 时间线变化把上一张图的曲线重新画回加载骨架上。
+        dropGraphSeriesSource();
+    }
+
     forEachEnabledGraphView((view) => {
         if (!view.svgEl || !view.fillEl || !view.lineEl) {
             return;
@@ -430,6 +457,7 @@ export function showDiffGraphError(message) {
 
     setGraphLoading(false);
     state.graphSeries = null;
+    dropGraphSeriesSource();
     forEachEnabledGraphView((view) => {
         clearGraphScanEnter(view);
         if (view.cursorEl) {
@@ -556,16 +584,22 @@ function f1(v) {
     return Number.isFinite(v) ? v.toFixed(1) : "0";
 }
 
-export function renderDiffGraph(graphData) {
+export function renderDiffGraph(graphData, options = {}) {
     if (!hasAnyGraphModeEnabled()) {
         return false;
     }
+
+    const animate = options.animate !== false;
 
     const normalizedSeries = normalizeGraphSeries(graphData, GRAPH_RESAMPLE_INTERVAL_MS);
     if (!normalizedSeries) {
         showDiffGraphError("Graph unavailable");
         return false;
     }
+
+    // 未裁剪的归一化序列留作重建源：渲染时的时间线只是快照（见
+    // trimSeriesStartToFirstObject），refreshGraphTimeline 用它按新时间线重画。
+    state.graphSeriesSource = normalizedSeries;
 
     const { minYValue: preMinY, maxYValue: preMaxY } = normalizedSeries;
 
@@ -657,13 +691,33 @@ export function renderDiffGraph(graphData) {
         });
 
         state.graphSeries = { times, values, minTime, maxTime, minYValue, maxYValue };
+        state.graphSeriesTimelineStartMs = currentTimelineStartMs();
 
-        forEachEnabledGraphView((view) => { triggerGraphScanEnter(view); });
+        if (animate) {
+            forEachEnabledGraphView((view) => { triggerGraphScanEnter(view); });
+        }
         redrawPauseMarkers();
         updateGraphCursor();
     });
 
     return true;
+}
+
+/**
+ * 按当前谱面时间线重建图表。渲染时 songStartMs 可能尚未由 tosu 补全
+ * （选歌阶段为 0 / 缺失），x 轴窗口会被写成含前奏的整段；时间线补全后
+ * 必须重画，否则前奏空档与进度线偏移会保留整首歌。
+ * 时间线未变化时不做任何事（每包调用，必须廉价）。
+ */
+export function refreshGraphTimeline() {
+    const source = state.graphSeriesSource;
+    if (!source || !hasAnyGraphModeEnabled()) {
+        return false;
+    }
+    if (state.graphSeriesTimelineStartMs === currentTimelineStartMs()) {
+        return false;
+    }
+    return renderDiffGraph(source, { animate: false });
 }
 
 export function updateDiffTextVisibility() {

--- a/ManiaMapAnalyser by Leo_Black/js/app/socketHandlers.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/socketHandlers.js
@@ -19,6 +19,7 @@ import {
 } from "./modeLogic.js";
 import {
     addPauseMarker,
+    refreshGraphTimeline,
     resetPauseRuntime,
     updateGraphCursor,
 } from "./graph.js";
@@ -49,17 +50,29 @@ function extractCurrentSongTimeMs(data) {
 function updateSongTimeState(data) {
     const beatmapTime = data?.beatmap?.time;
     const liveTimeMs = extractCurrentSongTimeMs(data);
+
+    const speedRate = Number.isFinite(state.speedRate) && state.speedRate > 0 ? state.speedRate : 1;
+
+    // 谱面时间线的更新不依赖 live 时间：早期实现在无 live 时直接返回，
+    // 会连带丢掉 firstObject/lastObject，使图表 x 轴窗口永远按"未知时间线"渲染。
+    const firstObjectMs = Number(beatmapTime?.firstObject);
+    const lastObjectMs = Number(beatmapTime?.lastObject);
+    const previousSongStartMs = state.songStartMs;
+    state.songStartMs = Number.isFinite(firstObjectMs) ? firstObjectMs / speedRate : null;
+    state.songEndMs = Number.isFinite(lastObjectMs) ? lastObjectMs / speedRate : null;
+
+    // 图表 x 轴窗口按渲染时刻的 songStartMs 裁剪；tosu 常在首次渲染后才补全
+    // firstObject（选歌阶段为 0），此处补一次重建，避免前奏空档 + 进度线偏移
+    // 残留整首歌。未变化时 refreshGraphTimeline 立即返回。
+    if (state.songStartMs !== previousSongStartMs) {
+        refreshGraphTimeline();
+    }
+
     if (!Number.isFinite(liveTimeMs)) {
         return;
     }
 
-    const speedRate = Number.isFinite(state.speedRate) && state.speedRate > 0 ? state.speedRate : 1;
     const scaledLiveTimeMs = liveTimeMs / speedRate;
-
-    const firstObjectMs = Number(beatmapTime?.firstObject);
-    const lastObjectMs = Number(beatmapTime?.lastObject);
-    state.songStartMs = Number.isFinite(firstObjectMs) ? firstObjectMs / speedRate : null;
-    state.songEndMs = Number.isFinite(lastObjectMs) ? lastObjectMs / speedRate : null;
 
     if (state.pauseDetectionEnabled && state.isInPlayState && state.pauseMarkerTimes.length > 0) {
         let earliestPauseTimeMs = Number.POSITIVE_INFINITY;

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/roxyEstimator.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/roxyEstimator.js
@@ -459,8 +459,32 @@ function canonicalizeOsuTiming(osuText, speedRate) {
     };
 }
 
-function buildTapRows(parsed, speedRate, toleranceMs) {
-    const taps = [];
+/**
+ * canonicalizeOsuTiming 把分析文本的时间轴整体平移成"首个物件 = ROXY_CANONICAL_FIRST_OBJECT_MS"。
+ * 估算只看相对结构，平移不影响星数；但 graph 是逐点按谱面时间绘制的，必须还原到调用方
+ * 传入的原始谱面时间轴（与 Sunny/Daniel/Azusa 同口径）。
+ * 否则图表 x 轴窗口与进度线都按被平移过的时间轴映射：前奏越长偏得越多，当前奏长于
+ * 可玩段时 songStartMs 会超过被压缩后的 maxTime，游标被钉死在最右侧且整首歌不动。
+ */
+function restoreGraphTimeline(graph, timing, speedRate) {
+    if (!graph || timing?.applied !== true || !Array.isArray(graph.times)) {
+        return graph;
+    }
+
+    // 逆变换：canonical = raw / rate - firstObject / rate + CANONICAL_FIRST_OBJECT_MS
+    const offset = Number(timing.firstTime) / speedRate - ROXY_CANONICAL_FIRST_OBJECT_MS;
+    if (!Number.isFinite(offset) || offset === 0) {
+        return graph;
+    }
+
+    const { times } = graph;
+    for (let i = 0; i < times.length; i += 1) {
+        times[i] += offset;
+    }
+    return graph;
+}
+
+function buildTapRows(parsed, speedRate, toleranceMs) {    const taps = [];
     const columns = Array.isArray(parsed.columns) ? parsed.columns : [];
     const starts = Array.isArray(parsed.noteStarts) ? parsed.noteStarts : [];
     const types = Array.isArray(parsed.noteTypes) ? parsed.noteTypes : [];
@@ -1613,7 +1637,9 @@ export function runRoxyEstimatorFromText(osuText, options = {}, parsed = null) {
             estDiff,
             numericDifficulty: finalNumeric,
             numericDifficultyHint: "roxy-meta-ridge-v3",
-            graph: options.withGraph === true ? (metaDetails.graph || null) : null,
+            graph: options.withGraph === true
+                ? restoreGraphTimeline(metaDetails.graph, timing, speedRate)
+                : null,
             rawNumericDifficulty: Number(numericDetails.rawNumeric.toFixed(4)),
             debug: {
                 notes: taps.length,

--- a/docs/features/difficulty-estimation.md
+++ b/docs/features/difficulty-estimation.md
@@ -87,7 +87,7 @@ const effectiveWeights = (options?.classicMod === true ? CArr : CArrV2).map((c, 
 - **Daniel 排除**：使用独立改进算法（自己的 `sr`），不做归一化；
 - **Companella / SunnyWindow**：star 本就是 Sunny sr（Companella 直接跑 Sunny，`analysis.js:494`；SunnyWindow 只替换 estDiff 的 LN 段，不碰 star），无需处理；
 - **vibro 检测**仍用算法自身 star 判定（`analysis.js:671` `Number(selectedRework?.star)`），不随归一化变化，保持既有行为；
-- 缓存快照存储的就是归一化后的 `rework.star`（`analysis.js:753`），命中恢复一致；缓存键带 `star-v4` 版本前缀使旧快照（存算法自身 star；v4 亦作废 Etterna 难度前缀修复前的错误首块快照）失效。
+- 缓存快照存储的就是归一化后的 `rework.star`（`analysis.js:753`），命中恢复一致；缓存键带 `star-v6` 版本前缀使旧快照失效（沿革见 [result-cache.md](../pipeline/result-cache.md) §5）。
 
 ## 4. Worker 回退（主线程同步执行）
 

--- a/docs/features/graph-visualization.md
+++ b/docs/features/graph-visualization.md
@@ -60,7 +60,7 @@ graph.js 中通过 `view.svgEl` / `view.fillEl` / `view.fillPlayEl` / `view.play
 
 1. `hasAnyGraphModeEnabled()` 为假直接返回 `false`（`graph.js:546`）。
 2. `normalizeGraphSeries(graphData, GRAPH_RESAMPLE_INTERVAL_MS)` 归一化（`graph.js:550`）；失败 → `graph.js:552 showDiffGraphError("Graph unavailable")`。
-3. `graph.js:558 trimSeriesStartToFirstObject(normalizedSeries)`（定义于 `graph.js:144`）：谱面首个物件（`state.songStartMs`）之前的点被裁剪，起点值经 `interpolateSeriesValue` 插值补出，避免图线从谱面开始前就画出来。
+3. `graph.js:164 trimSeriesStartToFirstObject(normalizedSeries)`：谱面首个物件（`state.songStartMs`）之前的点被裁剪，起点值经 `interpolateSeriesValue` 插值补出，避免图线从谱面开始前就画出来。裁剪用的时间线是**渲染时刻的快照**——tosu 常在首次渲染之后才补全 `beatmap.time.firstObject`（选歌阶段为 `0` / 缺失），未裁剪的归一化序列会存进 `state.graphSeriesSource`，时间线变化时由 `refreshGraphTimeline()` 按新时间线重画（见 §4.5）；否则整首歌都会保留前奏空档，进度线也随之偏移。
 4. 手工预分配 `lineParts`/`fillParts` 数组，逐点计算 viewBox 坐标：`x = xMin + (t - minTime) * tScale * xSpan`，`y = yMax - (v - minYValue) * vScale * ySpan`；坐标字符串用 `graph.js:541 f1`（一位小数，注释说明对 260px viewBox 足够且省 ~20% 字符串长度）；填充基线 `baseYs = yMax`（`graph.js:594`），闭合 `Z`（`graph.js:623`）。
 5. `graph.js:629 setGraphLoading(false)` 先撤掉加载态，然后用 `requestAnimationFrame` 把 DOM 更新**推迟到下一帧**（`graph.js:632`），保证加载骨架能先绘制一帧、避免闪烁。
 6. 下一帧回调内 `forEachEnabledGraphView`（`graph.js:633`）：
@@ -76,18 +76,32 @@ graph.js 中通过 `view.svgEl` / `view.fillEl` / `view.fillPlayEl` / `view.play
 
 ### 4.2 加载态 setGraphLoading
 
-`graph.js:388 setGraphLoading(isLoading)`：仅在 `hasAnyGraphModeEnabled()` 时工作，只作用于启用视图（`graph.js:393`）。
+`graph.js:409 setGraphLoading(isLoading)`：仅在 `hasAnyGraphModeEnabled()` 时工作，只作用于启用视图（`graph.js:393`）。
 
-- 进入加载（`graph.js:398-418`）：`buildGraphLoadingPaths()`（`graph.js:92`，用 `APP_CONFIG.graph.loadingSampleCount` 个点 + `loadingBaseOffset` 画水平基线骨架）生成 line/fill path；`svgEl` 加 `loading` 类（触发 CSS 波浪动画）；`fillEl` **移除** `graph-unplayed`（`graph.js:404`，注释说明加载骨架不继承上一张图的暗化）；`resetPlayedFill(view)`；显示 "Graph loading..." 文本（`graph.js:406`，文本元素由 `graph.js:112 ensureGraphLoadingTextEl` 惰性创建，显示切换 `graph.js:136 setGraphLoadingTextVisible`）；隐藏游标与错误元素。
+- 进入加载（`graph.js:398-418`）：`buildGraphLoadingPaths()`（`graph.js:92`，用 `APP_CONFIG.graph.loadingSampleCount` 个点 + `loadingBaseOffset` 画水平基线骨架）生成 line/fill path；`svgEl` 加 `loading` 类（触发 CSS 波浪动画）；`fillEl` **移除** `graph-unplayed`（`graph.js:404`，注释说明加载骨架不继承上一张图的暗化）；`resetPlayedFill(view)`；显示 "Graph loading..." 文本（`graph.js:406`，文本元素由 `graph.js:112 ensureGraphLoadingTextEl` 惰性创建，显示切换 `graph.js:136 setGraphLoadingTextVisible`）；隐藏游标与错误元素。同时调用 `dropGraphSeriesSource()` 丢弃重建源——曲线即将被替换，此时若谱面时间线变化，不得把上一张图的曲线重画回加载骨架上。
 - 退出加载（`graph.js:421-422`）：移除 `loading` 类、隐藏加载文本。
 
 ### 4.3 错误态 showDiffGraphError
 
-`graph.js:426 showDiffGraphError(message)`：先 `setGraphLoading(false)`，置 `state.graphSeries = null`（`graph.js:432`），对启用视图清空 fill/line path、`resetPlayedFill`、隐藏游标、清空暂停标记（`graph.js:433-449`），最后在 `errorEl` 显示错误消息（默认 "Graph unavailable"，`graph.js:452`）。调用方：`analysis.js:568`（Unsupported Keys）与 `analysis.js:572`（渲染失败）。
+`graph.js:453 showDiffGraphError(message)`：先 `setGraphLoading(false)`，置 `state.graphSeries = null`（`graph.js:432`）并 `dropGraphSeriesSource()`，对启用视图清空 fill/line path、`resetPlayedFill`、隐藏游标、清空暂停标记（`graph.js:433-449`），最后在 `errorEl` 显示错误消息（默认 "Graph unavailable"，`graph.js:452`）。调用方：`analysis.js:568`（Unsupported Keys）与 `analysis.js:572`（渲染失败）。
 
 ### 4.4 图整体清空 clearDiffGraph
 
-`graph.js:341 clearDiffGraph()`：`state.graphSeries = null`；对**所有**视图（`forEachGraphView`）移除 `loading` 类、清除扫描动画、清空 fill/line path、`resetPlayedFill`、隐藏游标、隐藏错误、隐藏加载文本、清空暂停标记。`graph.js:704` 中当 `updateDiffTextVisibility` 发现无任何图表模式启用时也会调用它。
+`graph.js:359 clearDiffGraph()`：`state.graphSeries = null` 并 `dropGraphSeriesSource()`；对**所有**视图（`forEachGraphView`）移除 `loading` 类、清除扫描动画、清空 fill/line path、`resetPlayedFill`、隐藏游标、隐藏错误、隐藏加载文本、清空暂停标记。`graph.js:773` 中当 `updateDiffTextVisibility` 发现无任何图表模式启用时也会调用它。
+
+### 4.5 谱面时间线补全后的重建 refreshGraphTimeline
+
+x 轴窗口在渲染时刻由 `state.songStartMs`（tosu `beatmap.time.firstObject / speedRate`）裁剪，但这个值**是异步补全的**：选歌阶段 tosu 常给出 `firstObject: 0`（或字段缺失），真正载入谱面后才给出首个物件时间。设计谱面（长前奏）下若只在渲染时裁剪一次，整首歌都会保留前奏空档——曲线左段是贴底的 0 难度（视觉上空缺），进度线也随之偏移，直到用户改设置 / 换图触发重算才恢复。
+
+重建链路：
+
+- `renderDiffGraph(graphData, options)`（`graph.js:587`）把**未裁剪**的归一化序列存进 `state.graphSeriesSource`，并在 DOM 写入那一帧记录 `state.graphSeriesTimelineStartMs = currentTimelineStartMs()`（渲染所用的时间线快照）。`options.animate !== false` 才播放入场动画（重建时传 `{ animate: false }`，避免播放中重放 400ms 扫描动画）。
+- `refreshGraphTimeline()`（`graph.js:712`）：无重建源、或任一图表模式未启用时直接返回 `false`；时间线快照与当前 `songStartMs` 相同时返回 `false`（该函数每个 api_v2 包都会被调用，必须廉价）；否则用重建源重新 `renderDiffGraph(source, { animate: false })`。
+- 调用点：`socketHandlers.js:68 updateSongTimeState()` 中 `state.songStartMs` 发生变化时触发。
+- 时间线取值经 `currentTimelineStartMs()`（`graph.js:148`）读取：显式把 `null` / `undefined` / `""` 判为"未知时间线"（`Number(null) === 0`，直接 `Number()` 会把未知当成 `firstObject = 0`）。
+- 重建源在 4 条路径上被丢弃（`dropGraphSeriesSource()`）：`clearDiffGraph`、`setGraphLoading(true)`、`showDiffGraphError`、`renderDiffGraph` 的归一化失败分支——保证被清空 / 失败 / 处于加载态的图不会被时间线变化"复活"。
+
+`state.songStartMs` 的更新本身不依赖 `live` 时间：`updateSongTimeState` 先写 `songStartMs` / `songEndMs` 再对 `liveTimeMs` 做 early-return（早期实现在无 `live` 时直接返回，会连带丢掉 `firstObject` / `lastObject`）。
 
 ## 5. 已玩/未玩双色填充（重点）
 
@@ -131,7 +145,7 @@ graph.js 中通过 `view.svgEl` / `view.fillEl` / `view.fillPlayEl` / `view.play
 - 重绘：`graph.js:305 redrawPauseMarkers()`——对启用视图逐视图重画。渲染完成（`graph.js:662`）、暂停开关变更（`settings.js:581`）、新增标记后（`graph.js:326`）都会触发。
 - 清除：`graph.js:246 clearPauseMarkersDom(view = null)`（带 view 清单个，否则清全部）；`graph.js:311 clearAllPauseMarkers()`（同时清空 `pauseMarkerTimes`、`pauseCount` 并刷新 HUD）；`graph.js:329 resetPauseRuntime(clearMarkers)` 在 `clearMarkers` 时调用前者。
 - 清空时机：`clearDiffGraph`（`graph.js:339`）、加载（`graph.js:388`）、错误（`graph.js:426`）、设置关闭（`settings.js:569-577` 清空数组）。
-- 联动：`socketHandlers.js:62-72` 在回退到最早暂停点之前时 `resetPauseRuntime(true)`，实现"重绕即清除旧暂停标记"。
+- 联动：`socketHandlers.js:77-87` 在回退到最早暂停点之前时 `resetPauseRuntime(true)`，实现"重绕即清除旧暂停标记"。
 
 ## 7. 常量（config.js graph 块）
 
@@ -155,7 +169,7 @@ graph.js 中通过 `view.svgEl` / `view.fillEl` / `view.fillPlayEl` / `view.play
 
 ## 8. 其他入口与注意事项
 
-- **显示切换**：`graph.js:655 updateDiffTextVisibility()` 统一按 `state.diffText` 切换右上区域（Difficulty 文本 / header 图 / MSD 等右胶囊）的可见性：`Graph` 显示 header 图（`graph.js:658`），`Difficulty` 显示估计难度（`graph.js:657`），`MSD/Pattern/ReworkSR/InterludeSR` 显示右胶囊（`graph.js:659-662`）；`None` 时隐藏 caption（`graph.js:680`）。无任何图表模式启用时调用 `clearDiffGraph()`（`graph.js:704-705`）。
+- **显示切换**：`graph.js:723 updateDiffTextVisibility()` 统一按 `state.diffText` 切换右上区域（Difficulty 文本 / header 图 / MSD 等右胶囊）的可见性：`Graph` 显示 header 图（`graph.js:658`），`Difficulty` 显示估计难度（`graph.js:657`），`MSD/Pattern/ReworkSR/InterludeSR` 显示右胶囊（`graph.js:659-662`）；`None` 时隐藏 caption（`graph.js:680`）。无任何图表模式启用时调用 `clearDiffGraph()`（`graph.js:704-705`）。
 - **数值难度**：`graph.js:720 setNumericDifficultyValue(value, hint)` 写入 `state.numericDifficulty` / `numericDifficultyHint`；`graph.js:737 setForceHideNumericDifficulty(value)` 强制隐藏。两者仅在 `diffText === "Difficulty"` 时触发 caption 重渲染（`graph.js:732`、`graph.js:744`）。caption 文本由 `graph.js:199 formatEstimateDifficultyCaption()` 生成（含 `[实际算法]` 前缀、`RCxx|LNxx*` 双值格式）。
 - **游标可见性**：`graph.js:376 setGraphCursorVisible(visible)`——隐藏时对启用视图强制隐藏游标与游标点（`graph.js:378-385`），防止禁用视图残留游标。
 - **图表是否启用**：由 `state.diffText` 与 `contentBar` 共同判定（`hasAnyGraphModeEnabled`，见 §2.2），与缓存快照的 coverage 检查相关（详见 [result-cache.md](../pipeline/result-cache.md)）。

--- a/docs/features/graph-visualization.md
+++ b/docs/features/graph-visualization.md
@@ -8,6 +8,8 @@
 
 难度图表（difficulty graph）将谱面难度随时间的变化渲染为 SVG 折线图。图表数据来自 `rework.graph`（由估算管线产出，见 [difficulty-estimation.md](difficulty-estimation.md)）。核心代码集中在浏览器专属模块 `ManiaMapAnalyser by Leo_Black/js/app/graph.js`（DOM 操作只发生在该模块，可安全使用 `document`）。
 
+**时间轴契约（重要）**：`rework.graph.times` 必须与 `state.songStartMs` / `state.songTimeMs` 同域，即**按 `speedRate` 缩放后的原始谱面时间**（`rawTime / speedRate`）。Sunny / Daniel / Azusa 天然如此；Roxy 的分析文本会被 `canonicalizeOsuTiming` 平移，因此它在返回前会把 `graph.times` 逆变换回原始时间轴（见 [roxy_algorithm.md](../roxy_algorithm.md) §4、§17）。**新增/修改估算器时若输出 graph，必须遵守该契约**——否则裁剪窗口、游标映射、暂停标记全部按错误的时间轴走。
+
 图表有**两处独立的显示位置**（双图结构），共用同一份数据与同一套渲染逻辑：
 
 | 视图 | DOM | 启用条件 | 显示位置 |
@@ -91,7 +93,9 @@ graph.js 中通过 `view.svgEl` / `view.fillEl` / `view.fillPlayEl` / `view.play
 
 ### 4.5 谱面时间线补全后的重建 refreshGraphTimeline
 
-x 轴窗口在渲染时刻由 `state.songStartMs`（tosu `beatmap.time.firstObject / speedRate`）裁剪，但这个值**是异步补全的**：选歌阶段 tosu 常给出 `firstObject: 0`（或字段缺失），真正载入谱面后才给出首个物件时间。设计谱面（长前奏）下若只在渲染时裁剪一次，整首歌都会保留前奏空档——曲线左段是贴底的 0 难度（视觉上空缺），进度线也随之偏移，直到用户改设置 / 换图触发重算才恢复。
+x 轴窗口在渲染时刻由 `state.songStartMs`（tosu `beatmap.time.firstObject / speedRate`）裁剪，但这个值**是异步补全的**：选歌阶段 tosu 可能给出 `firstObject: 0`（或字段缺失），真正载入谱面后才给出首个物件时间。设计谱面（长前奏）下若只在渲染时裁剪一次，整首歌都会保留前奏空档——曲线左段是贴底的 0 难度（视觉上空缺），进度线也随之偏移，直到用户改设置 / 换图触发重算才恢复。
+
+> 注意区分两类成因：本节处理的是"谱面时间线晚到"，而 [roxy_algorithm.md](../roxy_algorithm.md) §17 处理的是"图表序列时间轴与谱面时间线不同域"。后者（Roxy 的 canonical 时间轴）会让 `songStartMs` 超过被压缩后的 `maxTime`，游标被 clamp 钉死在最右侧且整首歌不动——本节的重建无法修复它，必须由估算器侧还原时间轴。
 
 重建链路：
 

--- a/docs/features/pause-detection.md
+++ b/docs/features/pause-detection.md
@@ -18,8 +18,8 @@
 
 `ManiaMapAnalyser by Leo_Black/js/app/socketHandlers.js:47` 的 `updateSongTimeState(data)` 是暂停检测的唯一驱动入口。每个 tosu 数据帧到达时：
 
-1. 从 tosu payload 提取实时谱面时间，并按倍速缩放为**谱面时间**（除以 `state.speedRate`，见 `socketHandlers.js:54-55`）。
-2. 记录 `state.songStartMs` / `state.songEndMs`（谱面第一个/最后一个物件的谱面时间，`socketHandlers.js:57-60`），作为判定时间轴边界。
+1. 记录 `state.songStartMs` / `state.songEndMs`（谱面第一个/最后一个物件的谱面时间，按 `state.speedRate` 缩放），作为判定时间轴边界。该步**不依赖 live 时间**，位于 `liveTimeMs` 的 early-return 之前（`socketHandlers.js:50-69`）；时间线变化还会触发 `refreshGraphTimeline()` 重建难度图表（见 [graph-visualization.md](graph-visualization.md) §4.5）。
+2. 从 tosu payload 提取实时谱面时间，并按倍速缩放为**谱面时间**（除以 `state.speedRate`，见 `socketHandlers.js:71-75`）；无 live 时间的帧到此为止。
 3. 读取 **tosu api_v2 原生暂停标志** `data?.game?.paused`（`socketHandlers.js:95`）——游戏是否暂停由 tosu 直接上报，**不再**通过"谱面时间冻结 ≥ 阈值"来推断。
 
 ### 2.2 状态转移（socketHandlers.js:91-116）
@@ -39,7 +39,7 @@
 
 **兼容性**：旧版 tosu 的 api_v2 若无 `game.paused` 字段（undefined），一律视为未暂停——暂停检测静默不可用，不影响其余功能；无需任何回退启发式。
 
-### 2.3 时间线回退清理（socketHandlers.js:62-72）
+### 2.3 时间线回退清理（socketHandlers.js:77-87）
 
 若已收集暂停标记，且当前谱面时间倒退到**最早标记之前**（`scaledLiveTimeMs + PAUSE_DETECT_EPSILON_MS < earliestPauseTimeMs`），说明时间线被重置（如重开本图），调用 `resetPauseRuntime(true)` 清空全部标记与计数。
 
@@ -111,8 +111,8 @@
 
 1. **不受游戏卡顿影响**：暂停判定基于 tosu 上报的 `game.paused` 原生标志，谱面时间帧间冻结（掉帧/卡顿）不会产生误判；原"卡顿误判需调高阈值"的问题因阈值移除而自然消失。
 2. **仅在游玩状态工作**：`socketHandlers.js:91` 要求 `state.isInPlayState` 为真，结算界面/选图界面不检测。
-3. **时间线回退清标记**：谱面时间倒退到最早标记之前（重开本图等）触发 `resetPauseRuntime(true)` 清空标记与计数（`socketHandlers.js:62-72`）。
+3. **时间线回退清标记**：谱面时间倒退到最早标记之前（重开本图等）触发 `resetPauseRuntime(true)` 清空标记与计数（`socketHandlers.js:77-87`）。
 4. **末尾缓冲**：进入谱面最后 500ms 后不再记录暂停标记（`atTimelineEnd`）；首物件之前同样不记录（`beforeStart`），避免谱面开始/结束的收尾帧产生无效标记。
 5. **旧版 tosu 兼容**：api_v2 无 `game.paused` 字段时（undefined）视为未暂停——暂停检测静默不可用，不报错、不影响其余功能。
-6. **倍速归一化**：标记时间基于倍速缩放后的谱面时间（`socketHandlers.js:54-55`），DT/HT 下标记位置与谱面时间轴一致。
+6. **倍速归一化**：标记时间基于倍速缩放后的谱面时间（`socketHandlers.js:71-75`），DT/HT 下标记位置与谱面时间轴一致。
 7. **禁用即清理**：关闭 `enablePauseDetection` 会立即清空已收集的标记与计数（`settings.js:569-577`），此后暂停检测不再运行。

--- a/docs/guides/cache-invalidation.md
+++ b/docs/guides/cache-invalidation.md
@@ -27,7 +27,7 @@
 const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
 ```
 
-即 `star-v4|算法|谱面身份|mod 签名`（`CACHE_KEY_STAR_UNIFIED_VERSION` 常量是星数统一语义的缓存版本前缀，改星数口径/转换语义时 bump 它以作废旧快照；v4 起因：Etterna `Difficulty_*` 前缀匹配修复，见 result-cache.md §5）。**不含** `display6kLevel`、`extendedEstimationRange`、`forceSunnyWindow`、etterna 版本、debug 标志等一切其余设置（详见 result-cache.md §5、§11 注意事项）。
+即 `star-v6|算法|谱面身份|mod 签名`（`CACHE_KEY_STAR_UNIFIED_VERSION` 常量是缓存语义版本前缀，改星数口径/输出时间轴/转换语义时 bump 它以作废旧快照；v6 起因：Roxy `graph` 时间轴还原，见 result-cache.md §5）。**不含** `display6kLevel`、`extendedEstimationRange`、`forceSunnyWindow`、etterna 版本、debug 标志等一切其余设置（详见 result-cache.md §5、§11 注意事项）。
 
 键设计的取舍：键保持最小 → 无关设置切换不会误伤命中；代价是正确性完全委托给失效列表 + 命中重派生。漏加失效 = 设置变了但键没变 → 静默命中旧快照：
 
@@ -228,7 +228,7 @@ const jsonSafe = (value) => (value == null ? value : JSON.parse(JSON.stringify(v
 const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
 ```
 
-版本前缀 + 三段：缓存语义版本（`star-v4`，星数统一后作废旧快照；v4 另作废 Etterna 难度前缀修复前的错误首块快照）| 用户选择的算法 | 谱面身份（含 md5） | mod 签名（`speedRate|odFlag|cvtFlag|classic` 四段，classic 段反映 Classic 感知星数语义，modData.js:218-228）。**写前确认三段都在**——写门已校验 `state.lastBeatmapIdentity` 存在；直接用 fetchBeatmapFile 开头构造好的 `cacheKey` 变量，不要自己重造键（键不含任何其他设置，正确性依赖失效列表，见 §2）。
+版本前缀 + 三段：缓存语义版本（`star-v6`，沿革见 result-cache.md §5）| 用户选择的算法 | 谱面身份（含 md5） | mod 签名（`speedRate|odFlag|cvtFlag|classic` 四段，classic 段反映 Classic 感知星数语义，modData.js:218-228）。**写前确认三段都在**——写门已校验 `state.lastBeatmapIdentity` 存在；直接用 fetchBeatmapFile 开头构造好的 `cacheKey` 变量，不要自己重造键（键不含任何其他设置，正确性依赖失效列表，见 §2）。
 
 ### 10.6 needComputed 推导与随快照保存（`analysis.js:775`、:322-340、:348-355）
 

--- a/docs/learnings/difficulty-estimation.md
+++ b/docs/learnings/difficulty-estimation.md
@@ -119,6 +119,7 @@
 - **Mixed 低难段 RC 融合**：Azusa⊕Companella 0.5/0.5（scope=azusa<11 + star<9 门控，`onDisagree` 回落分支原赢家，详见 §3.6 与 difficulty-estimation.md §3.6）。
 - **Azusa LN 门控生效**：`rcLnRatioLimit=0.18` 在入口断言（此前只存在于文档，见 §3.5）。
 - **缓存键 bump star-v4 → star-v5**（低难 numeric/estDiff 语义变化）。
+- **缓存键 bump star-v5 → star-v6**（Roxy `graph` 时间轴从 canonical 还原为原始谱面时间；旧快照的 `times` 会导致图表 x 轴窗口与进度线错位——见 [graph-visualization.md](../features/graph-visualization.md) §4.5 与 roxy_algorithm.md）。
 
 Benchmark（harness harness before/after，746 行，官方 results 为旧代码口径不可直接对比）：
 

--- a/docs/pipeline/analysis-pipeline.md
+++ b/docs/pipeline/analysis-pipeline.md
@@ -284,7 +284,7 @@ const response = await fetch(getEndpoint(), { method: "GET", cache: "no-store" }
 | analysis.js:277-279/:230/:576 `setGraphLoading` / `clearDiffGraph` | graph.js:388/:341 | 加载/清除态 |
 | analysis.js:234/:553/:568/:572 `showDiffGraphError(...)` | graph.js:426 `showDiffGraphError` | 错误提示 |
 | socketHandlers.js:103 `addPauseMarker(...)` | graph.js:318 `addPauseMarker` | 暂停标记（暂停检测驱动：`game.paused` 上升沿） |
-| socketHandlers.js:62-72/:287 `resetPauseRuntime(...)` | graph.js:329 `resetPauseRuntime` | 暂停运行时重置 |
+| socketHandlers.js:77-87/:299 `resetPauseRuntime(...)` | graph.js:329 `resetPauseRuntime` | 暂停运行时重置 |
 
 ### hud.js（HUD 状态）
 

--- a/docs/pipeline/analysis-pipeline.md
+++ b/docs/pipeline/analysis-pipeline.md
@@ -138,7 +138,7 @@ state.pendingChangeKind = changeKind;   // :286
 
 - api_v2 包可能不完整（partial），因此 mod 状态**只在 mod payload 显式出现时应用**：`socketHandlers.js:257-261 shouldApplyModState = !previousModSignature || (modData.hasModPayload && (modData.hasModInfo || modData.hasExplicitNoMod))`；不满足时沿用旧 modSignature。
 - 应用侧 `socketHandlers.js:267-272`：写入 `state.speedRate / state.odFlag / state.cvtFlag / state.modSignature`（来源 `modData.js:62 getModData`，解析细节见 mod-handling.md），并同步写入 `state.modCodes = modData.modCodes || []`、`state.classicMod = Boolean(modData.classic)`（socketHandlers.js:172-173）。
-- **modSignature 不参与换歌判定**，只进缓存键：`analysis.js:305` 缓存键 = `star-v4|estimatorAlgorithm|beatmapIdentity|modSignature`（`star-v4` 是星数统一语义的版本前缀；构成见 modData.js:218-228，`speedRate|odFlag|cvtFlag|classic` 四段，详见 result-cache.md §5 与 mod-handling.md）。
+- **modSignature 不参与换歌判定**，只进缓存键：`analysis.js:395` 缓存键 = `star-v6|estimatorAlgorithm|beatmapIdentity|modSignature`（`star-v6` 是缓存语义版本前缀；构成见 modData.js:218-228，`speedRate|odFlag|cvtFlag|classic` 四段，详见 result-cache.md §5 与 mod-handling.md）。
 
 ## 5. 请求调度（scheduler.js）
 
@@ -171,7 +171,7 @@ const isStaleRequest = () => requestSeq !== state.analysisRequestSeq;
 ### 7.1 缓存查找与覆盖检查（简述，详见 result-cache.md §6）
 
 - `analysis.js:287-304 needComputed`：本次需要的计算产物布尔集 `{pattern, ett, graph, interlude, pp}`，由显示需求与算法需求推导（例如 `state.diffText === "Graph" || contentBarShows("Graph")` 需要 graph，:334；Companella/Mixed 需要 ett 与 interlude，:333、:337-338；`contentBarShows("ReworkPP")` 需要 pp，:339）。
-- `analysis.js:305 cacheKey`：`${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`（版本前缀 `star-v4` + 三段，modSignature 四段含 classic）。
+- `analysis.js:305 cacheKey`：`${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`（版本前缀 `star-v6` + 三段，modSignature 四段含 classic）。
 - `analysis.js:306 isMetaDegraded`：identity 以 `meta:` 开头。
 - `analysis.js:308-317`：`state.enableResultCache && state.lastBeatmapIdentity` 时查 `resultCache.get(cacheKey)`，取到后比对快照 `computed` 五项（graph/pattern/ett/interlude/pp）与 needComputed——全等才命中（`cached = snapshot`），任一不等视为 miss 走完整重算。
 

--- a/docs/pipeline/mod-handling.md
+++ b/docs/pipeline/mod-handling.md
@@ -112,7 +112,7 @@ const nextModSignature = shouldApplyModState ? modData.modSignature : previousMo
 | Etterna WASM | `js/app/analysis.js:152-159 buildEtternaAnalyzeOptions` | `musicRate: state.speedRate`（analysis.js:154） |
 | 估算器（Worker/主线程） | analysis.js:441-447 `estimatorOptions` | `speedRate: state.speedRate`（analysis.js:442），经 `runInWorker`/`runXxxEstimatorFromText` 透传 |
 | Interlude | analysis.js:590 `calculateInterludeStar(rawText, state.speedRate, state.cvtFlag)` → `js/interlude/index.js:14 calculateInterludeStar(source, rate, cvtFlag)` | 第二参数 rate |
-| 歌曲时间换算 | socketHandlers.js:54-60 | `liveTimeMs / speedRate` 得到谱面时间轴（beatmap time 是原速时间，需除速率还原） |
+| 歌曲时间换算 | socketHandlers.js:54-75 | `liveTimeMs / speedRate` 得到谱面时间轴（beatmap time 是原速时间，需除速率还原） |
 
 ## 5. odFlag / cvtFlag 语义
 

--- a/docs/pipeline/mod-handling.md
+++ b/docs/pipeline/mod-handling.md
@@ -168,7 +168,7 @@ const nextModSignature = shouldApplyModState ? modData.modSignature : previousMo
 
 ## 7. modSignature 在缓存键中的作用
 
-缓存键 = `star-v4|state.estimatorAlgorithm|state.lastBeatmapIdentity|state.modSignature`（`js/app/analysis.js:305`，`star-v4` 为星数统一语义的版本前缀；v4 起另作废 Etterna 难度前缀修复前的错误首块快照，见 result-cache.md §5）：
+缓存键 = `star-v6|state.estimatorAlgorithm|state.lastBeatmapIdentity|state.modSignature`（`js/app/analysis.js:395`，`star-v6` 为缓存语义版本前缀，沿革见 result-cache.md §5）：
 
 - mod 变化 → `modSignature` 变化 → 缓存键变化 → 旧快照 miss → 重新计算。同一谱面开 DT 与不开 DT 是**两个缓存条目**，互不污染。
 - 键的第三段就是 §3 的四元组签名（速率/OD/cvt/classic 任一变化即换键）。

--- a/docs/pipeline/result-cache.md
+++ b/docs/pipeline/result-cache.md
@@ -57,7 +57,7 @@ fetchBeatmapFile() → 查缓存（analysis.js:308-317）
 `analysis.js:305`：
 
 ```js
-const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v4"; // 星数统一为 Sunny 原始 sr 后作废旧快照（v3→v4 见下）
+const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v6"; // 星数统一为 Sunny 原始 sr 后作废旧快照（版本沿革见下）
 const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
 ```
 
@@ -65,7 +65,7 @@ const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|
 
 | 段 | 来源 | 说明 |
 | --- | --- | --- |
-| `star-v4` | 常量 `CACHE_KEY_STAR_UNIFIED_VERSION`（analysis.js:305） | 缓存语义版本。v3 前：星数统一为 Sunny 原始 sr（Azusa/Roxy/Mixed 的 star 被归一化，见 difficulty-estimation.md §显示星数）后旧快照失效；**v4（2.1.0 修复）：转换器难度别名修复（Etterna 桥 `Difficulty_*` 前缀此前匹配失败 → 恒取 .sm 首块）使同 identity 的旧快照（错误首块结果）必须作废** |
+| `star-v6` | 常量 `CACHE_KEY_STAR_UNIFIED_VERSION`（analysis.js:394） | 缓存语义版本。v3 前：星数统一为 Sunny 原始 sr（Azusa/Roxy/Mixed 的 star 被归一化，见 difficulty-estimation.md §显示星数）后旧快照失效；**v4（2.1.0 修复）：转换器难度别名修复（Etterna 桥 `Difficulty_*` 前缀此前匹配失败 → 恒取 .sm 首块）使同 identity 的旧快照（错误首块结果）必须作废**；v5：Mixed 低难 RC 段 Azusa⊕Companella 融合 + Azusa LN 门控；**v6：Roxy 的 `graph` 时间轴还原为原始谱面时间（此前是被 `canonicalizeOsuTiming` 平移过的分析文本时间轴，见 roxy_algorithm.md），旧快照的 `times` 会让图表 x 轴窗口与进度线整体错位** |
 | `estimatorAlgorithm` | `state.estimatorAlgorithm`（appContext.js:88） | 用户选择的算法。注意不是实际算法——Azusa 回退 Sunny 时 key 仍含 "Azusa"，快照内用 `actualEstimatorAlgorithm` 记录实况（§10） |
 | `lastBeatmapIdentity` | `state.lastBeatmapIdentity` | 谱面身份，由 socketHandlers.js 构建（见下）。**含 beatmap 的 md5 hash → 谱面文件被替换（内容变化）后 hash 变、键变，天然免疫文件替换** |
 | `modSignature` | `state.modSignature` | mod 签名，modData.js 构建（见下） |

--- a/docs/roxy_algorithm.md
+++ b/docs/roxy_algorithm.md
@@ -85,6 +85,8 @@ The transform is applied to:
 
 After this step, using `speedRate = 1.3` on an original chart is intended to follow the same analysis path as an equivalent pre-speeded `1.3x` `.osu` file. Roxy uses `floor` for timestamp conversion because the benchmark pre-speeded `.osu` files follow floor-style integer conversion.
 
+The rewrite is an analysis-internal transform: all scalar outputs (`star`, `numericDifficulty`, `estDiff`) depend only on relative structure and are unaffected by the shift. The one output that is *not* shift-invariant is `graph.times`, which is restored to the caller's chart timeline before returning — see §17.
+
 ## 5. Row Model
 
 Rows are built from the canonicalized text. In the normal analysis path this means:
@@ -448,6 +450,16 @@ This prevents Roxy from displaying `Iota` or higher labels while still allowing 
 ## 17. Graph Output
 
 The numeric calculation uses Roxy's structural strain data. The returned `graph` field does not use Roxy's local strain series. When graph output is requested, Roxy returns the graph provided by the Azusa reference call, which currently resolves to Azusa/Sunny graph data.
+
+**Time axis.** That reference call runs on the *canonicalized* analysis text (§4), whose timeline is shifted so the first object sits at `canonicalFirstObjectMs = 1000`. Estimation only cares about relative structure, so the shift is invisible in `star` / `numericDifficulty` / `estDiff` — but `graph.times` is plotted point-by-point against the chart timeline, so returning it shifted would misplace the whole curve relative to the playhead. Every other estimator (Sunny / Daniel / Azusa) returns `graph.times` in the caller's chart timeline (`rawTime / speedRate`); Roxy therefore reverses the shift before returning:
+
+```
+restoredTime = canonicalTime + firstObjectTime / speedRate - canonicalFirstObjectMs
+```
+
+The inverse is applied only when the rewrite actually happened (`canonicalizeOsuTiming` reports `applied: true`), so an un-rewritten text passes through unchanged. Consumers (the plugin's difficulty graph, the benchmark runner) can rely on one timeline contract for every estimator.
+
+> Regression note (issue #68): before this restoration, a chart whose lead-in was longer than its playable section pushed `beatmap.time.firstObject / speedRate` past the shifted series' `maxTime`; the plugin clamps the progress cursor into the series window, so the cursor sat pinned at the far right and never moved for the whole play. Cache prefix bumped `star-v5` → `star-v6` (see [pipeline/result-cache.md](pipeline/result-cache.md) §5) to invalidate snapshots holding shifted `times`.
 
 ## 19. Marathon Duration Correction (Estimator-Embedded)
 


### PR DESCRIPTION
## Problem

Closes #68. 
With **Card Body Content = Graph**, on charts with a long lead-in the difficulty curve is drawn against the wrong x-axis and the progress line does not track the song — in the extreme (lead-in longer than the playable section) it sits pinned at the far right and never moves for the whole play.

## Root causes

**1. Roxy returns its graph in a shifted time domain.**

Roxy analyses a rewritten copy of the `.osu` text: `canonicalizeOsuTiming` translates every timestamp so the first object sits at `ROXY_CANONICAL_FIRST_OBJECT_MS` (1000 ms), which is how `speedRate` and the pre-speeded benchmark files are kept equivalent. The shift is invisible in `star` / `numericDifficulty` / `estDiff` (the structural layer and the meta head are both shift-invariant), but not in `graph.times`, which is plotted point-by-point against the chart timeline. `graph` comes from the Azusa reference call, which runs on the *canonicalized* text, so Roxy returned a shifted series while Sunny / Daniel / Azusa all return the caller's chart timeline (`rawTime / speedRate`).

The graph layer trusts that contract: it trims the x-axis window from `state.songStartMs = beatmap.time.firstObject / speedRate` and clamps the cursor into it (`Math.max(minTime, Math.min(boundedTime, maxTime))`). A shifted series spans only `lastObject − firstObject + 1000` ms of chart time, so once the lead-in exceeds the playable section, `songStartMs` is past the series `maxTime` and the cursor is pinned there for every chart time. Shorter lead-ins show the same mismatch as a plain offset between curve and playhead. This also explains why the reporter dates it to the change from "whole song" to "only the part with notes" — the trim reads the series' own `minTime`, so a wrongly-shifted series silently becomes a wrongly-trimmed window.

**2. The x-axis window was trimmed once and never re-derived.** `state.songStartMs` may be published by tosu after the first render (song select can report `firstObject: 0` or omit it). `updateSongTimeState` also recorded `firstObject` / `lastObject` *after* the `liveTimeMs` early-return, so a frame without a live time dropped the timeline update entirely.

## Changes

`js/estimator/roxyEstimator.js` — restore the graph timeline before returning, only when the text was actually rewritten:

```
restoredTime = canonicalTime + firstObjectTime / speedRate − canonicalFirstObjectMs
```

`js/app/analysis.js` — cache prefix `star-v5` → `star-v6` (snapshots store the graph).

`js/app/graph.js` — keep the untrimmed series (`state.graphSeriesSource`) plus the timeline snapshot used for the trim; `refreshGraphTimeline()` re-renders when it changes; `renderDiffGraph(data, { animate: false })` rebuilds without replaying the 400 ms scan-in; `currentTimelineStartMs()` treats `null`/`undefined`/`""` as unknown (`Number(null) === 0` would fake `firstObject = 0`); `dropGraphSeriesSource()` on the clear / loading / error paths so a stale curve cannot be repainted.

`js/app/socketHandlers.js` — refresh on `songStartMs` change; record the timeline before the live-time early-return.

Docs: `roxy_algorithm.md` §4 + §17, `graph-visualization.md` (timeline contract + new §4.5), `result-cache.md` §5, plus `mod-handling.md`, `analysis-pipeline.md`, `cache-invalidation.md`, `difficulty-estimation.md`, `learnings/difficulty-estimation.md`.