### PR TITLE
fix(roxy): clamp the degenerate corr_lowCj meta feature (issue #70)

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/analysis.js
@@ -393,7 +393,10 @@ export async function fetchBeatmapFile(reason) {
     //   低难图的 numeric/estDiff 语义变化 → 旧快照必须失效。
     // star-v6：Roxy 的 graph 时间轴还原为原始谱面时间（此前是 canonicalizeOsuTiming
     //   平移过的分析文本时间轴），旧快照里的 times 会让整张图的 x 轴窗口与进度线错位。
-    const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v6";
+    // star-v7：Roxy meta 头对退化修正项 corr_lowCj 改用「特征关闭状态取值」截断——该系数
+    //   是在特征恒为常数处拟合的，遇到正常触发值即外推出极端离群项（实测压低 4.34 分），
+    //   Roxy 的 numeric/estDiff 语义变化 → 旧快照必须失效。
+    const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v7";
     const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
     const isMetaDegraded = String(state.lastBeatmapIdentity || "").startsWith("meta:");
     let cached = null;

--- a/ManiaMapAnalyser by Leo_Black/js/estimator/roxyMetaModel.generated.js
+++ b/ManiaMapAnalyser by Leo_Black/js/estimator/roxyMetaModel.generated.js
@@ -47,6 +47,37 @@ function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value));
 }
 
