### PR TITLE
fix(sources): change brand colors for the source dot + clear the stale color when no source

### DIFF
--- a/ManiaMapAnalyser by Leo_Black/js/app/sources/sourceManager.js
+++ b/ManiaMapAnalyser by Leo_Black/js/app/sources/sourceManager.js
@@ -19,8 +19,8 @@ const FRESH_WINDOW_MS = 60000;
 const DEBOUNCE_MS = 200;
 const PRIORITY = ["osu", "etterna", "malody"];
 const LABELS = { osu: "osu!", etterna: "Etterna", malody: "Malody" };
-// 与遥测 Client 饼图段色一致（dashboard PALETTE 前 3 色）。
-const DOT_COLORS = { osu: "#635bff", etterna: "#0d9c5f", malody: "#f5a623" };
+// 各源品牌色（osu! 粉 / Etterna 紫 / Malody 蓝），与遥测 dashboard 的 PALETTE 无关。
+const DOT_COLORS = { osu: "#ff66aa", etterna: "#a855f7", malody: "#3b82f6" };
 
 let debounceTimer = 0;
 let activeSource = null; // 最近一次已应用的路由结果（null=无源）
@@ -167,9 +167,10 @@ function dotElement() {
 function syncDot(source) {
     const dot = dotElement();
     if (!dot) return;
-    // 空心 = 无来源；osu!/Etterna/Malody 各一实心色（蓝/绿/橙）。
+    // 空心 = 无来源；osu!/Etterna/Malody 各一实心色（粉/紫/蓝）。
     if (!source) {
         dot.className = "mma-source-dot off";
+        dot.style.background = ""; // 清除内联色，让 .off 的空心样式生效
         dot.title = "无数据源";
         return;
     }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 - **键型分析**：分析谱面中的RC/LN键型分布，帮助玩家了解谱面结构。
 - **Rework PP**：提供Rework PP难度表现面板，显示Max PP/Live PP、Proportion及各乘子柱状图，游玩/结算时实时更新。
 - **预设系统**：提供系统与自定义预设，一键应用/保存整套配置，支持自动跟随手动修改。
-- **Etterna/Malody支持**：除 osu!mania 外可接收来自 Etterna、Malody V（需桌面壳）的数据，状态行圆点实时指示（osu! 蓝 / Etterna 绿 / Malody 橙）。
+- **Etterna/Malody支持**：除 osu!mania 外可接收来自 Etterna、Malody V（需桌面壳）的数据，状态行圆点实时指示（osu! 粉 / Etterna 紫 / Malody 蓝）。
 - **桌面壳**：独立置顶/透明/无边框小窗口。
 - **高度自定义**：提供丰富的自定义选项，满足不同玩家的需求。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -23,7 +23,7 @@ This repository is an entirely AI-crafted in-game overlay (ppcounter) for [tosu]
 - **Pattern Analysis**: Analyzes RC/LN pattern distribution in the beatmap to help players understand its structure.
 - **Rework PP**: Provides the Rework PP performance panel with Max PP/Live PP, Proportion, and multiplier bars, updating in real-time during play and results.
 - **Preset System**: Provides system and custom presets to apply or save the whole configuration with one click, with automatic follow mode for manual changes.
-- **Etterna/Malody Support**: Besides osu!mania, the card can receive data from Etterna and Malody V (desktop shell required); a status-dot indicator shows the current source (osu! blue / Etterna green / Malody orange).
+- **Etterna/Malody Support**: Besides osu!mania, the card can receive data from Etterna and Malody V (desktop shell required); a status-dot indicator shows the current source (osu! pink / Etterna purple / Malody blue).
 - **Desktop Shell**: A standalone always-on-top/transparent/borderless mini window.
 - **Highly Customizable**: Offers a wealth of customization options to meet the needs of different players.
 

--- a/docs/features/desktop-shell.md
+++ b/docs/features/desktop-shell.md
@@ -67,4 +67,4 @@ window.navigate(url)
 
 ## 6. 已知限制与待办
 
-离线设置持久化已实现（`mma-shell-config.json` 壳配置 + `mma-settings.json` 插件设置 + 页面 `/settings` 应用，在线时仍以 tosu 为准只读）。外部源封面消费（壳 cover URL 已下发）为待办。真机验证项：Etterna 主题桥真实写入、Malody 编辑器文件通道（WriteFile `<base>_mma_request.json` → 壳扫 chart/（两级目录 mtime 快筛，≤1Hz）→ 谱面 = 同目录 `<base>.mc|.osu` → 分析 → 卡片展示，处理完删 request；DoRequest POST 实测被 Malody 网络层拒绝（invalid url: {body}），故不走网络通道）、PlayMeta 字段；窗口穿透与透明目视。浏览器模式（无壳）不受影响：osu! 单源，control/result no-op。来源指示器：空心=无源；osu! 蓝 / Etterna 绿 / Malody 橙实心。
+离线设置持久化已实现（`mma-shell-config.json` 壳配置 + `mma-settings.json` 插件设置 + 页面 `/settings` 应用，在线时仍以 tosu 为准只读）。外部源封面消费（壳 cover URL 已下发）为待办。真机验证项：Etterna 主题桥真实写入、Malody 编辑器文件通道（WriteFile `<base>_mma_request.json` → 壳扫 chart/（两级目录 mtime 快筛，≤1Hz）→ 谱面 = 同目录 `<base>.mc|.osu` → 分析 → 卡片展示，处理完删 request；DoRequest POST 实测被 Malody 网络层拒绝（invalid url: {body}），故不走网络通道）、PlayMeta 字段；窗口穿透与透明目视。浏览器模式（无壳）不受影响：osu! 单源，control/result no-op。来源指示器：空心=无源；osu! 粉 / Etterna 紫 / Malody 蓝实心。

--- a/docs/features/multi-source.md
+++ b/docs/features/multi-source.md
@@ -37,7 +37,7 @@ Malody（编辑器插件 WriteFile `<base>_mma_request.json` → 壳 ≤1Hz 扫 
   - L3 hold 只作用于当前源，他源新鲜事件无游玩态可抢占；窗口过期按 osu>Etterna>Malody 重选；
   - L3' 存活回窗（无窗口源时 tosu 在线 → osu）；
   - L4 全离线 → 无源（圆点灰空心）。
-- 切源 debounce 200ms，旧结果保留；源圆点（状态行末端）：三色实心（osu! #635bff / Etterna #0d9c5f / Malody #f5a623，与遥测 Client 饼图一致）或灰空心（无源）。
+- 切源 debounce 200ms，旧结果保留；源圆点（状态行末端）：三色实心（osu! #ff66aa / Etterna #a855f7 / Malody #3b82f6，各源品牌色）或灰空心（无源）。
 
 ## osu 败方门控
 
@@ -71,7 +71,7 @@ Technical document for AI readers. Human installation guides: `docs/shell-guide.
 Adds Etterna and Malody V as live data sources beside osu!mania/tosu, with automatic follow on game switch. **Zero algorithm-layer changes**: `.sm/.ssc/.mc` are converted to `.osu` text and enter the existing pipeline.
 
 - Converters: `js/parser/{smSscToOsuConverter,mcToOsuConverter}.js` (vendor simfile-parser MIT, STOPS/DELAYS baked, key-count from row width, LN tail fix; OD9/HP8/AR5; real samples and test scripts stay local-only).
-- Router: `js/app/sources/sourceManager.js` decision table L1–L4+L3' (play-state > 60s fresh-event window with hold/preempt > priority reselect > tosu-alive re-entry > none); forced `gameClient`; source dot colors match telemetry pie.
+- Router: `js/app/sources/sourceManager.js` decision table L1–L4+L3' (play-state > 60s fresh-event window with hold/preempt > priority reselect > tosu-alive re-entry > none); forced `gameClient`; source dot uses each game's brand color (osu! pink / Etterna purple / Malody blue).
 - osu gate: beatmap-state handler suspended while another source routes (signals exempt, buffered replay on return).
 - Bridge contract: `desktop/docs/CONTRACT.md` (v2).
 - Telemetry: analyze `client` field, dashboard Client pie with Version on its own row.

--- a/docs/shell-guide.md
+++ b/docs/shell-guide.md
@@ -28,7 +28,7 @@
 - 随后请参照下方「安装桥」章节安装 Etterna/Malody 桥文件。
 - 如有需要，请编辑 `mma-shell-config.json` 来对壳进行配置（游戏安装路径 `etternaRoot` / `malodyRoot`、快捷键 `hotkeys` 等）；离线模式 / 没有 tosu 时，也可编辑 `mma-settings.json` 配置卡片显示（见「配置」）。
 - 启动壳，然后在 Etterna 中选歌即可显示；或者在 Malody V 中选择编辑谱面，在编辑器中点击「MMA Analyze」按钮进行分析。
-- 数据源指示：卡片右上状态行末尾的小圆点——蓝色=osu!、绿色=Etterna、橙色=Malody、灰色空心=当前没有数据源。
+- 数据源指示：卡片右上状态行末尾的小圆点——粉色=osu!、紫色=Etterna、蓝色=Malody、灰色空心=当前没有数据源。
 
 ## 二、窗口操作说明
 
@@ -161,8 +161,8 @@ the **Malody V editor**. The classic browser usage (tosu plugin) is unaffected.
   (see "Configuration").
 - Start the shell: select a song in Etterna to display, or select a chart in Malody V and click "MMA Analyze" in the
   editor.
-- Source indicator: the small dot at the end of the card's top status row — blue = osu!, green = Etterna,
-  orange = Malody, hollow grey = no data source.
+- Source indicator: the small dot at the end of the card's top status row — pink = osu!, purple = Etterna,
+  blue = Malody, hollow grey = no data source.
 
 ## Window controls
 


### PR DESCRIPTION
## Summary

The data-source indicator (the 8px dot at the end of the card's status row) now uses each game's brand color instead of the telemetry chart palette: osu! pink `#ff66aa`, Etterna purple `#a855f7`, Malody blue `#3b82f6`. The dot also returns to the hollow grey state when no source is left, which it silently failed to do before. Routing, tooltips, the osu suppression gate and every display-setting path are untouched.

## What changed

- `ManiaMapAnalyser by Leo_Black/js/app/sources/sourceManager.js` — `DOT_COLORS`: osu! `#635bff` → `#ff66aa`, Etterna `#0d9c5f` → `#a855f7`, Malody `#f5a623` → `#3b82f6`; both comments updated, since the dot no longer mirrors the telemetry dashboard palette.
- Same file, `syncDot()` — the "no source" branch now clears the inline background (`dot.style.background = ""`). Inline styles outrank `.mma-source-dot.off { background: transparent }`, so once a source had been shown the dot kept that game's color after everything went offline instead of turning hollow. Pre-existing defect (the old palette leaked the same way), one-line fix, and it makes the dot match what `docs/features/multi-source.md` and `docs/features/desktop-shell.md` already promised.
- Docs and READMEs restated to the new colors: `docs/features/multi-source.md` (CN hex list + EN router bullet), `docs/features/desktop-shell.md`, `docs/shell-guide.md` (CN + EN), `README.md`, `README_EN.md`.
- Telemetry dashboard intentionally untouched: `backend/internal/web/dashboard.js` `PALETTE` is an index-based chart palette shared by every dimension, not the source indicator — so the "dot matches the Client pie" claim was dropped from the docs instead of repainting the dashboard.