+/**
+ * 退化修正项：只允许取「训练集实际覆盖到」的取值。
+ *
+ * corr_lowCj 在训练集中几乎没有变化，mean = 2.07e-4、std = 4.65e-3，而它在真实谱面上
+ * 触发时取值 0.011 ~ 0.39（实测某图 0.033 = 7σ，理论可达 84σ）。线性系数却是在特征
+ * 恒为常数的位置上拟合出来的（beta/scale = -134），所以 (f - mean) / scale 一旦落到
+ * 触发值上就会外推出极端离群项：不处理时某图被压低 4.34 分，标签从 Delta 级掉到 Beta low。
+ *
+ * 关键点：按「几个标准差」截断并不够。同一赛道上有两张几乎同源的图（同一时间轴、
+ * 90% 的行内音符数相同、98% 的音符能在对方里找到同列同刻的对应音符），只因为
+ * overlapRate 是 0.7772 对 0.7413——刚好跨过 lowCj 闸门的 0.75 下界——一张触发、
+ * 一张不触发。±3σ 截断下仍差 1.01 分（触发的那张被压低 1.86 分），而 Azusa(差 0.06)、
+ * Daniel(差 0.07) 与 Roxy 自己的 structural 层(差 0.10) 都认为两张图同难。
+ *
+ * 因此这里不按 σ 截断，而是把标准化取值限制在该特征「关闭状态」（f = 0）所能取到的
+ * 水平内：模型对「它被触发时会怎样」没有任何数据支撑，触发即视为回到训练集里的典型
+ * 谱面。这样既不丢掉它在 f ≈ mean 附近的常数贡献（+0.028，直接删除该维度会让全表整体
+ * 下移），也不会让一个训练集从未覆盖的取值决定一张图的难度。
+ *
+ * 为什么名单只有 corr_lowCj：其余 corr_* 项的病态程度低若干个量级。以 beta/scale 衡量，
+ * corr_lowCj 是 -134，corr_courseSustainLift 只有 21、corr_denseJsLift 只有 0.4，
+ * corr_handBiasLift / corr_courseBreakDamp 则恒为 0（训练集无方差，beta 本身就是 0）。
+ * 单独处理 corr_lowCj 就足以修掉报告的问题，且在 benchmark osu! 子集 746 行上不改变任何
+ * 已报出的数值；若把另外三项一并按 σ 截断则改动 7 行、其中 4 行变差（MAE 0.2424），
+ * 因为那几项在 benchmark 上携带的是有效信号。故名单按"每个特征的实际病态程度"取，
+ * 而不是按"训练统计量是否退化"一刀切。
+ */
+const ROXY_META_DEGENERATE_FEATURES = new Set([
+    "corr_lowCj",
+]);
+
 export function evaluateRoxyMetaModel(features) {
     if (!Array.isArray(features) || features.length !== ROXY_META_FEATURE_NAMES.length) {
         return Number.NaN;
@@ -54,7 +85,12 @@ export function evaluateRoxyMetaModel(features) {
     let value = ROXY_META_BETA[0];
     for (let i = 0; i < ROXY_META_FEATURE_NAMES.length; i += 1) {
         const scale = ROXY_META_SCALE[i] || 1;
-        value += ROXY_META_BETA[i + 1] * ((Number(features[i]) - ROXY_META_MEAN[i]) / scale);
+        let z = (Number(features[i]) - ROXY_META_MEAN[i]) / scale;
+        if (ROXY_META_DEGENERATE_FEATURES.has(ROXY_META_FEATURE_NAMES[i])) {
+            const offZ = Math.abs(ROXY_META_MEAN[i] / scale);
+            z = clamp(z, -offZ, offZ);
+        }
+        value += ROXY_META_BETA[i + 1] * z;
     }
     return clamp(value, -2, 30);
 }

--- a/docs/features/difficulty-estimation.md
+++ b/docs/features/difficulty-estimation.md
@@ -87,7 +87,7 @@ const effectiveWeights = (options?.classicMod === true ? CArr : CArrV2).map((c, 
 - **Daniel 排除**：使用独立改进算法（自己的 `sr`），不做归一化；
 - **Companella / SunnyWindow**：star 本就是 Sunny sr（Companella 直接跑 Sunny，`analysis.js:494`；SunnyWindow 只替换 estDiff 的 LN 段，不碰 star），无需处理；
 - **vibro 检测**仍用算法自身 star 判定（`analysis.js:671` `Number(selectedRework?.star)`），不随归一化变化，保持既有行为；
-- 缓存快照存储的就是归一化后的 `rework.star`（`analysis.js:753`），命中恢复一致；缓存键带 `star-v6` 版本前缀使旧快照失效（沿革见 [result-cache.md](../pipeline/result-cache.md) §5）。
+- 缓存快照存储的就是归一化后的 `rework.star`（`analysis.js:753`），命中恢复一致；缓存键带 `star-v7` 版本前缀使旧快照失效（沿革见 [result-cache.md](../pipeline/result-cache.md) §5）。
 
 ## 4. Worker 回退（主线程同步执行）
 

--- a/docs/guides/cache-invalidation.md
+++ b/docs/guides/cache-invalidation.md
@@ -21,13 +21,13 @@
 
 ## 2. 为什么：缓存键不含这些设置
 
-缓存键是版本前缀 + 三段（`analysis.js:305`）：
+缓存键是版本前缀 + 三段（`analysis.js:398`）：
 
 ```js
 const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
 ```
 
-即 `star-v6|算法|谱面身份|mod 签名`（`CACHE_KEY_STAR_UNIFIED_VERSION` 常量是缓存语义版本前缀，改星数口径/输出时间轴/转换语义时 bump 它以作废旧快照；v6 起因：Roxy `graph` 时间轴还原，见 result-cache.md §5）。**不含** `display6kLevel`、`extendedEstimationRange`、`forceSunnyWindow`、etterna 版本、debug 标志等一切其余设置（详见 result-cache.md §5、§11 注意事项）。
+即 `star-v7|算法|谱面身份|mod 签名`（`CACHE_KEY_STAR_UNIFIED_VERSION` 常量是缓存语义版本前缀，改星数口径/输出时间轴/转换语义时 bump 它以作废旧快照；v6 起因：Roxy `graph` 时间轴还原，见 result-cache.md §5）。**不含** `display6kLevel`、`extendedEstimationRange`、`forceSunnyWindow`、etterna 版本、debug 标志等一切其余设置（详见 result-cache.md §5、§11 注意事项）。
 
 键设计的取舍：键保持最小 → 无关设置切换不会误伤命中；代价是正确性完全委托给失效列表 + 命中重派生。漏加失效 = 设置变了但键没变 → 静默命中旧快照：
 
@@ -103,7 +103,7 @@ if 块条件在 `settings.js:835-848`，`clearResultCache()` 调用在 `settings
 
 | # | 条件变量（settings.js:835-848） | 设置 | 为何影响计算结果 |
 | --- | --- | --- | --- |
-| 1 | `estimatorChanged` | estimatorAlgorithm | 算法选择。注：算法名已在缓存键中（`analysis.js:305` 第一段），失效属冗余保险（防未来键改动的 belt-and-suspenders） |
+| 1 | `estimatorChanged` | estimatorAlgorithm | 算法选择。注：算法名已在缓存键中（`analysis.js:398` 第一段），失效属冗余保险（防未来键改动的 belt-and-suspenders） |
 | 2 | `azusaSunnyReferenceHoChanged` | azusaSunnyReferenceHo | 改变 Azusa 的 Sunny 参考阈值 → 改变谱面被接受/回退的判定 → 改变实际结果与 `actualEstimatorAlgorithm` |
 | 3 | `etternaVersionChanged` | etternaVersion | 不同 MinaCalc 版本算出的 MSD 不同（快照含 `ettResult`） |
 | 4 | `companellaEtternaVersionChanged` | companellaEtternaVersion | Companella 自带 Ett 版本，同上影响 MSD |
@@ -220,15 +220,15 @@ const jsonSafe = (value) => (value == null ? value : JSON.parse(JSON.stringify(v
 }, { skip: isMetaDegraded });
 ```
 
-`isMetaDegraded` 在 `analysis.js:306` 判定（identity 以 `meta:` 开头）。meta 降级身份的快照**永不写入**：标题键碰撞风险、无 md5 无法检测文件替换（见 result-cache.md §8）。`skip:true` 时 `resultCache.put` 直接返回（`resultCache.js:35`），不写入、不占容量、不驱逐。**新写缓存代码必须带上这个 skip 参数**，漏了会让 meta 身份的快照污染 LRU。
+`isMetaDegraded` 在 `analysis.js:399` 判定（identity 以 `meta:` 开头）。meta 降级身份的快照**永不写入**：标题键碰撞风险、无 md5 无法检测文件替换（见 result-cache.md §8）。`skip:true` 时 `resultCache.put` 直接返回（`resultCache.js:35`），不写入、不占容量、不驱逐。**新写缓存代码必须带上这个 skip 参数**，漏了会让 meta 身份的快照污染 LRU。
 
-### 10.5 缓存键构造（`analysis.js:305`）
+### 10.5 缓存键构造（`analysis.js:398`）
 
 ```js
 const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
 ```
 
-版本前缀 + 三段：缓存语义版本（`star-v6`，沿革见 result-cache.md §5）| 用户选择的算法 | 谱面身份（含 md5） | mod 签名（`speedRate|odFlag|cvtFlag|classic` 四段，classic 段反映 Classic 感知星数语义，modData.js:218-228）。**写前确认三段都在**——写门已校验 `state.lastBeatmapIdentity` 存在；直接用 fetchBeatmapFile 开头构造好的 `cacheKey` 变量，不要自己重造键（键不含任何其他设置，正确性依赖失效列表，见 §2）。
+版本前缀 + 三段：缓存语义版本（`star-v7`，沿革见 result-cache.md §5）| 用户选择的算法 | 谱面身份（含 md5） | mod 签名（`speedRate|odFlag|cvtFlag|classic` 四段，classic 段反映 Classic 感知星数语义，modData.js:218-228）。**写前确认三段都在**——写门已校验 `state.lastBeatmapIdentity` 存在；直接用 fetchBeatmapFile 开头构造好的 `cacheKey` 变量，不要自己重造键（键不含任何其他设置，正确性依赖失效列表，见 §2）。
 
 ### 10.6 needComputed 推导与随快照保存（`analysis.js:775`、:322-340、:348-355）
 

--- a/docs/learnings/difficulty-estimation.md
+++ b/docs/learnings/difficulty-estimation.md
@@ -120,6 +120,7 @@
 - **Azusa LN 门控生效**：`rcLnRatioLimit=0.18` 在入口断言（此前只存在于文档，见 §3.5）。
 - **缓存键 bump star-v4 → star-v5**（低难 numeric/estDiff 语义变化）。
 - **缓存键 bump star-v5 → star-v6**（Roxy `graph` 时间轴从 canonical 还原为原始谱面时间；旧快照的 `times` 会导致图表 x 轴窗口与进度线错位——见 [graph-visualization.md](../features/graph-visualization.md) §4.5 与 roxy_algorithm.md）。
+- **缓存键 bump star-v6 → star-v7**（Roxy meta 头对退化修正项 `corr_lowCj` 改用「特征关闭状态取值」截断，即 `|z| <= |mean/scale|`——该系数是在特征恒为常数处拟合的（beta/scale = -134），遇到正常触发值即外推出极端离群项，单张图实测被压低 2.49 分、标签从 Delta 级掉到 Beta low，见 roxy_algorithm.md §11.1；报告图的 `metaNumeric` 由 `9.60 → 13.92`，最终数值 `11.65 → 14.19`，标签 `Beta low → Delta mid/high`，其 Azusa(14.48)/Daniel(14.62) 参考未变）。**为什么不是按 σ 截断**：issue #70 的两张参考图几乎同源（同一时间轴、90.1% 的行内音符数相同、98.3% 的音符能在对方里找到同列同刻的对应音符），只因为 `overlapRate` 是 0.7772 对 0.7413——刚好跨过 lowCj 闸门的 0.75 下界——一张触发一张不触发；±3σ 截断下仍差 1.01 分（触发的那张仍被压低 1.86 分），而 Azusa(差 0.06)/Daniel(差 0.07)/Roxy structural(差 0.10) 都认为两张同难。改成关闭状态截断后两图差 0.05、标签一致。**名单只含 `corr_lowCj`**：其余 corr_* 项病态程度低 1~3 个量级（`corr_courseSustainLift` 的 beta/scale 仅 21、`corr_denseJsLift` 仅 0.4、另两项 beta 恒为 0），且在 benchmark 上携带有效信号——一并按 σ 截断会改动 7 行、其中 4 行变差（MAE `0.2424`），只处理 `corr_lowCj` 则不改变任何已报出数值。对照的"直接删除该特征"方案会连带丢掉它在 `f ≈ mean` 处的常数贡献（+0.028），使全表整体下移（实测改动 474/746 行）。
 
 Benchmark（harness harness before/after，746 行，官方 results 为旧代码口径不可直接对比）：
 

--- a/docs/pipeline/analysis-pipeline.md
+++ b/docs/pipeline/analysis-pipeline.md
@@ -90,7 +90,7 @@ if (!nextBeatmapIdentity) return;                                // :253 空身�
 ```
 
 - **md5 免疫文件替换**：`hash:` 段来自 `beatmap?.md5 || beatmap?.checksum`（:196），谱面文件内容变化 → md5 变 → identity 变 → 缓存键变，天然免疫文件替换（这是缓存键安全性的基石，见 result-cache.md §5）。
-- **meta: 降级**：仅当 tosu 同时缺少 id/hash/path 时发生（:248）。此时身份只有标题元数据（artist::title::version::mapper 小写拼接，:198-203）——**更弱**：同标题不同谱面会共用同一键（碰撞风险），且无 md5 无法检测文件替换。对应处理：`analysis.js:306 isMetaDegraded` 判定，缓存侧永不写入（result-cache.md §8）。
+- **meta: 降级**：仅当 tosu 同时缺少 id/hash/path 时发生（:248）。此时身份只有标题元数据（artist::title::version::mapper 小写拼接，:198-203）——**更弱**：同标题不同谱面会共用同一键（碰撞风险），且无 md5 无法检测文件替换。对应处理：`analysis.js:399 isMetaDegraded` 判定，缓存侧永不写入（result-cache.md §8）。
 - 归一化：id 取正整数（`normalizeNumberText` :187-193，`Math.trunc` 去小数）；path 反斜杠转正斜杠、折叠重复斜杠、小写（:181-185）；hash 小写（:196）。
 - `socketHandlers.js:290-292 lastBeatmapIdentitySource`：记录身份是 composite（≥2 段）还是单段来源，供展示层区分。
 
@@ -138,7 +138,7 @@ state.pendingChangeKind = changeKind;   // :286
 
 - api_v2 包可能不完整（partial），因此 mod 状态**只在 mod payload 显式出现时应用**：`socketHandlers.js:257-261 shouldApplyModState = !previousModSignature || (modData.hasModPayload && (modData.hasModInfo || modData.hasExplicitNoMod))`；不满足时沿用旧 modSignature。
 - 应用侧 `socketHandlers.js:267-272`：写入 `state.speedRate / state.odFlag / state.cvtFlag / state.modSignature`（来源 `modData.js:62 getModData`，解析细节见 mod-handling.md），并同步写入 `state.modCodes = modData.modCodes || []`、`state.classicMod = Boolean(modData.classic)`（socketHandlers.js:172-173）。
-- **modSignature 不参与换歌判定**，只进缓存键：`analysis.js:395` 缓存键 = `star-v6|estimatorAlgorithm|beatmapIdentity|modSignature`（`star-v6` 是缓存语义版本前缀；构成见 modData.js:218-228，`speedRate|odFlag|cvtFlag|classic` 四段，详见 result-cache.md §5 与 mod-handling.md）。
+- **modSignature 不参与换歌判定**，只进缓存键：`analysis.js:395` 缓存键 = `star-v7|estimatorAlgorithm|beatmapIdentity|modSignature`（`star-v7` 是缓存语义版本前缀；构成见 modData.js:218-228，`speedRate|odFlag|cvtFlag|classic` 四段，详见 result-cache.md §5 与 mod-handling.md）。
 
 ## 5. 请求调度（scheduler.js）
 
@@ -171,8 +171,8 @@ const isStaleRequest = () => requestSeq !== state.analysisRequestSeq;
 ### 7.1 缓存查找与覆盖检查（简述，详见 result-cache.md §6）
 
 - `analysis.js:287-304 needComputed`：本次需要的计算产物布尔集 `{pattern, ett, graph, interlude, pp}`，由显示需求与算法需求推导（例如 `state.diffText === "Graph" || contentBarShows("Graph")` 需要 graph，:334；Companella/Mixed 需要 ett 与 interlude，:333、:337-338；`contentBarShows("ReworkPP")` 需要 pp，:339）。
-- `analysis.js:305 cacheKey`：`${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`（版本前缀 `star-v6` + 三段，modSignature 四段含 classic）。
-- `analysis.js:306 isMetaDegraded`：identity 以 `meta:` 开头。
+- `analysis.js:398 cacheKey`：`${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`（版本前缀 `star-v7` + 三段，modSignature 四段含 classic）。
+- `analysis.js:399 isMetaDegraded`：identity 以 `meta:` 开头。
 - `analysis.js:308-317`：`state.enableResultCache && state.lastBeatmapIdentity` 时查 `resultCache.get(cacheKey)`，取到后比对快照 `computed` 五项（graph/pattern/ett/interlude/pp）与 needComputed——全等才命中（`cached = snapshot`），任一不等视为 miss 走完整重算。
 
 ### 7.2 fetch .osu

--- a/docs/pipeline/mod-handling.md
+++ b/docs/pipeline/mod-handling.md
@@ -168,7 +168,7 @@ const nextModSignature = shouldApplyModState ? modData.modSignature : previousMo
 
 ## 7. modSignature 在缓存键中的作用
 
-缓存键 = `star-v6|state.estimatorAlgorithm|state.lastBeatmapIdentity|state.modSignature`（`js/app/analysis.js:395`，`star-v6` 为缓存语义版本前缀，沿革见 result-cache.md §5）：
+缓存键 = `star-v7|state.estimatorAlgorithm|state.lastBeatmapIdentity|state.modSignature`（`js/app/analysis.js:398`，`star-v7` 为缓存语义版本前缀，沿革见 result-cache.md §5）：
 
 - mod 变化 → `modSignature` 变化 → 缓存键变化 → 旧快照 miss → 重新计算。同一谱面开 DT 与不开 DT 是**两个缓存条目**，互不污染。
 - 键的第三段就是 §3 的四元组签名（速率/OD/cvt/classic 任一变化即换键）。

--- a/docs/pipeline/result-cache.md
+++ b/docs/pipeline/result-cache.md
@@ -54,10 +54,10 @@ fetchBeatmapFile() → 查缓存（analysis.js:308-317）
 
 ## 5. 缓存键
 
-`analysis.js:305`：
+`analysis.js:398`：
 
 ```js
-const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v6"; // 星数统一为 Sunny 原始 sr 后作废旧快照（版本沿革见下）
+const CACHE_KEY_STAR_UNIFIED_VERSION = "star-v7"; // 星数统一为 Sunny 原始 sr 后作废旧快照（版本沿革见下）
 const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|${state.lastBeatmapIdentity}|${state.modSignature}`;
 ```
 
@@ -65,7 +65,7 @@ const cacheKey = `${CACHE_KEY_STAR_UNIFIED_VERSION}|${state.estimatorAlgorithm}|
 
 | 段 | 来源 | 说明 |
 | --- | --- | --- |
-| `star-v6` | 常量 `CACHE_KEY_STAR_UNIFIED_VERSION`（analysis.js:394） | 缓存语义版本。v3 前：星数统一为 Sunny 原始 sr（Azusa/Roxy/Mixed 的 star 被归一化，见 difficulty-estimation.md §显示星数）后旧快照失效；**v4（2.1.0 修复）：转换器难度别名修复（Etterna 桥 `Difficulty_*` 前缀此前匹配失败 → 恒取 .sm 首块）使同 identity 的旧快照（错误首块结果）必须作废**；v5：Mixed 低难 RC 段 Azusa⊕Companella 融合 + Azusa LN 门控；**v6：Roxy 的 `graph` 时间轴还原为原始谱面时间（此前是被 `canonicalizeOsuTiming` 平移过的分析文本时间轴，见 roxy_algorithm.md），旧快照的 `times` 会让图表 x 轴窗口与进度线整体错位** |
+| `star-v7` | 常量 `CACHE_KEY_STAR_UNIFIED_VERSION`（analysis.js:399） | 缓存语义版本。v3 前：星数统一为 Sunny 原始 sr（Azusa/Roxy/Mixed 的 star 被归一化，见 difficulty-estimation.md §显示星数）后旧快照失效；**v4（2.1.0 修复）：转换器难度别名修复（Etterna 桥 `Difficulty_*` 前缀此前匹配失败 → 恒取 .sm 首块）使同 identity 的旧快照（错误首块结果）必须作废**；v5：Mixed 低难 RC 段 Azusa⊕Companella 融合 + Azusa LN 门控；**v6：Roxy 的 `graph` 时间轴还原为原始谱面时间（此前是被 `canonicalizeOsuTiming` 平移过的分析文本时间轴，见 roxy_algorithm.md），旧快照的 `times` 会让图表 x 轴窗口与进度线整体错位**；**v7：Roxy meta 头对退化修正项 `corr_lowCj` 改用「特征关闭状态取值」截断（`|z| <= |mean/scale|`）——该系数是在特征恒为常数处拟合的（beta/scale = -134），遇到正常触发值即外推出极端离群项，单张图实测被压低 2.49 分，见 roxy_algorithm.md §11.1** |
 | `estimatorAlgorithm` | `state.estimatorAlgorithm`（appContext.js:88） | 用户选择的算法。注意不是实际算法——Azusa 回退 Sunny 时 key 仍含 "Azusa"，快照内用 `actualEstimatorAlgorithm` 记录实况（§10） |
 | `lastBeatmapIdentity` | `state.lastBeatmapIdentity` | 谱面身份，由 socketHandlers.js 构建（见下）。**含 beatmap 的 md5 hash → 谱面文件被替换（内容变化）后 hash 变、键变，天然免疫文件替换** |
 | `modSignature` | `state.modSignature` | mod 签名，modData.js 构建（见下） |
@@ -142,7 +142,7 @@ if (identityParts.length === 0 && hasMetadataIdentity) {
 
 处理链：
 
-1. `analysis.js:306 isMetaDegraded = String(state.lastBeatmapIdentity || "").startsWith("meta:")`——在 fetchBeatmapFile 开头判定。
+1. `analysis.js:399 isMetaDegraded = String(state.lastBeatmapIdentity || "").startsWith("meta:")`——在 fetchBeatmapFile 开头判定。
 2. 查询侧：`analysis.js:308` 只要 identity 存在就会尝试查缓存（`meta:` 键也可能命中——但如果从未写入过，实际永远 miss）。
 3. 写入侧：`analysis.js:776` `{ skip: isMetaDegraded }` → `put({skip:true})`（§3），**meta 降级快照永不进入缓存**。
 

--- a/docs/roxy_algorithm.md
+++ b/docs/roxy_algorithm.md
@@ -320,6 +320,56 @@ The generated meta head is a standardized ridge linear model. It is intentionall
 
 The Sunny feature slots remain in the schema for compatibility with the generated feature list, but the live Sunny prediction is set unavailable before feature construction. Those slots therefore carry fallback values plus `has_Sunny = 0`, not a live Sunny vote.
 
+### 11.1 Degenerate meta features (issue #70)
+
+`corr_lowCj` has its standardized value clamped to the range the feature occupies when it is **off** (`f = 0`), i.e. `|z| <= |mean / scale|`. Every other feature — including the four other `corr_*` terms — is used unchanged.
+
+During training this term was almost always constant, so its stored `mean` and `std` are tiny relative to the values it reaches on real charts: `mean = 2.07e-4`, `std = 4.65e-3`, while the gate behind it can only be non-zero when `overlapRate > 0.75` and `chordRate > 0.48`, where the term spans `0.011 ~ 0.39`. A chart sitting just inside that gate scores `0.033`, which standardizes to `z = 6.99` — and the fitted coefficient is `beta / scale = -134`, so that single dimension subtracted `4.34` from the meta value and `2.49` from the final numeric of the reported chart.
+
+**Why a plain `±Nσ` clamp is not enough.** Issue #70 reported two charts that are near-identical rather than merely similar. Aligning them at `±2 ms`:
+
+| | `2808336` (practice-pack edit) | `3630235` (original) |
+|---|---|---|
+| notes / rows / LNs | `2063` / `794` / `101` | `2314` / `892` / `46` |
+| time span | `106266 ms` | `106266 ms` (identical) |
+| rows of the left chart found in the right one | `794 / 794` | — |
+| rows with an identical note count | `715 / 794` (`90.1%`) | — |
+| notes with a same-column, `±2 ms` counterpart | `2027 / 2063` (`98.3%`) | — |
+| `overlapRate` | `0.7772` | `0.7413` |
+| `corr_lowCj` | `0.0327` | `0` |
+| Azusa / Daniel reference | `14.48` / `14.62` | `14.42` / `14.55` |
+| Roxy structural | `9.77` | `9.87` |
+
+The right-hand chart is the left one plus `251` notes (`98` new rows, `77` rows thickened), and every reference layer agrees they are equally hard. The only thing separating them is that `overlapRate` straddles the `lowCj` gate's lower bound of `0.75`: a `3.6` percentage-point difference decides whether a `1.8`-point penalty applies. A `±3σ` clamp still left the pair `1.01` apart (the triggering chart was suppressed by `1.86`), because `3σ` is itself an extrapolation of `3 * 134` scale units for a coefficient that was fitted where the feature never moved. Clamping to the feature-off value removes the extrapolation instead of shrinking it, and the pair lands `0.05` apart at the same label.
+
+**Why clamp `corr_lowCj` rather than remove it.** Dropping the term entirely also drops its constant contribution at `f ≈ mean` (`+0.028`), which shifts every chart down. That variant changes `474` of the `746` benchmark rows for no gain. The clamp keeps that contribution and only bounds the tail.
+
+**Why only `corr_lowCj` and not the other four.** The other terms are degenerate in the same statistical sense but by orders of magnitude less pathological. Measured as `beta / scale`:
+
+| feature | `beta / scale` |
+|---|---|
+| `corr_lowCj` | `-134` |
+| `corr_courseSustainLift` | `21` |
+| `corr_denseJsLift` | `0.4` |
+| `corr_handBiasLift` | `0` (no training variance, `beta = 0`) |
+| `corr_courseBreakDamp` | `0` (no training variance, `beta = 0`) |
+
+Handling `corr_lowCj` alone fixes the reported chart without touching any other benchmark value. Clamping the other three as well — which a blanket "degenerate training statistics" rule would have selected — changes `7` rows, of which `4` get worse (MAE `0.2424`), because those terms carry real signal on the benchmark. Corroborating evidence: on a structural-distance check over the affected benchmark charts, handling `corr_lowCj` is neutral-or-helpful (1 chart closer to its structural score, 0 further), whereas clamping all five pushes 6 of 9 affected charts *further* from the structural score than the unclamped value. The feature list is therefore chosen per feature by its actual pathology, not by a blanket rule.
+
+The reported chart's `metaNumeric` moves `9.60 -> 13.92` (structural `9.77`), taking its final numeric from `11.65` to `14.19` and its label from `Beta low` to `Delta mid/high`; its Azusa (`14.48`) and Daniel (`14.62`) references are unchanged, so the meta head was the only layer disagreeing.
+
+**Corpus-wide measurement (231,780 random `.osu` files, 21,459 of them mania 4K).** The `corr_lowCj` contribution depends only on the structural layer, so it is computable for every chart without running the reference estimators. Over the 13,028 charts Roxy analyses, `corr_lowCj` alone moves 10 charts by more than `0.05`, with `|z|` up to `25.3` and up to `15.73` of suppression before clamping (chart `5058397`, structural `3.74`, was pinned at the `-2` output clamp).
+
+Because a warped meta value also crosses the `ROXY_SCOPE_MIN`/`MAX` boundaries, the bug could additionally flip which algorithm answers: on the 88 charts with any degenerate dimension beyond `3σ`, 5 flipped scope (4 became `< Alpha Low`, so Mixed routed away from Roxy). The clamp recovers those routings where the unwarped value belongs in scope.
+
+For reference, the wider set of five degenerate dimensions affects 66 charts (0.51%) by `>= 0.05` and 36 (0.28%) by `>= 0.25`, driven mostly by `corr_courseSustainLift` (27 charts, all over-estimated, `|z|` up to `119.5`). Those are **not** clamped here, because on the benchmark they carry signal and the corpus measurement alone cannot separate signal from noise without labelled difficulty. `corr_courseSustainLift` stays a known open item: if it is ever confirmed to misfire on real charts, the proper fix is a variance floor at training time rather than another inference-side clamp.
+
+**Benchmark impact.** On the osu! subset none of the already-reported values change — every one of those rows keeps exactly the same error. The only row that moves is `I Love It(lynessa)` (`jack / high chordjack`, expected `10.5`), which the `lowCj` term had pinned below the scope floor and which now reports `11.65`; that this term was suppressing a *high* chordjack chart is a direct illustration of the mis-firing, and the single newly-valid row is what takes MAE from `0.2414` to `0.2432`. Mixed reaches Roxy through its low-difficulty fallback, so the same chart moves there too (`11.54 -> 11.65`, Mixed MAE `0.4219 -> 0.4221`); no other Mixed row changes. `results/Roxy.csv` also moved on 26 further rows when regenerated, but those come from other plugin commits landed since that file was last produced on 2026-08-30, not from this change.
+
+If the meta head is ever retrained, the proper fix is a variance floor at training time; the inference-side clamp exists because the training script (`temp/retrain_upper.py`) is not in the repository.
+
+Cache prefix bumped `star-v6` → `star-v7` because Roxy `numeric`/`estDiff` change semantics.
+
 After meta evaluation, a structural backstop prevents the calibrated value from falling slightly below Roxy's own structural score. The backstop is gated from structural numeric `12.25` to `14.0`, targets `structuralNumeric - 0.15`, and only applies when the gap is positive but no larger than `0.35`. This keeps it from acting as a broad high-difficulty special case.
 
 After OD correction and the high-reference structural floor, Roxy applies a very small reference-gap residual correction only when no explicit OD override is present. The correction compares the current unguarded output with Azusa, Daniel, and the structural score:


### PR DESCRIPTION
Closes #70

## Problem

Two rice charts the reporter calls very similar were estimated a tier apart — one at `Beta low` where they expected at least `Delta`. `Estimator Algorithm: Mixed` (Roxy selected in both).

They really are near-identical. Aligning them at ±2 ms: all 794 row timestamps of the first have a counterpart in the second, 715/794 (`90.1%`) of those rows have an identical note count, and 2027/2063 (`98.3%`) of its notes have a same-column counterpart — the second is the first plus 251 notes (98 new rows, 77 rows thickened). Azusa (`14.48` vs `14.42`), Daniel (`14.62` vs `14.55`) and Roxy's own structural layer (`9.77` vs `9.87`) all rate them equally hard, so the gap was never coming from the charts.

## Root cause

Roxy's ridge meta head standardizes each feature as `(f − mean) / scale` before applying the fitted coefficient. `corr_lowCj` was almost always constant during training, so its stored statistics are tiny relative to the values it reaches on real charts:

| quantity | value |
|---|---|
| training `mean` | `2.07e-4` |
| training `std` (the `scale`) | `4.65e-3` |
| reachable range when its gate fires | `0.011 ~ 0.39` |
| value on the reported chart | `0.033` → `z = 6.99` |
| coefficient | `beta / scale = -134` |
| resulting shift | `-4.34` in the meta value |

The gate is `gate(chordRate, 0.48, 0.68) * gate(overlapRate, 0.75, 1.25)`. The reported chart sits just inside it (`chordRate 0.834`, `overlapRate 0.777`); the partner chart sits just outside (`overlapRate 0.741`), so a `3.6` percentage-point difference decided whether a `1.8`-point penalty applied.

Isolation: on the reported chart the references were `Azusa 14.48` and `Daniel 14.62` while the meta head returned `9.60` against a structural score of `9.77`, so the meta head was the only layer disagreeing.

## Changes

`js/estimator/roxyMetaModel.generated.js` — `corr_lowCj`'s standardized value is clamped to the range the feature occupies when it is **off** (`f = 0`), i.e. `|z| <= |mean / scale|`. Every other feature is used unchanged. The model has no data on what happens when this feature fires, so firing falls back to the typical chart instead of extrapolating.

Clamping rather than dropping the term: removal also discards its constant contribution at `f ≈ mean` (`+0.028`), which shifts every chart down — `474` of the `746` benchmark rows change under removal.

A plain `±Nσ` clamp was implemented and measured first, and is **not** sufficient: `3σ` is itself an extrapolation of `3 * 134` scale units for a coefficient fitted where the feature never moved, and the reported pair still differed by `1.01`. This PR carries the feature-off clamp instead.

Only `corr_lowCj` is handled, not the other four `corr_*` terms, which are degenerate in the same statistical sense but orders of magnitude less pathological:

| feature | `beta / scale` |
|---|---|
| `corr_lowCj` | `-134` |
| `corr_courseSustainLift` | `21` |
| `corr_denseJsLift` | `0.4` |
| `corr_handBiasLift` | `0` (no training variance, `beta = 0`) |
| `corr_courseBreakDamp` | `0` (no training variance, `beta = 0`) |

Clamping the other three as well changes `7` rows of which `4` get worse (MAE `0.2424`), because those terms carry real signal there. A structural-distance check agrees: handling `corr_lowCj` is neutral-or-helpful (1 chart closer to its structural score, 0 further), while clamping all five pushes 6 of 9 affected charts further from the structural score than the unclamped value.

`js/app/analysis.js` — cache prefix `star-v6` → `star-v7` (Roxy `numeric`/`estDiff` semantics change).

Docs — `roxy_algorithm.md` gains §11.1 (degeneracy, the near-identical pair, why the feature-off clamp and not a sigma clamp, why only this feature, the A/B and corpus numbers); `result-cache.md` §5, `learnings/difficulty-estimation.md`, `cache-invalidation.md`, `analysis-pipeline.md`, `mod-handling.md` and `difficulty-estimation.md` are updated for the new prefix.

## Verification

Reported chart (`2808336`, Flashnia's 150 Chordjack Practice Pack):

| | before | after |
|---|---|---|
| structural numeric | `9.77` | `9.77` |
| meta numeric | `9.604` | `13.917` |
| final numeric | `11.65` | `14.19` |
| label | `Beta low` | `Delta mid/high` |

Its references were `Azusa 14.48` / `Daniel 14.62` in both runs. Partner chart (`3630235`, Sakazuki) is unchanged at `14.14` (`Delta mid/high`), so the reported gap goes from `2.49` to `0.05`.

Benchmark (osu! subset, 746 rows): `Roxy` MAE `0.2414 -> 0.2432` (`Exact 62.75% -> 62.62%`, `Within 0.5 90.24% -> 90.06%`), `Mixed` MAE `0.4219 -> 0.4221`. Both files move on the same single row, `I Love It(lynessa)` (`jack / high chordjack`, expected `10.5`), which the `lowCj` term had pinned below Roxy's scope floor: `Invalid -> 11.65` in Roxy, `11.54 -> 11.65` in Mixed. All other Roxy lines and all other Mixed lines are byte-identical, so the MAE moves are entirely that one row (`0.2414 * 502 = 121.18`, `+ 1.15 = 122.33`, `/ 503 = 0.2432`).

Sunny, Daniel, Azusa, Companella and DanOverlay are untouched — `roxyMetaModel.generated.js` is imported by `roxyEstimator.js` alone, and Mixed only reaches it through its Roxy fallback.

Corpus (21,459 mania 4K, 13,028 that Roxy analyses): `corr_lowCj` alone moves 10 charts by more than `0.05`, `|z|` up to `25.3`, up to `15.73` of suppression before clamping (chart `5058397`, structural `3.74`, was pinned at the `-2` output clamp). Because a warped meta value also crosses the `ROXY_SCOPE_MIN`/`MAX` boundaries, 5 of the 88 charts with any degenerate dimension beyond `3σ` flipped which algorithm answers.

## Known open item

The wider five-dimension set affects 66 charts (`0.51%`) by `>= 0.05`, driven mostly by `corr_courseSustainLift` (27 charts, all over-estimated, `|z|` up to `119.5`). It is deliberately left alone — on the benchmark it carries signal, and the corpus measurement alone cannot separate signal from noise without labelled difficulty. If it is ever confirmed to misfire, the proper fix is a variance floor at training time, which needs `temp/retrain_upper.py` (not in the repository).